### PR TITLE
RIA-465 added Jenkinsfile_nightly to trigger jobs such as dependency checks overnight

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,0 +1,16 @@
+#!groovy
+
+properties([
+  // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
+  pipelineTriggers([cron('H 22 * * *')])
+])
+
+@Library("Infrastructure")
+
+def type = "java"
+def product = "ia"
+def component = "case-api"
+
+withNightlyPipeline(type, product, component) {
+  enableSlackNotifications('#ia-tech')
+}


### PR DESCRIPTION
### What?

This change implements the overnight pipeline.

### Why?

This gives us by default a way to run dependency checks overnight so that any new vulnerabilities that might be discovered on those dependencies is picked up before having to wait for the normal build pipeline to run (which could be infrequently).

### How?

A `Jenkinsfile_nightly` has been added with the chronjob set to trigger at some point between 10:00 and 10:59 pm