### PR TITLE
RIA-706 Upload additional evidence

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-385-request-hearing-requirements.json
+++ b/src/functionalTest/resources/scenarios/RIA-385-request-hearing-requirements.json
@@ -22,7 +22,8 @@
               }
             }
           ],
-          "notificationsSent": []
+          "notificationsSent": [],
+          "uploadAdditionalEvidenceActionAvailable": "Yes"
         }
       }
     }
@@ -60,7 +61,8 @@
             "id": "1122_LEGAL_REPRESENTATIVE_HEARING_REQUIREMENTS_DIRECTION",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
-        ]
+        ],
+        "uploadAdditionalEvidenceActionAvailable": "Yes"
       }
     }
   }

--- a/src/functionalTest/resources/scenarios/RIA-611-request-case-edit-submit.json
+++ b/src/functionalTest/resources/scenarios/RIA-611-request-case-edit-submit.json
@@ -22,7 +22,8 @@
                 "tag": ""
               }
             }
-          ]
+          ],
+          "uploadAdditionalEvidenceActionAvailable": "Yes"
         }
       }
     }
@@ -54,7 +55,8 @@
               "tag": ""
             }
           }
-        ]
+        ],
+        "uploadAdditionalEvidenceActionAvailable": "Yes"
       }
     }
   }

--- a/src/functionalTest/resources/scenarios/RIA-697-RIA-237-add-appeal-response-initial.json
+++ b/src/functionalTest/resources/scenarios/RIA-697-RIA-237-add-appeal-response-initial.json
@@ -39,7 +39,8 @@
                 "description": "Some more appeal response evidence"
               }
             }
-          ]
+          ],
+          "uploadAdditionalEvidenceActionAvailable": "Yes"
         }
       }
     }
@@ -133,7 +134,8 @@
               "tag": "appealResponse"
             }
           }
-        ]
+        ],
+        "uploadAdditionalEvidenceActionAvailable": "Yes"
       }
     }
   }

--- a/src/functionalTest/resources/scenarios/RIA-697-RIA-237-add-appeal-response-replace.json
+++ b/src/functionalTest/resources/scenarios/RIA-697-RIA-237-add-appeal-response-replace.json
@@ -67,7 +67,8 @@
                 "tag": "appealResponse"
               }
             }
-          ]
+          ],
+          "uploadAdditionalEvidenceActionAvailable": "Yes"
         }
       }
     }
@@ -161,7 +162,8 @@
               "tag": "appealResponse"
             }
           }
-        ]
+        ],
+        "uploadAdditionalEvidenceActionAvailable": "Yes"
       }
     }
   }

--- a/src/functionalTest/resources/scenarios/RIA-706-upload-additional-evidence-action-available.json
+++ b/src/functionalTest/resources/scenarios/RIA-706-upload-additional-evidence-action-available.json
@@ -1,0 +1,27 @@
+{
+  "description": "RIA-706 Upload additional evidence action becomes available in appropriate state",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "submitCase",
+      "state": "caseUnderReview",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "uploadAdditionalEvidenceActionAvailable": "No"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "uploadAdditionalEvidenceActionAvailable": "Yes"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-706-upload-additional-evidence-confirmation.json
+++ b/src/functionalTest/resources/scenarios/RIA-706-upload-additional-evidence-confirmation.json
@@ -1,0 +1,22 @@
+{
+  "description": "RIA-706 Upload additional evidence confirmation",
+  "request": {
+    "uri": "/asylum/ccdSubmitted",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "uploadAdditionalEvidence",
+      "state": "respondentReview",
+      "id": 1234,
+      "caseData": {
+        "template": "minimal-appeal-submitted.json"
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "confirmation": {
+      "header": "# You have uploaded a document",
+      "body": "#### What happens next\n\nThe document is now available in the documents tab."
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-706-upload-additional-evidence-submit.json
+++ b/src/functionalTest/resources/scenarios/RIA-706-upload-additional-evidence-submit.json
@@ -1,0 +1,108 @@
+{
+  "description": "RIA-706 Upload additional evidence",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "id": 1234,
+      "eventId": "uploadAdditionalEvidence",
+      "state": "submitHearingRequirements",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "additionalEvidenceDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "document": {
+                  "document_url": "http://document-store/AAA",
+                  "document_binary_url": "http://document-store/AAA/binary",
+                  "document_filename": "existing-evidence.pdf"
+                },
+                "description": "Existing evidence",
+                "dateUploaded": "2018-12-25",
+                "tag": "additionalEvidence"
+              }
+            }
+          ],
+          "additionalEvidence": [
+            {
+              "id": "1",
+              "value": {
+                "document": {
+                  "document_url": "http://document-store/BBB",
+                  "document_binary_url": "http://document-store/BBB/binary",
+                  "document_filename": "some-new-evidence.pdf"
+                },
+                "description": "Some new evidence"
+              }
+            },
+            {
+              "id": "2",
+              "value": {
+                "document": {
+                  "document_url": "http://document-store/CCC",
+                  "document_binary_url": "http://document-store/CCC/binary",
+                  "document_filename": "some-more-new-evidence.pdf"
+                },
+                "description": "Some more new evidence"
+              }
+            }
+          ],
+          "uploadAdditionalEvidenceActionAvailable": "Yes"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "additionalDocuments": [
+          {
+            "id": "3",
+            "value": {
+              "document": {
+                "document_url": "http://document-store/BBB",
+                "document_binary_url": "http://document-store/BBB/binary",
+                "document_filename": "some-new-evidence.pdf"
+              },
+              "description": "Some new evidence",
+              "dateUploaded": "{$TODAY}",
+              "tag": "additionalEvidence"
+            }
+          },
+          {
+            "id": "2",
+            "value": {
+              "document": {
+                "document_url": "http://document-store/CCC",
+                "document_binary_url": "http://document-store/CCC/binary",
+                "document_filename": "some-more-new-evidence.pdf"
+              },
+              "description": "Some more new evidence",
+              "dateUploaded": "{$TODAY}",
+              "tag": "additionalEvidence"
+            }
+          },
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "http://document-store/AAA",
+                "document_binary_url": "http://document-store/AAA/binary",
+                "document_filename": "existing-evidence.pdf"
+              },
+              "description": "Existing evidence",
+              "dateUploaded": "2018-12-25",
+              "tag": "additionalEvidence"
+            }
+          }
+        ],
+        "uploadAdditionalEvidenceActionAvailable": "Yes"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-837-send-legal-rep-review-direction.json
+++ b/src/functionalTest/resources/scenarios/RIA-837-send-legal-rep-review-direction.json
@@ -17,7 +17,8 @@
             "document_filename": "appeal-response.pdf"
           },
           "appealResponseDescription": "Appeal response",
