### PR TITLE
RIA-466 added mutation tests to build pipeline

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -12,5 +12,15 @@ def component = "case-api"
 
 withPipeline(type, product, component) {
     enableDockerBuild()
+
+    after('test') {
+        try {
+            sh './gradlew pitest'
+        }
+        finally {
+            steps.archiveArtifacts 'build/reports/pitest/**/*.*'
+        }
+    }
+
     enableSlackNotifications('#ia-tech')
 }


### PR DESCRIPTION
### WHAT?

This changes adds the mutation tests to the build pipeline (they're already part of the overnight pipeline)

### WHY?

This means that PRs will fail when test coverage isn't up to scratch, rather than wait for the overnight tests to run. This should increase quality of the code being released.
(If in future the build pipeline starts taking too long to run, then at that point the decision can be taken about relying on the overnight tests)

### HOW?

Used `after('test') { ... }` to trigger the Pitest tool because the overnight `enableMutationTest()`command  did not work.