### PR TITLE
RIA-473 Add serenity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 /build/
+/target/
 !gradle/wrapper/gradle-wrapper.jar
 
 ### STS ###

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -22,5 +22,14 @@ withPipeline(type, product, component) {
         }
     }
 
+    after('functionalTest') {
+        publishHTML target: [
+                reportDir            : "target/site/serenity/",
+                reportFiles          : "index.html",
+                reportName           : "Functional Test Results",
+                alwaysLinkToLastBuild: true
+        ]
+    }
+
     enableSlackNotifications('#ia-tech')
 }

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -15,4 +15,13 @@ properties([
 
 withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, params.ENVIRONMENT, params.SUBSCRIPTION) {
 
+  after('functionalTest') {
+    publishHTML target: [
+            reportDir            : "target/site/serenity/",
+            reportFiles          : "index.html",
+            reportName           : "Functional Test Results",
+            alwaysLinkToLastBuild: true
+    ]
+  }
+
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    dependencies {
+        classpath("net.serenity-bdd:serenity-gradle-plugin:1.5.2")
+    }
+}
+
 plugins {
     id 'application'
     id 'checkstyle'
@@ -12,11 +18,13 @@ plugins {
 }
 
 apply plugin: 'java'
+apply plugin: 'net.serenity-bdd.aggregator'
 
 def versions = [
     gradlePitest    : '1.3.0',
     pitest          : '1.4.2',
     reformLogging   : '3.0.1',
+    serenity        : '1.5.2',
     sonarPitest     : '0.5',
     springBoot      : '2.0.4.RELEASE',
     springHystrix   : '2.0.0.RELEASE',
@@ -167,7 +175,7 @@ dependencies {
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.21.0'
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
 
-    testCompile group: 'org.pitest', name: 'pitest', version: '1.3.2'
+    testCompile group: 'org.pitest', name: 'pitest', version: versions.pitest
     testCompile 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.3.0'
     testCompile 'org.codehaus.sonar-plugins:sonar-pitest-plugin:0.5'
 
@@ -176,6 +184,10 @@ dependencies {
 
     functionalTestCompile sourceSets.main.runtimeClasspath
     functionalTestCompile sourceSets.test.runtimeClasspath
+    functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-core', version: versions.serenity
+    functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-junit', version: versions.serenity
+    functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity
+    functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: '1.0.26'
 
     smokeTestCompile sourceSets.main.runtimeClasspath
     smokeTestCompile sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -189,10 +189,10 @@ dependencies {
     functionalTestCompile sourceSets.main.runtimeClasspath
     functionalTestCompile sourceSets.test.runtimeClasspath
 
-    functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-core', version: versions.serenity
-    functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-junit', version: versions.serenity
-    functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity
-    functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: versions.serenity
+    testCompile group: 'net.serenity-bdd', name: 'serenity-core', version: versions.serenity
+    testCompile group: 'net.serenity-bdd', name: 'serenity-junit', version: versions.serenity
+    testCompile group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity
+    testCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: versions.serenity
 
     smokeTestCompile sourceSets.main.runtimeClasspath
     smokeTestCompile sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
+    repositories {
+        jcenter()
+    }
     dependencies {
-        classpath("net.serenity-bdd:serenity-gradle-plugin:1.5.2")
+        classpath("net.serenity-bdd:serenity-gradle-plugin:2.0.11")
     }
 }
 
@@ -24,7 +27,7 @@ def versions = [
     gradlePitest    : '1.3.0',
     pitest          : '1.4.2',
     reformLogging   : '3.0.1',
-    serenity        : '1.5.2',
+    serenity        : '2.0.11',
     sonarPitest     : '0.5',
     springBoot      : '2.0.4.RELEASE',
     springHystrix   : '2.0.0.RELEASE',
@@ -101,6 +104,7 @@ task integration(type: Test, description: 'Runs the integration tests.', group: 
 task functional(type: Test, description: 'Runs the functional tests.', group: 'Verification') {
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.functionalTest.runtimeClasspath
+    finalizedBy aggregate
 }
 
 task smoke(type: Test, description: 'Runs the smoke tests.', group: 'Verification') {
@@ -166,7 +170,7 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-json', version: versions.springBoot
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: versions.springHystrix
 
-    compile group: 'io.rest-assured', name: 'rest-assured', version: '3.1.0'
+    compile group: 'io.rest-assured', name: 'rest-assured', version: '3.0.7'
     compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
     compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
 
@@ -184,10 +188,11 @@ dependencies {
 
     functionalTestCompile sourceSets.main.runtimeClasspath
     functionalTestCompile sourceSets.test.runtimeClasspath
+
     functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-core', version: versions.serenity
     functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-junit', version: versions.serenity
     functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity
-    functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: '1.0.26'
+    functionalTestCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: versions.serenity
 
     smokeTestCompile sourceSets.main.runtimeClasspath
     smokeTestCompile sourceSets.test.runtimeClasspath
@@ -222,6 +227,8 @@ dependencyUpdates.resolutionStrategy = {
         }
     }
 }
+
+gradle.startParameter.continueOnFailure = true
 
 // during check task:
 // first run checkstyle,

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/WelcomeTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/WelcomeTest.java
@@ -3,12 +3,12 @@ package uk.gov.hmcts.reform.iacaseapi;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.RestAssured;
+import net.serenitybdd.junit.runners.SerenityRunner;
+import net.serenitybdd.rest.SerenityRest;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
-import net.serenitybdd.junit.runners.SerenityRunner;
-import net.serenitybdd.rest.SerenityRest;
 
 @RunWith(SerenityRunner.class)
 public class WelcomeTest {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/WelcomeTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/WelcomeTest.java
@@ -5,8 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.restassured.RestAssured;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
+import net.serenitybdd.junit.runners.SerenityRunner;
+import net.serenitybdd.rest.SerenityRest;
 
+@RunWith(SerenityRunner.class)
 public class WelcomeTest {
 
     private final String targetInstance =
@@ -21,7 +25,7 @@ public class WelcomeTest {
         RestAssured.baseURI = targetInstance;
         RestAssured.useRelaxedHTTPSValidation();
 
-        String response = RestAssured
+        String response = SerenityRest
             .given()
             .when()
             .get("/")


### PR DESCRIPTION
### WHAT?

This change adds Serenity reporting to the existing RestAssured tests.

### WHY?

Serenity creates a really clear test report as it's output, which should help pin-point failures (and hopefully their reasons).

### HOW?

Serenity was included as dependency for the project and incorporated in the functionalTest. The Jenkinsfiles were updated to publish the reports as part of the builds.