-          "appealResponseEvidence": []
+          "appealResponseEvidence": [],
+          "uploadAdditionalEvidenceActionAvailable": "Yes"
         }
       }
     }
@@ -53,7 +54,8 @@
             "id": "3333_LEGAL_REPRESENTATIVE_REVIEW_DIRECTION",
             "value": "$/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/"
           }
-        ]
+        ],
+        "uploadAdditionalEvidenceActionAvailable": "Yes"
       }
     }
   }

--- a/src/functionalTest/resources/scenarios/RIA-910-RIA-911-RIA-912-current-case-state-example2.json
+++ b/src/functionalTest/resources/scenarios/RIA-910-RIA-911-RIA-912-current-case-state-example2.json
@@ -10,7 +10,8 @@
         "template": "minimal-appeal-submitted.json",
         "replacements": {
           "currentCaseStateVisibleToCaseOfficer": "respondentReview",
-          "currentCaseStateVisibleToLegalRepresentative": "respondentReview"
+          "currentCaseStateVisibleToLegalRepresentative": "respondentReview",
+          "uploadAdditionalEvidenceActionAvailable": "Yes"
         }
       }
     }
@@ -22,7 +23,8 @@
       "template": "minimal-appeal-submitted.json",
       "replacements": {
         "currentCaseStateVisibleToCaseOfficer": "submitHearingRequirements",
-        "currentCaseStateVisibleToLegalRepresentative": "submitHearingRequirements"
+        "currentCaseStateVisibleToLegalRepresentative": "submitHearingRequirements",
+        "uploadAdditionalEvidenceActionAvailable": "Yes"
       }
     }
   }

--- a/src/functionalTest/resources/templates/minimal-appeal-submitted.json
+++ b/src/functionalTest/resources/templates/minimal-appeal-submitted.json
@@ -28,5 +28,6 @@
   "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
   "sendDirectionActionAvailable": "Yes",
   "hearingCentre": "taylorHouse",
