### PR TITLE
Welcome endpoint re-enabled with JSON and no cache headers (for Zap)

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/EndpointSecurityTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/EndpointSecurityTest.java
@@ -3,7 +3,10 @@ package uk.gov.hmcts.reform.iacaseapi;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.RestAssured;
+import java.util.Arrays;
+import java.util.List;
 import net.serenitybdd.rest.SerenityRest;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,21 +24,48 @@ public class EndpointSecurityTest {
 
     @Value("${targetInstance}") private String targetInstance;
 
+    private final List<String> callbackEndpoints =
+        Arrays.asList(
+            "/asylum/ccdAboutToStart",
+            "/asylum/ccdAboutToSubmit",
+            "/asylum/ccdSubmitted"
+        );
+
     @Autowired private AuthorizationHeadersProvider authorizationHeadersProvider;
+
+    @Before
+    public void setUp() {
+        RestAssured.baseURI = targetInstance;
+        RestAssured.useRelaxedHTTPSValidation();
+    }
+
+    @Test
+    public void should_allow_unauthenticated_requests_to_welcome_message_and_return_200_response_code() {
+
+        String response =
+            SerenityRest
+                .when()
+                .get("/")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .and()
+                .extract().body().asString();
+
+        assertThat(response)
+            .contains("Welcome");
+    }
 
     @Test
     public void should_allow_unauthenticated_requests_to_health_check_and_return_200_response_code() {
 
-        RestAssured.baseURI = targetInstance;
-        RestAssured.useRelaxedHTTPSValidation();
-
-        String response = SerenityRest
-            .when()
-            .get("/health")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .and()
-            .extract().body().asString();
+        String response =
+            SerenityRest
+                .when()
+                .get("/health")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .and()
+                .extract().body().asString();
 
         assertThat(response)
             .contains("UP");
@@ -44,12 +74,15 @@ public class EndpointSecurityTest {
     @Test
     public void should_not_allow_unauthenticated_requests_and_return_403_response_code() {
 
-        SerenityRest
-            .given()
-            .when()
-            .get("/")
-            .then()
-            .statusCode(HttpStatus.FORBIDDEN.value());
+        callbackEndpoints.forEach(callbackEndpoint ->
+
+            SerenityRest
+                .given()
+                .when()
+                .get("/asylum/ccdAboutToSubmit")
+                .then()
+                .statusCode(HttpStatus.FORBIDDEN.value())
+        );
     }
 
     @Test
@@ -57,42 +90,44 @@ public class EndpointSecurityTest {
 
         String invalidServiceToken = "invalid";
 
-        String accessToken = authorizationHeadersProvider
-            .getCaseOfficerAuthorization()
-            .getValue("Authorization");
+        String accessToken =
+            authorizationHeadersProvider
+                .getCaseOfficerAuthorization()
+                .getValue("Authorization");
 
-        RestAssured.baseURI = targetInstance;
-        RestAssured.useRelaxedHTTPSValidation();
+        callbackEndpoints.forEach(callbackEndpoint ->
 
-        SerenityRest
-            .given()
-            .header("ServiceAuthorization", invalidServiceToken)
-            .header("Authorization", accessToken)
-            .when()
-            .get("/")
-            .then()
-            .statusCode(HttpStatus.FORBIDDEN.value());
+            SerenityRest
+                .given()
+                .header("ServiceAuthorization", invalidServiceToken)
+                .header("Authorization", accessToken)
+                .when()
+                .get("/asylum/ccdAboutToSubmit")
+                .then()
+                .statusCode(HttpStatus.FORBIDDEN.value())
+        );
     }
 
     @Test
     public void should_not_allow_requests_without_valid_user_authorisation_and_return_403_response_code() {
 
-        String serviceToken = authorizationHeadersProvider
-            .getCaseOfficerAuthorization()
-            .getValue("ServiceAuthorization");
+        String serviceToken =
+            authorizationHeadersProvider
+                .getCaseOfficerAuthorization()
+                .getValue("ServiceAuthorization");
 
         String invalidAccessToken = "invalid";
 
-        RestAssured.baseURI = targetInstance;
-        RestAssured.useRelaxedHTTPSValidation();
+        callbackEndpoints.forEach(callbackEndpoint ->
 
-        SerenityRest
-            .given()
-            .header("ServiceAuthorization", serviceToken)
-            .header("Authorization", invalidAccessToken)
-            .when()
-            .get("/")
-            .then()
-            .statusCode(HttpStatus.FORBIDDEN.value());
+            SerenityRest
+                .given()
+                .header("ServiceAuthorization", serviceToken)
+                .header("Authorization", invalidAccessToken)
+                .when()
+                .get("/asylum/ccdAboutToSubmit")
+                .then()
+                .statusCode(HttpStatus.FORBIDDEN.value())
+        );
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/EndpointSecurityTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/EndpointSecurityTest.java
@@ -79,7 +79,7 @@ public class EndpointSecurityTest {
             SerenityRest
                 .given()
                 .when()
-                .get("/asylum/ccdAboutToSubmit")
+                .get(callbackEndpoint)
                 .then()
                 .statusCode(HttpStatus.FORBIDDEN.value())
         );
@@ -102,7 +102,7 @@ public class EndpointSecurityTest {
                 .header("ServiceAuthorization", invalidServiceToken)
                 .header("Authorization", accessToken)
                 .when()
-                .get("/asylum/ccdAboutToSubmit")
+                .get(callbackEndpoint)
                 .then()
                 .statusCode(HttpStatus.FORBIDDEN.value())
         );
@@ -125,7 +125,7 @@ public class EndpointSecurityTest {
                 .header("ServiceAuthorization", serviceToken)
                 .header("Authorization", invalidAccessToken)
                 .when()
-                .get("/asylum/ccdAboutToSubmit")
+                .get(callbackEndpoint)
                 .then()
                 .statusCode(HttpStatus.FORBIDDEN.value())
         );

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/WelcomeTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/WelcomeTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.iacaseapi.util.AuthorizationHeadersProvider;
@@ -29,15 +30,16 @@ public class WelcomeTest {
         RestAssured.baseURI = targetInstance;
         RestAssured.useRelaxedHTTPSValidation();
 
-        String response = SerenityRest
-            .given()
-            .headers(authorizationHeadersProvider.getCaseOfficerAuthorization())
-            .when()
-            .get("/")
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .and()
-            .extract().body().asString();
+        String response =
+            SerenityRest
+                .given()
+                .when()
+                .get("/")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+                .and()
+                .extract().body().asString();
 
         assertThat(response)
             .contains("Welcome to Immigration & Asylum case API");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/controllers/WelcomeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/controllers/WelcomeController.java
@@ -1,9 +1,13 @@
 package uk.gov.hmcts.reform.iacaseapi.infrastructure.controllers;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.util.UUID;
+import org.slf4j.Logger;
 import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +23,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class WelcomeController {
 
+    private static final Logger LOG = getLogger(WelcomeController.class);
+    private static final String INSTANCE_ID = UUID.randomUUID().toString();
+    private static final String MESSAGE = "Welcome to Immigration & Asylum case API";
+
     /**
      * Root GET endpoint.
      *
@@ -28,7 +36,7 @@ public class WelcomeController {
      *
      * @return Welcome message from the service.
      */
-    @ApiOperation("Welcome message for the Immigration & Asylum case API")
+    @ApiOperation(MESSAGE)
     @ApiResponses({
         @ApiResponse(
             code = 200,
@@ -42,10 +50,13 @@ public class WelcomeController {
     )
     @ResponseBody
     public ResponseEntity<String> welcome() {
+
+        LOG.info("Welcome message '{}' from running instance: {}", MESSAGE, INSTANCE_ID);
+
         return ResponseEntity
             .ok()
             .cacheControl(CacheControl.noCache())
-            .body("{\"message\": \"Welcome to Immigration & Asylum case API\"}");
+            .body("{\"message\": \"" + MESSAGE + "\"}");
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/controllers/WelcomeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/controllers/WelcomeController.java
@@ -1,19 +1,18 @@
 package uk.gov.hmcts.reform.iacaseapi.infrastructure.controllers;
 
-import static org.springframework.http.ResponseEntity.ok;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @Api(
     value = "/",
-    consumes = MediaType.APPLICATION_JSON_UTF8_VALUE,
     produces = MediaType.APPLICATION_JSON_UTF8_VALUE
 )
 
@@ -29,17 +28,24 @@ public class WelcomeController {
      *
      * @return Welcome message from the service.
      */
-    @ApiOperation("Welcome page for the Immigration & Asylum case API")
+    @ApiOperation("Welcome message for the Immigration & Asylum case API")
     @ApiResponses({
         @ApiResponse(
             code = 200,
-            message = "Welcome Page",
+            message = "Welcome message",
             response = String.class
         )
     })
-    @GetMapping(path = "/")
+    @GetMapping(
+        path = "/",
+        produces = MediaType.APPLICATION_JSON_UTF8_VALUE
+    )
+    @ResponseBody
     public ResponseEntity<String> welcome() {
-        return ok("Welcome to Immigration & Asylum case API");
+        return ResponseEntity
+            .ok()
+            .cacheControl(CacheControl.noCache())
+            .body("{\"message\": \"Welcome to Immigration & Asylum case API\"}");
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/controllers/WelcomeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/controllers/WelcomeController.java
@@ -36,7 +36,7 @@ public class WelcomeController {
      *
      * @return Welcome message from the service.
      */
-    @ApiOperation(MESSAGE)
+    @ApiOperation("Welcome message for the Immigration & Asylum case API")
     @ApiResponses({
         @ApiResponse(
             code = 200,
@@ -58,5 +58,4 @@ public class WelcomeController {
             .cacheControl(CacheControl.noCache())
             .body("{\"message\": \"" + MESSAGE + "\"}");
     }
-
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -66,6 +66,7 @@ ia_system_user_password: ${IA_SYSTEM_PASSWORD:system-password}
 
 security:
   anonymousPaths:
+    - "/"
     - "/health"
     - "/loggers/**"
     - "/swagger-ui.html"


### PR DESCRIPTION
Primary goal is to stop the error logs filling up with Auth Errors when Azure pings the root endpoint.