### PR TITLE
Use service plan

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -17,7 +17,7 @@ data "azurerm_key_vault_secret" "ia_case_api_url" {
 }
 
 locals {
-  ase_name = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
+  ase_name            = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
   previewVaultName    = "${var.raw_product}-aat"
   nonPreviewVaultName = "${var.raw_product}-${var.env}"
   vaultName           = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultName : local.nonPreviewVaultName}"
@@ -33,6 +33,8 @@ module "ia-case-api" {
   subscription        = "${var.subscription}"
   capacity            = "${var.capacity}"
   common_tags         = "${var.common_tags}"
+  asp_rg              = "${var.product}-${var.component}-${var.env}"
+  asp_name            = "${var.product}-${var.component}-${var.env}"
 
   app_settings = {
     LOGBACK_REQUIRE_ALERT_LEVEL = false

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -2,10 +2,18 @@ output "microserviceName" {
   value = "${var.component}"
 }
 
-output "vaultUri" {
-  value = "${data.azurerm_key_vault.ia_key_vault.vault_uri}"
+output "resourceGroup" {
+  value = "${local.resource_group_name}"
+}
+
+output "appServicePlan" {
+  value = "${local.app_service_plan}"
 }
 
 output "vaultName" {
-  value = "${local.vaultName}"
+  value = "${local.key_vault_name}"
+}
+
+output "vaultUri" {
+  value = "${data.azurerm_key_vault.ia_key_vault.vault_uri}"
 }

--- a/infrastructure/sprod.tfvars
+++ b/infrastructure/sprod.tfvars
@@ -1,0 +1,1 @@
+capacity = "2"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,9 +1,5 @@
 variable "product" {
-  type    = "string"
-}
-
-variable "raw_product" {
-  default = "ia" // jenkins-library overrides product for PRs and adds e.g. pr-123-ia
+  type = "string"
 }
 
 variable "component" {
@@ -23,19 +19,7 @@ variable "subscription" {
   type = "string"
 }
 
-variable "ilbIp"{}
-
-variable "tenant_id" {
-  description = "(Required) The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. This is usually sourced from environemnt variables and not normally required to be specified."
-}
-
-variable "client_id" {
-  description = "(Required) The object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies. This is usually sourced from environment variables and not normally required to be specified."
-}
-
-variable "jenkins_AAD_objectId" {
-  type = "string"
-}
+variable "ilbIp" {}
 
 variable "common_tags" {
   type = "map"


### PR DESCRIPTION
In a few words: we currently use a service plan for application. After the change, we will have a single plan per project.

While we currently have a 1:1 mapping between applications and compute resources, with a shared plan we can fit more apps into a single compute resource.
The change is rolled out in two stages.

1. Explicitly enable the app service plan in Terraform
1. Switch the service plan to use a shared service plan.

**PLEASE NOTE, THIS PR IS FOR STEP 1 ONLY**

More info on the change: https://tools.hmcts.net/confluence/display/CNP/Migrate+to+Shared+App+Service+Plan (please note that the instructions are for the full migration).