### PR TITLE
RIA-466 mutation testing tweaks

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -12,5 +12,7 @@ def product = "ia"
 def component = "case-api"
 
 withNightlyPipeline(type, product, component) {
+
+  enableMutationTest()
   enableSlackNotifications('#ia-tech')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'java'
 
 def versions = [
     gradlePitest    : '1.3.0',
-    pitest          : '1.3.2',
+    pitest          : '1.4.2',
     reformLogging   : '3.0.1',
     sonarPitest     : '0.5',
     springBoot      : '2.0.4.RELEASE',
@@ -122,7 +122,7 @@ pitest {
     threads = 10
     outputFormats = ['XML', 'HTML']
     timestampedReports = false
-    mutationThreshold = 50
+    mutationThreshold = 90
 }
 
 project.tasks['pitest'].group = "Verification"


### PR DESCRIPTION
### What?

Some mutation testing tweaks that were spotted during review for RIA-466

### Why?

The mutation tests don't appear to be running as part of the build pipeline like originally thought, so I've added the tests to the nightly build as a safety net. A separate PR can be created to address the build pipeline step if necessary.

The success threshold was increased to a future-proof level, and one that should help ensure quality of tests are kept high.

### How?

- bumped the Pitest version
- upped the mutationThreshold to 90%
- added mutation tests to nightly build