### PR TITLE
BLOCKED: RIA-469 add nightly zap testing

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -2,17 +2,22 @@
 
 properties([
   // H allow predefined but random minute see https://en.wikipedia.org/wiki/Cron#Non-standard_characters
-  pipelineTriggers([cron('H 22 * * *')])
+  pipelineTriggers([cron('H 22 * * *')]),
+  parameters([
+          string(name: 'URL_TO_TEST', defaultValue: 'https://ia-case-api-aat.service.core-compute-aat.internal', description: 'The URL you want to run these tests against'),
+  ])
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@securityscan")
 
 def type = "java"
 def product = "ia"
 def component = "case-api"
 
 withNightlyPipeline(type, product, component) {
+  env.TEST_URL = params.URL_TO_TEST
 
-  enableMutationTest()
-  enableSlackNotifications('#ia-tech')
+  //  enableMutationTest()
+  enableSecurityScan()
+//  enableSlackNotifications('#ia-tech')
 }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -8,7 +8,7 @@ properties([
   ])
 ])
 
-@Library("Infrastructure@securityscan")
+@Library("Infrastructure")
 
 def type = "java"
 def product = "ia"
@@ -17,7 +17,7 @@ def component = "case-api"
 withNightlyPipeline(type, product, component) {
   env.TEST_URL = params.URL_TO_TEST
 
-  //  enableMutationTest()
   enableSecurityScan()
-//  enableSlackNotifications('#ia-tech')
+  enableMutationTest()
+  enableSlackNotifications('#ia-tech')
 }

--- a/security.sh
+++ b/security.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo ${TEST_URL}
-zap-api-scan.py -t ${TEST_URL}/v2/api-docs -f openapi -P 1001 -a
+zap-api-scan.py -t ${TEST_URL}/v2/api-docs -f openapi -P 1001
 cat zap.out
 zap-cli --zap-url http://0.0.0.0 -p 1001 report -o /zap/api-report.html -f html
 echo "listings of zap folder"

--- a/security.sh
+++ b/security.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+echo ${TEST_URL}
+zap-api-scan.py -t ${TEST_URL}/v2/api-docs -f openapi -P 1001 -a
+cat zap.out
+zap-cli --zap-url http://0.0.0.0 -p 1001 report -o /zap/api-report.html -f html
+echo "listings of zap folder"
+ls -la /zap
+cp /zap/api-report.html functional-output/
+zap-cli -p 1001 alerts -l Informational


### PR DESCRIPTION
### WHAT?

This change adds a `security.sh` file to make use of the `Jenkins_nightly` pipeline **enableSecurityScan()** call. This means that each night the Zap security scanner will security test this service's APIs and produce a report that will be published in Jenkins.

### WHY?

This gives us an automated way to discover any vulnerabilities that might exist in our code, and even if the repo isn't touched in a while the code is still being security tested with the latests Zap docker image.

**!!! PLEASE NOTE: This PR is BLOCKED until https://github.com/hmcts/cnp-jenkins-library/pull/371 has been merged into master !!!**