-  "submissionOutOfTime": "No"
+  "submissionOutOfTime": "No",
+  "uploadAdditionalEvidenceActionAvailable": "No"
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCase.java
@@ -61,6 +61,7 @@ public class AsylumCase implements CaseData {
     // case documents ...
     // -----------------------------------------------------------------------------
 
+    private Optional<List<IdValue<DocumentWithMetadata>>> additionalEvidenceDocuments = Optional.empty();
     private Optional<List<IdValue<DocumentWithMetadata>>> legalRepresentativeDocuments = Optional.empty();
     private Optional<List<IdValue<DocumentWithMetadata>>> respondentDocuments = Optional.empty();
 
@@ -94,6 +95,12 @@ public class AsylumCase implements CaseData {
     private Optional<Document> applicationOutOfTimeDocument = Optional.empty();
 
     // -----------------------------------------------------------------------------
+    // upload additional evidence ...
+    // -----------------------------------------------------------------------------
+
+    private Optional<List<IdValue<DocumentWithDescription>>> additionalEvidence = Optional.empty();
+
+    // -----------------------------------------------------------------------------
     // internal API managed fields ...
     // -----------------------------------------------------------------------------
 
@@ -102,6 +109,7 @@ public class AsylumCase implements CaseData {
     private Optional<List<IdValue<String>>> notificationsSent = Optional.empty();
     private Optional<YesOrNo> changeDirectionDueDateActionAvailable = Optional.empty();
     private Optional<YesOrNo> sendDirectionActionAvailable = Optional.empty();
+    private Optional<YesOrNo> uploadAdditionalEvidenceActionAvailable = Optional.empty();
     private Optional<YesOrNo> caseBuildingReadyForSubmission = Optional.empty();
     private Optional<State> currentCaseStateVisibleToCaseOfficer = Optional.empty();
     private Optional<State> currentCaseStateVisibleToLegalRepresentative = Optional.empty();
@@ -143,6 +151,7 @@ public class AsylumCase implements CaseData {
         this.sendDirectionDateDue = asylumCaseBuilder.getSendDirectionDateDue();
         this.directions = asylumCaseBuilder.getDirections();
         this.editableDirections = asylumCaseBuilder.getEditableDirections();
+        this.additionalEvidenceDocuments = asylumCaseBuilder.getAdditionalEvidenceDocuments();
         this.legalRepresentativeDocuments = asylumCaseBuilder.getLegalRepresentativeDocuments();
         this.respondentDocuments = asylumCaseBuilder.getRespondentDocuments();
         this.respondentEvidence = asylumCaseBuilder.getRespondentEvidence();
@@ -154,11 +163,13 @@ public class AsylumCase implements CaseData {
         this.appealResponseEvidence = asylumCaseBuilder.getAppealResponseEvidence();
         this.applicationOutOfTimeExplanation = asylumCaseBuilder.getApplicationOutOfTimeExplanation();
         this.applicationOutOfTimeDocument = asylumCaseBuilder.getApplicationOutOfTimeDocument();
+        this.additionalEvidence = asylumCaseBuilder.getAdditionalEvidence();
         this.legalRepresentativeName = asylumCaseBuilder.getLegalRepresentativeName();
         this.legalRepresentativeEmailAddress = asylumCaseBuilder.getLegalRepresentativeEmailAddress();
         this.notificationsSent = asylumCaseBuilder.getNotificationsSent();
         this.changeDirectionDueDateActionAvailable = asylumCaseBuilder.getChangeDirectionDueDateActionAvailable();
         this.sendDirectionActionAvailable = asylumCaseBuilder.getSendDirectionActionAvailable();
+        this.uploadAdditionalEvidenceActionAvailable = asylumCaseBuilder.getUploadAdditionalEvidenceActionAvailable();
         this.caseBuildingReadyForSubmission = asylumCaseBuilder.getCaseBuildingReadyForSubmission();
         this.currentCaseStateVisibleToCaseOfficer = asylumCaseBuilder.getCurrentCaseStateVisibleToCaseOfficer();
         this.currentCaseStateVisibleToLegalRepresentative = asylumCaseBuilder.getCurrentCaseStateVisibleToLegalRepresentative();
@@ -370,6 +381,11 @@ public class AsylumCase implements CaseData {
     // case documents ...
     // -----------------------------------------------------------------------------
 
+    public Optional<List<IdValue<DocumentWithMetadata>>> getAdditionalEvidenceDocuments() {
+        requireNonNull(additionalEvidenceDocuments);
+        return additionalEvidenceDocuments;
+    }
+
     public Optional<List<IdValue<DocumentWithMetadata>>> getLegalRepresentativeDocuments() {
         requireNonNull(legalRepresentativeDocuments);
         return legalRepresentativeDocuments;
@@ -378,6 +394,10 @@ public class AsylumCase implements CaseData {
     public Optional<List<IdValue<DocumentWithMetadata>>> getRespondentDocuments() {
         requireNonNull(respondentDocuments);
         return respondentDocuments;
+    }
+
+    public void setAdditionalEvidenceDocuments(List<IdValue<DocumentWithMetadata>> additionalEvidenceDocuments) {
+        this.additionalEvidenceDocuments = Optional.ofNullable(additionalEvidenceDocuments);
     }
 
     public void setLegalRepresentativeDocuments(List<IdValue<DocumentWithMetadata>> legalRepresentativeDocuments) {
@@ -454,6 +474,19 @@ public class AsylumCase implements CaseData {
     }
 
     // -----------------------------------------------------------------------------
+    // upload additional evidence ...
+    // -----------------------------------------------------------------------------
+
+    public Optional<List<IdValue<DocumentWithDescription>>> getAdditionalEvidence() {
+        requireNonNull(additionalEvidence);
+        return additionalEvidence;
+    }
+
+    public void clearAdditionalEvidence() {
+        this.additionalEvidence = Optional.empty();
+    }
+
+    // -----------------------------------------------------------------------------
     // internal API managed fields ...
     // -----------------------------------------------------------------------------
 
@@ -480,6 +513,11 @@ public class AsylumCase implements CaseData {
     public Optional<YesOrNo> getSendDirectionActionAvailable() {
         requireNonNull(sendDirectionActionAvailable);
         return sendDirectionActionAvailable;
+    }
+
+    public Optional<YesOrNo> getUploadAdditionalEvidenceActionAvailable() {
+        requireNonNull(uploadAdditionalEvidenceActionAvailable);
+        return uploadAdditionalEvidenceActionAvailable;
     }
 
     public Optional<YesOrNo> getCaseBuildingReadyForSubmission() {
@@ -534,6 +572,10 @@ public class AsylumCase implements CaseData {
 
     public void setSendDirectionActionAvailable(YesOrNo sendDirectionActionAvailable) {
         this.sendDirectionActionAvailable = Optional.ofNullable(sendDirectionActionAvailable);
+    }
+
+    public void setUploadAdditionalEvidenceActionAvailable(YesOrNo uploadAdditionalEvidenceActionAvailable) {
+        this.uploadAdditionalEvidenceActionAvailable = Optional.ofNullable(uploadAdditionalEvidenceActionAvailable);
     }
 
     public void setCaseBuildingReadyForSubmission(YesOrNo caseBuildingReadyForSubmission) {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseBuilder.java
@@ -60,6 +60,7 @@ public class AsylumCaseBuilder {
     // case documents ...
     // -----------------------------------------------------------------------------
 
+    private Optional<List<IdValue<DocumentWithMetadata>>> additionalEvidenceDocuments = Optional.empty();
     private Optional<List<IdValue<DocumentWithMetadata>>> legalRepresentativeDocuments = Optional.empty();
     private Optional<List<IdValue<DocumentWithMetadata>>> respondentDocuments = Optional.empty();
 
@@ -93,6 +94,12 @@ public class AsylumCaseBuilder {
     private Optional<Document> applicationOutOfTimeDocument = Optional.empty();
 
     // -----------------------------------------------------------------------------
+    // upload additional evidence ...
+    // -----------------------------------------------------------------------------
+
+    private Optional<List<IdValue<DocumentWithDescription>>> additionalEvidence = Optional.empty();
+
+    // -----------------------------------------------------------------------------
     // internal API managed fields ...
     // -----------------------------------------------------------------------------
 
@@ -101,6 +108,7 @@ public class AsylumCaseBuilder {
     private Optional<List<IdValue<String>>> notificationsSent = Optional.empty();
     private Optional<YesOrNo> changeDirectionDueDateActionAvailable = Optional.empty();
     private Optional<YesOrNo> sendDirectionActionAvailable = Optional.empty();
+    private Optional<YesOrNo> uploadAdditionalEvidenceActionAvailable = Optional.empty();
     private Optional<YesOrNo> caseBuildingReadyForSubmission = Optional.empty();
     private Optional<State> currentCaseStateVisibleToCaseOfficer = Optional.empty();
     private Optional<State> currentCaseStateVisibleToLegalRepresentative = Optional.empty();
@@ -344,6 +352,9 @@ public class AsylumCaseBuilder {
     // case documents ...
     // -----------------------------------------------------------------------------
 
+    public Optional<List<IdValue<DocumentWithMetadata>>> getAdditionalEvidenceDocuments() {
+        return additionalEvidenceDocuments;
+    }
 
     public Optional<List<IdValue<DocumentWithMetadata>>> getLegalRepresentativeDocuments() {
         return legalRepresentativeDocuments;
@@ -351,6 +362,10 @@ public class AsylumCaseBuilder {
 
     public Optional<List<IdValue<DocumentWithMetadata>>> getRespondentDocuments() {
         return respondentDocuments;
+    }
+
+    public void setAdditionalEvidenceDocuments(Optional<List<IdValue<DocumentWithMetadata>>> additionalEvidenceDocuments) {
+        this.additionalEvidenceDocuments = additionalEvidenceDocuments;
     }
 
     public void setLegalRepresentativeDocuments(Optional<List<IdValue<DocumentWithMetadata>>> legalRepresentativeDocuments) {
@@ -442,6 +457,18 @@ public class AsylumCaseBuilder {
     }
 
     // -----------------------------------------------------------------------------
+    // upload additional evidence ...
+    // -----------------------------------------------------------------------------
+
+    public Optional<List<IdValue<DocumentWithDescription>>> getAdditionalEvidence() {
+        return additionalEvidence;
+    }
+
+    public void setAdditionalEvidence(Optional<List<IdValue<DocumentWithDescription>>> additionalEvidence) {
+        this.additionalEvidence = additionalEvidence;
+    }
+
+    // -----------------------------------------------------------------------------
     // internal API managed fields ...
     // -----------------------------------------------------------------------------
 
@@ -463,6 +490,10 @@ public class AsylumCaseBuilder {
 
     public Optional<YesOrNo> getSendDirectionActionAvailable() {
         return sendDirectionActionAvailable;
+    }
+
+    public Optional<YesOrNo> getUploadAdditionalEvidenceActionAvailable() {
+        return uploadAdditionalEvidenceActionAvailable;
     }
 
     public Optional<YesOrNo> getCaseBuildingReadyForSubmission() {
@@ -515,6 +546,10 @@ public class AsylumCaseBuilder {
 
     public void setSendDirectionActionAvailable(Optional<YesOrNo> sendDirectionActionAvailable) {
         this.sendDirectionActionAvailable = sendDirectionActionAvailable;
+    }
+
+    public void setUploadAdditionalEvidenceActionAvailable(Optional<YesOrNo> uploadAdditionalEvidenceActionAvailable) {
+        this.uploadAdditionalEvidenceActionAvailable = uploadAdditionalEvidenceActionAvailable;
     }
 
     public void setCaseBuildingReadyForSubmission(Optional<YesOrNo> caseBuildingReadyForSubmission) {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/DocumentTag.java
@@ -8,6 +8,7 @@ public enum DocumentTag {
     RESPONDENT_EVIDENCE("respondentEvidence"),
     APPEAL_RESPONSE("appealResponse"),
     APPEAL_SUBMISSION("appealSubmission"),
+    ADDITIONAL_EVIDENCE("additionalEvidence"),
 
     @JsonEnumDefaultValue
     NONE("");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -17,6 +17,7 @@ public enum Event {
     ADD_APPEAL_RESPONSE("addAppealResponse"),
     REQUEST_HEARING_REQUIREMENTS("requestHearingRequirements"),
     CHANGE_DIRECTION_DUE_DATE("changeDirectionDueDate"),
+    UPLOAD_ADDITIONAL_EVIDENCE("uploadAdditionalEvidence"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/UploadAdditionalEvidenceConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/UploadAdditionalEvidenceConfirmation.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+@Component
+public class UploadAdditionalEvidenceConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callback, "callback must not be null");
+
+        return callback.getEvent() == Event.UPLOAD_ADDITIONAL_EVIDENCE;
+    }
+
+    public PostSubmitCallbackResponse handle(
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+
+        postSubmitResponse.setConfirmationHeader("# You have uploaded a document");
+        postSubmitResponse.setConfirmationBody(
+            "#### What happens next\n\n"
+            + "The document is now available in the documents tab."
+        );
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UploadAdditionalEvidenceActionAvailableUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UploadAdditionalEvidenceActionAvailableUpdater.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class UploadAdditionalEvidenceActionAvailableUpdater implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        CaseDetails<AsylumCase> caseDetails =
+            callback
+                .getCaseDetails();
+
+        AsylumCase asylumCase = caseDetails.getCaseData();
+
+        if (Arrays.asList(
+            State.CASE_UNDER_REVIEW,
+            State.RESPONDENT_REVIEW,
+            State.SUBMIT_HEARING_REQUIREMENTS,
+            State.LISTING
+        ).contains(caseDetails.getState())) {
+
+            asylumCase.setUploadAdditionalEvidenceActionAvailable(YesOrNo.YES);
+        } else {
+            asylumCase.setUploadAdditionalEvidenceActionAvailable(YesOrNo.NO);
+        }
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UploadAdditionalEvidenceHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UploadAdditionalEvidenceHandler.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.DocumentReceiver;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.DocumentsAppender;
+
+@Component
+public class UploadAdditionalEvidenceHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final DocumentReceiver documentReceiver;
+    private final DocumentsAppender documentsAppender;
+
+    public UploadAdditionalEvidenceHandler(
+        DocumentReceiver documentReceiver,
+        DocumentsAppender documentsAppender
+    ) {
+        this.documentReceiver = documentReceiver;
+        this.documentsAppender = documentsAppender;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+               && callback.getEvent() == Event.UPLOAD_ADDITIONAL_EVIDENCE;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        List<DocumentWithMetadata> additionalEvidenceDocuments =
+            asylumCase
+                .getAdditionalEvidence()
+                .orElseThrow(() -> new IllegalStateException("additionalEvidence is not present"))
+                .stream()
+                .map(IdValue::getValue)
+                .map(document -> documentReceiver.tryReceive(document, DocumentTag.ADDITIONAL_EVIDENCE))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+
+        final List<IdValue<DocumentWithMetadata>> existingAdditionalEvidenceDocuments =
+            asylumCase
+                .getAdditionalEvidenceDocuments()
+                .orElse(Collections.emptyList());
+
+        List<IdValue<DocumentWithMetadata>> allAdditionalEvidenceDocuments =
+            documentsAppender.append(existingAdditionalEvidenceDocuments, additionalEvidenceDocuments);
+
+        asylumCase.setAdditionalEvidenceDocuments(allAdditionalEvidenceDocuments);
+
+        asylumCase.clearAdditionalEvidence();
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -116,6 +116,7 @@ security:
       - "submitAppeal"
       - "buildCase"
       - "submitCase"
+      - "uploadAdditionalEvidence"
     caseworker-ia-caseofficer:
       - "sendDirection"
       - "changeDirectionDueDate"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseBuilderTest.java
@@ -63,6 +63,7 @@ public class AsylumCaseBuilderTest {
     // case documents ...
     // -----------------------------------------------------------------------------
 
+    private final List<IdValue<DocumentWithMetadata>> additionalEvidenceDocuments = mock(List.class);
     private final List<IdValue<DocumentWithMetadata>> legalRepresentativeDocuments = mock(List.class);
     private final List<IdValue<DocumentWithMetadata>> respondentDocuments = mock(List.class);
 
@@ -96,6 +97,12 @@ public class AsylumCaseBuilderTest {
     private final Document applicationOutOfTimeDocument = mock(Document.class);
 
     // -----------------------------------------------------------------------------
+    // upload additional evidence ...
+    // -----------------------------------------------------------------------------
+
+    private final List<IdValue<DocumentWithDescription>> additionalEvidence = mock(List.class);
+
+    // -----------------------------------------------------------------------------
     // internal API managed fields ...
     // -----------------------------------------------------------------------------
 
@@ -104,6 +111,7 @@ public class AsylumCaseBuilderTest {
     private final List<IdValue<String>> notificationsSent = mock(List.class);
     private final YesOrNo changeDirectionDueDateActionAvailable = YesOrNo.YES;
     private final YesOrNo sendDirectionActionAvailable = YesOrNo.YES;
+    private final YesOrNo uploadAdditionalEvidenceActionAvailable = YesOrNo.YES;
     private final YesOrNo caseBuildingReadyForSubmission = YesOrNo.YES;
     private final State currentCaseStateVisibleToCaseOfficer = State.APPEAL_SUBMITTED;
     private final State currentCaseStateVisibleToLegalRepresentative = State.APPEAL_SUBMITTED;
@@ -143,6 +151,7 @@ public class AsylumCaseBuilderTest {
         asylumCaseBuilder.setSendDirectionDateDue(Optional.of(sendDirectionDateDue));
         asylumCaseBuilder.setDirections(Optional.of(directions));
         asylumCaseBuilder.setEditableDirections(Optional.of(editableDirections));
+        asylumCaseBuilder.setAdditionalEvidenceDocuments(Optional.of(additionalEvidenceDocuments));
         asylumCaseBuilder.setLegalRepresentativeDocuments(Optional.of(legalRepresentativeDocuments));
         asylumCaseBuilder.setRespondentDocuments(Optional.of(respondentDocuments));
         asylumCaseBuilder.setRespondentEvidence(Optional.of(respondentEvidence));
@@ -154,11 +163,13 @@ public class AsylumCaseBuilderTest {
         asylumCaseBuilder.setAppealResponseEvidence(Optional.of(appealResponseEvidence));
         asylumCaseBuilder.setApplicationOutOfTimeExplanation(Optional.of(applicationOutOfTimeExplanation));
         asylumCaseBuilder.setApplicationOutOfTimeDocument(Optional.of(applicationOutOfTimeDocument));
+        asylumCaseBuilder.setAdditionalEvidence(Optional.of(additionalEvidence));
         asylumCaseBuilder.setLegalRepresentativeName(Optional.of(legalRepresentativeName));
         asylumCaseBuilder.setLegalRepresentativeEmailAddress(Optional.of(legalRepresentativeEmailAddress));
         asylumCaseBuilder.setNotificationsSent(Optional.of(notificationsSent));
         asylumCaseBuilder.setChangeDirectionDueDateActionAvailable(Optional.of(changeDirectionDueDateActionAvailable));
         asylumCaseBuilder.setSendDirectionActionAvailable(Optional.of(sendDirectionActionAvailable));
+        asylumCaseBuilder.setUploadAdditionalEvidenceActionAvailable(Optional.of(uploadAdditionalEvidenceActionAvailable));
         asylumCaseBuilder.setCaseBuildingReadyForSubmission(Optional.of(caseBuildingReadyForSubmission));
         asylumCaseBuilder.setCurrentCaseStateVisibleToCaseOfficer(Optional.of(currentCaseStateVisibleToCaseOfficer));
         asylumCaseBuilder.setCurrentCaseStateVisibleToLegalRepresentative(Optional.of(currentCaseStateVisibleToLegalRepresentative));
@@ -195,6 +206,7 @@ public class AsylumCaseBuilderTest {
         assertEquals(Optional.of(sendDirectionDateDue), asylumCase.getSendDirectionDateDue());
         assertEquals(Optional.of(directions), asylumCase.getDirections());
         assertEquals(Optional.of(editableDirections), asylumCase.getEditableDirections());
+        assertEquals(Optional.of(additionalEvidenceDocuments), asylumCase.getAdditionalEvidenceDocuments());
         assertEquals(Optional.of(legalRepresentativeDocuments), asylumCase.getLegalRepresentativeDocuments());
         assertEquals(Optional.of(respondentDocuments), asylumCase.getRespondentDocuments());
         assertEquals(Optional.of(respondentEvidence), asylumCase.getRespondentEvidence());
@@ -206,11 +218,13 @@ public class AsylumCaseBuilderTest {
         assertEquals(Optional.of(appealResponseEvidence), asylumCase.getAppealResponseEvidence());
         assertEquals(Optional.of(applicationOutOfTimeExplanation), asylumCase.getApplicationOutOfTimeExplanation());
         assertEquals(Optional.of(applicationOutOfTimeDocument), asylumCase.getApplicationOutOfTimeDocument());
+        assertEquals(Optional.of(additionalEvidence), asylumCase.getAdditionalEvidence());
         assertEquals(Optional.of(legalRepresentativeName), asylumCase.getLegalRepresentativeName());
         assertEquals(Optional.of(legalRepresentativeEmailAddress), asylumCase.getLegalRepresentativeEmailAddress());
         assertEquals(Optional.of(notificationsSent), asylumCase.getNotificationsSent());
         assertEquals(Optional.of(changeDirectionDueDateActionAvailable), asylumCase.getChangeDirectionDueDateActionAvailable());
         assertEquals(Optional.of(sendDirectionActionAvailable), asylumCase.getSendDirectionActionAvailable());
+        assertEquals(Optional.of(uploadAdditionalEvidenceActionAvailable), asylumCase.getUploadAdditionalEvidenceActionAvailable());
         assertEquals(Optional.of(caseBuildingReadyForSubmission), asylumCase.getCaseBuildingReadyForSubmission());
         assertEquals(Optional.of(currentCaseStateVisibleToCaseOfficer), asylumCase.getCurrentCaseStateVisibleToCaseOfficer());
         assertEquals(Optional.of(currentCaseStateVisibleToLegalRepresentative), asylumCase.getCurrentCaseStateVisibleToLegalRepresentative());

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseTest.java
@@ -67,6 +67,7 @@ public class AsylumCaseTest {
     // case documents ...
     // -----------------------------------------------------------------------------
 
+    private final List<IdValue<DocumentWithMetadata>> additionalEvidenceDocuments = mock(List.class);
     private final List<IdValue<DocumentWithMetadata>> legalRepresentativeDocuments = mock(List.class);
     private final List<IdValue<DocumentWithMetadata>> respondentDocuments = mock(List.class);
 
@@ -108,6 +109,7 @@ public class AsylumCaseTest {
     private final List<IdValue<String>> notificationsSent = mock(List.class);
     private final YesOrNo changeDirectionDueDateActionAvailable = YesOrNo.YES;
     private final YesOrNo sendDirectionActionAvailable = YesOrNo.YES;
+    private final YesOrNo uploadAdditionalEvidenceActionAvailable = YesOrNo.YES;
     private final YesOrNo caseBuildingReadyForSubmission = YesOrNo.YES;
     private final State currentCaseStateVisibleToCaseOfficer = State.APPEAL_SUBMITTED;
     private final State currentCaseStateVisibleToLegalRepresentative = State.APPEAL_SUBMITTED;
@@ -147,6 +149,7 @@ public class AsylumCaseTest {
         when(asylumCaseBuilder.getSendDirectionDateDue()).thenReturn(Optional.of(sendDirectionDateDue));
         when(asylumCaseBuilder.getDirections()).thenReturn(Optional.of(directions));
         when(asylumCaseBuilder.getEditableDirections()).thenReturn(Optional.of(editableDirections));
+        when(asylumCaseBuilder.getAdditionalEvidenceDocuments()).thenReturn(Optional.of(additionalEvidenceDocuments));
         when(asylumCaseBuilder.getLegalRepresentativeDocuments()).thenReturn(Optional.of(legalRepresentativeDocuments));
         when(asylumCaseBuilder.getRespondentDocuments()).thenReturn(Optional.of(respondentDocuments));
         when(asylumCaseBuilder.getRespondentEvidence()).thenReturn(Optional.of(respondentEvidence));
@@ -163,6 +166,7 @@ public class AsylumCaseTest {
         when(asylumCaseBuilder.getNotificationsSent()).thenReturn(Optional.of(notificationsSent));
         when(asylumCaseBuilder.getChangeDirectionDueDateActionAvailable()).thenReturn(Optional.of(changeDirectionDueDateActionAvailable));
         when(asylumCaseBuilder.getSendDirectionActionAvailable()).thenReturn(Optional.of(sendDirectionActionAvailable));
+        when(asylumCaseBuilder.getUploadAdditionalEvidenceActionAvailable()).thenReturn(Optional.of(uploadAdditionalEvidenceActionAvailable));
         when(asylumCaseBuilder.getCaseBuildingReadyForSubmission()).thenReturn(Optional.of(caseBuildingReadyForSubmission));
         when(asylumCaseBuilder.getCurrentCaseStateVisibleToCaseOfficer()).thenReturn(Optional.of(currentCaseStateVisibleToCaseOfficer));
         when(asylumCaseBuilder.getCurrentCaseStateVisibleToLegalRepresentative()).thenReturn(Optional.of(currentCaseStateVisibleToLegalRepresentative));
@@ -203,6 +207,7 @@ public class AsylumCaseTest {
         assertEquals(Optional.of(sendDirectionDateDue), asylumCase.getSendDirectionDateDue());
         assertEquals(Optional.of(directions), asylumCase.getDirections());
         assertEquals(Optional.of(editableDirections), asylumCase.getEditableDirections());
+        assertEquals(Optional.of(additionalEvidenceDocuments), asylumCase.getAdditionalEvidenceDocuments());
         assertEquals(Optional.of(legalRepresentativeDocuments), asylumCase.getLegalRepresentativeDocuments());
         assertEquals(Optional.of(respondentDocuments), asylumCase.getRespondentDocuments());
         assertEquals(Optional.of(respondentEvidence), asylumCase.getRespondentEvidence());
@@ -219,6 +224,7 @@ public class AsylumCaseTest {
         assertEquals(Optional.of(notificationsSent), asylumCase.getNotificationsSent());
         assertEquals(Optional.of(changeDirectionDueDateActionAvailable), asylumCase.getChangeDirectionDueDateActionAvailable());
         assertEquals(Optional.of(sendDirectionActionAvailable), asylumCase.getSendDirectionActionAvailable());
+        assertEquals(Optional.of(uploadAdditionalEvidenceActionAvailable), asylumCase.getUploadAdditionalEvidenceActionAvailable());
         assertEquals(Optional.of(caseBuildingReadyForSubmission), asylumCase.getCaseBuildingReadyForSubmission());
         assertEquals(Optional.of(currentCaseStateVisibleToCaseOfficer), asylumCase.getCurrentCaseStateVisibleToCaseOfficer());
         assertEquals(Optional.of(currentCaseStateVisibleToLegalRepresentative), asylumCase.getCurrentCaseStateVisibleToLegalRepresentative());
@@ -387,6 +393,24 @@ public class AsylumCaseTest {
     }
 
     @Test
+    public void additional_evidence_documents_is_mutable() {
+
+        AsylumCase asylumCase = new AsylumCase(asylumCaseBuilder);
+
+        List<IdValue<DocumentWithMetadata>> newAdditionalEvidenceDocuments =
+            Arrays.asList(new IdValue<>("ABC", mock(DocumentWithMetadata.class)));
+
+        asylumCase.setAdditionalEvidenceDocuments(newAdditionalEvidenceDocuments);
+        assertEquals(Optional.of(newAdditionalEvidenceDocuments), asylumCase.getAdditionalEvidenceDocuments());
+
+        asylumCase.setAdditionalEvidenceDocuments(Collections.emptyList());
+        assertEquals(Optional.of(Collections.emptyList()), asylumCase.getAdditionalEvidenceDocuments());
+
+        asylumCase.setAdditionalEvidenceDocuments(null);
+        assertEquals(Optional.empty(), asylumCase.getAdditionalEvidenceDocuments());
+    }
+
+    @Test
     public void legal_representative_documents_is_mutable() {
 
         AsylumCase asylumCase = new AsylumCase(asylumCaseBuilder);
@@ -494,6 +518,18 @@ public class AsylumCaseTest {
 
         asylumCase.setSendDirectionActionAvailable(null);
         assertEquals(Optional.empty(), asylumCase.getSendDirectionActionAvailable());
+    }
+
+    @Test
+    public void upload_additional_evidence_action_available_flag_is_mutable() {
+
+        AsylumCase asylumCase = new AsylumCase(asylumCaseBuilder);
+
+        asylumCase.setUploadAdditionalEvidenceActionAvailable(YesOrNo.NO);
+        assertEquals(Optional.of(YesOrNo.NO), asylumCase.getUploadAdditionalEvidenceActionAvailable());
+
+        asylumCase.setUploadAdditionalEvidenceActionAvailable(null);
+        assertEquals(Optional.empty(), asylumCase.getUploadAdditionalEvidenceActionAvailable());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/DocumentTagTest.java
@@ -12,11 +12,12 @@ public class DocumentTagTest {
         assertEquals("respondentEvidence", DocumentTag.RESPONDENT_EVIDENCE.toString());
         assertEquals("appealResponse", DocumentTag.APPEAL_RESPONSE.toString());
         assertEquals("appealSubmission", DocumentTag.APPEAL_SUBMISSION.toString());
+        assertEquals("additionalEvidence", DocumentTag.ADDITIONAL_EVIDENCE.toString());
         assertEquals("", DocumentTag.NONE.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(5, DocumentTag.values().length);
+        assertEquals(6, DocumentTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -21,11 +21,12 @@ public class EventTest {
         assertEquals("addAppealResponse", Event.ADD_APPEAL_RESPONSE.toString());
         assertEquals("requestHearingRequirements", Event.REQUEST_HEARING_REQUIREMENTS.toString());
         assertEquals("changeDirectionDueDate", Event.CHANGE_DIRECTION_DUE_DATE.toString());
+        assertEquals("uploadAdditionalEvidence", Event.UPLOAD_ADDITIONAL_EVIDENCE.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(14, Event.values().length);
+        assertEquals(15, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/UploadAdditionalEvidenceConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/UploadAdditionalEvidenceConfirmationTest.java
@@ -1,0 +1,89 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("unchecked")
+public class UploadAdditionalEvidenceConfirmationTest {
+
+    @Mock private Callback<AsylumCase> callback;
+
+    private UploadAdditionalEvidenceConfirmation uploadAdditionalEvidenceConfirmation =
+        new UploadAdditionalEvidenceConfirmation();
+
+    @Test
+    public void should_return_confirmation() {
+
+        when(callback.getEvent()).thenReturn(Event.UPLOAD_ADDITIONAL_EVIDENCE);
+
+        PostSubmitCallbackResponse callbackResponse =
+            uploadAdditionalEvidenceConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        assertThat(
+            callbackResponse.getConfirmationHeader().get(),
+            containsString("You have uploaded a document")
+        );
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get(),
+            containsString("What happens next")
+        );
+    }
+
+    @Test
+    public void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceConfirmation.handle(callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            boolean canHandle = uploadAdditionalEvidenceConfirmation.canHandle(callback);
+
+            if (event == Event.UPLOAD_ADDITIONAL_EVIDENCE) {
+
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceConfirmation.canHandle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceConfirmation.handle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UploadAdditionalEvidenceActionAvailableUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UploadAdditionalEvidenceActionAvailableUpdaterTest.java
@@ -1,0 +1,115 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("unchecked")
+public class UploadAdditionalEvidenceActionAvailableUpdaterTest {
+
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+
+    private UploadAdditionalEvidenceActionAvailableUpdater uploadAdditionalEvidenceActionAvailableUpdater =
+        new UploadAdditionalEvidenceActionAvailableUpdater();
+
+    @Test
+    public void should_set_action_available_flag_to_yes_when_state_applies() {
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        for (State state : State.values()) {
+
+            when(caseDetails.getState()).thenReturn(state);
+
+            PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                uploadAdditionalEvidenceActionAvailableUpdater
+                    .handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+            assertNotNull(callbackResponse);
+            assertEquals(asylumCase, callbackResponse.getData());
+
+            if (Arrays.asList(
+                State.CASE_UNDER_REVIEW,
+                State.RESPONDENT_REVIEW,
+                State.SUBMIT_HEARING_REQUIREMENTS,
+                State.LISTING
+            ).contains(state)) {
+
+                verify(asylumCase, times(1)).setUploadAdditionalEvidenceActionAvailable(YesOrNo.YES);
+            } else {
+                verify(asylumCase, times(1)).setUploadAdditionalEvidenceActionAvailable(YesOrNo.NO);
+            }
+
+            reset(asylumCase);
+        }
+    }
+
+    @Test
+    public void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceActionAvailableUpdater.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void it_can_handle_callback_for_all_events() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = uploadAdditionalEvidenceActionAvailableUpdater.canHandle(callbackStage, callback);
+
+                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceActionAvailableUpdater.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceActionAvailableUpdater.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceActionAvailableUpdater.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceActionAvailableUpdater.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UploadAdditionalEvidenceHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UploadAdditionalEvidenceHandlerTest.java
@@ -1,0 +1,212 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DocumentWithDescription;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.DocumentReceiver;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.DocumentsAppender;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("unchecked")
+public class UploadAdditionalEvidenceHandlerTest {
+
+    @Mock private DocumentReceiver documentReceiver;
+    @Mock private DocumentsAppender documentsAppender;
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+    @Mock private DocumentWithDescription additionalEvidence1;
+    @Mock private DocumentWithDescription additionalEvidence2;
+    @Mock private DocumentWithMetadata additionalEvidence1WithMetadata;
+    @Mock private DocumentWithMetadata additionalEvidence2WithMetadata;
+    @Mock private List<IdValue<DocumentWithMetadata>> existingAdditionalEvidenceDocuments;
+    @Mock private List<IdValue<DocumentWithMetadata>> allAdditionalEvidenceDocuments;
+
+    @Captor private ArgumentCaptor<List<IdValue<DocumentWithMetadata>>> existingAdditionalEvidenceDocumentsCaptor;
+
+    private UploadAdditionalEvidenceHandler uploadAdditionalEvidenceHandler;
+
+    @Before
+    public void setUp() {
+
+        uploadAdditionalEvidenceHandler =
+            new UploadAdditionalEvidenceHandler(
+                documentReceiver,
+                documentsAppender
+            );
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.UPLOAD_ADDITIONAL_EVIDENCE);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+    }
+
+    @Test
+    public void should_append_new_evidence_to_existing_additional_evidence_documents_for_the_case() {
+
+        List<IdValue<DocumentWithDescription>> additionalEvidence =
+            Arrays.asList(
+                new IdValue<>("1", additionalEvidence1),
+                new IdValue<>("2", additionalEvidence2)
+            );
+
+        List<DocumentWithMetadata> additionalEvidenceWithMetadata =
+            Arrays.asList(
+                additionalEvidence1WithMetadata,
+                additionalEvidence2WithMetadata
+            );
+
+        when(asylumCase.getAdditionalEvidenceDocuments()).thenReturn(Optional.of(existingAdditionalEvidenceDocuments));
+        when(asylumCase.getAdditionalEvidence()).thenReturn(Optional.of(additionalEvidence));
+
+        when(documentReceiver.tryReceive(additionalEvidence1, DocumentTag.ADDITIONAL_EVIDENCE))
+            .thenReturn(Optional.of(additionalEvidence1WithMetadata));
+
+        when(documentReceiver.tryReceive(additionalEvidence2, DocumentTag.ADDITIONAL_EVIDENCE))
+            .thenReturn(Optional.of(additionalEvidence2WithMetadata));
+
+        when(documentsAppender.append(existingAdditionalEvidenceDocuments, additionalEvidenceWithMetadata))
+            .thenReturn(allAdditionalEvidenceDocuments);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            uploadAdditionalEvidenceHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).getAdditionalEvidence();
+
+        verify(documentReceiver, times(1)).tryReceive(additionalEvidence1, DocumentTag.ADDITIONAL_EVIDENCE);
+        verify(documentReceiver, times(1)).tryReceive(additionalEvidence2, DocumentTag.ADDITIONAL_EVIDENCE);
+
+        verify(documentsAppender, times(1)).append(existingAdditionalEvidenceDocuments, additionalEvidenceWithMetadata);
+
+        verify(asylumCase, times(1)).setAdditionalEvidenceDocuments(allAdditionalEvidenceDocuments);
+        verify(asylumCase, times(1)).clearAdditionalEvidence();
+    }
+
+    @Test
+    public void should_add_new_evidence_to_the_case_when_no_additional_evidence_documents_exist() {
+
+        List<IdValue<DocumentWithDescription>> additionalEvidence = Arrays.asList(new IdValue<>("1", additionalEvidence1));
+        List<DocumentWithMetadata> additionalEvidenceWithMetadata = Arrays.asList(additionalEvidence1WithMetadata);
+
+        when(asylumCase.getAdditionalEvidenceDocuments()).thenReturn(Optional.empty());
+        when(asylumCase.getAdditionalEvidence()).thenReturn(Optional.of(additionalEvidence));
+
+        when(documentReceiver.tryReceive(additionalEvidence1, DocumentTag.ADDITIONAL_EVIDENCE))
+            .thenReturn(Optional.of(additionalEvidence1WithMetadata));
+
+        when(documentsAppender.append(any(List.class), eq(additionalEvidenceWithMetadata)))
+            .thenReturn(allAdditionalEvidenceDocuments);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            uploadAdditionalEvidenceHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).getAdditionalEvidence();
+
+        verify(documentReceiver, times(1)).tryReceive(additionalEvidence1, DocumentTag.ADDITIONAL_EVIDENCE);
+
+        verify(documentsAppender, times(1)).append(existingAdditionalEvidenceDocumentsCaptor.capture(), eq(additionalEvidenceWithMetadata));
+
+        List<IdValue<DocumentWithMetadata>> actualExistingAdditionalDocuments =
+            existingAdditionalEvidenceDocumentsCaptor
+                .getAllValues()
+                .get(0);
+
+        assertEquals(0, actualExistingAdditionalDocuments.size());
+
+        verify(asylumCase, times(1)).setAdditionalEvidenceDocuments(allAdditionalEvidenceDocuments);
+        verify(asylumCase, times(1)).clearAdditionalEvidence();
+    }
+
+    @Test
+    public void should_throw_when_new_evidence_is_not_present() {
+
+        when(asylumCase.getAdditionalEvidence()).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("additionalEvidence is not present")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.SEND_DIRECTION);
+        assertThatThrownBy(() -> uploadAdditionalEvidenceHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = uploadAdditionalEvidenceHandler.canHandle(callbackStage, callback);
+
+                if (event == Event.UPLOAD_ADDITIONAL_EVIDENCE
+                    && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> uploadAdditionalEvidenceHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-706

### Change description ###

Feature for Legal Reps to be able to upload more evidence documents later in the cases life cycle.

Documents are displayed in the Documents tab.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
