### PR TITLE
[PREVIEW] RIA-473 make Jenkins archive serenity reports correctly

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -22,13 +22,12 @@ withPipeline(type, product, component) {
         }
     }
 
-    after('functionalTest') {
-        publishHTML target: [
-                reportDir            : "target/site/serenity/",
-                reportFiles          : "index.html",
-                reportName           : "Functional Test Results",
-                alwaysLinkToLastBuild: true
-        ]
+    after('functionalTest:preview') {
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
+    }
+
+    after('functionalTest:aat') {
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     }
 
     enableSlackNotifications('#ia-tech')

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -15,13 +15,12 @@ properties([
 
 withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, params.ENVIRONMENT, params.SUBSCRIPTION) {
 
-  after('functionalTest') {
-    publishHTML target: [
-            reportDir            : "target/site/serenity/",
-            reportFiles          : "index.html",
-            reportName           : "Functional Test Results",
-            alwaysLinkToLastBuild: true
-    ]
+  after('functionalTest:preview') {
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
+  }
+
+  after('functionalTest:aat') {
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
   }
 
 }


### PR DESCRIPTION
### WHAT?

Serenity reports were not being correctly archived by Jenkins, and so this change fixes that. 

### WHY?

Otherwise any failures that have been correctly reported by Jenkins would not be available for viewing without this change