### PR TITLE
RIA-1539 pre-submit and post-submit callback handlers ordering

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/PostSubmitCallbackDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/PostSubmitCallbackDispatcher.java
@@ -2,7 +2,10 @@ package uk.gov.hmcts.reform.iacaseapi.infrastructure;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseData;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
@@ -12,13 +15,16 @@ import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
 @Component
 public class PostSubmitCallbackDispatcher<T extends CaseData> {
 
-    private final List<PostSubmitCallbackHandler<T>> callbackHandlers;
+    private final List<PostSubmitCallbackHandler<T>> sortedCallbackHandlers;
 
     public PostSubmitCallbackDispatcher(
         List<PostSubmitCallbackHandler<T>> callbackHandlers
     ) {
         requireNonNull(callbackHandlers, "callbackHandlers must not be null");
-        this.callbackHandlers = callbackHandlers;
+        this.sortedCallbackHandlers = callbackHandlers.stream()
+            // sorting handlers by handler class name
+            .sorted(Comparator.comparing(h -> h.getClass().getSimpleName()))
+            .collect(Collectors.toList());
     }
 
     public PostSubmitCallbackResponse handle(
@@ -29,7 +35,7 @@ public class PostSubmitCallbackDispatcher<T extends CaseData> {
         PostSubmitCallbackResponse callbackResponse =
             new PostSubmitCallbackResponse();
 
-        for (PostSubmitCallbackHandler<T> callbackHandler : callbackHandlers) {
+        for (PostSubmitCallbackHandler<T> callbackHandler : sortedCallbackHandlers) {
 
             if (callbackHandler.canHandle(callback)) {
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-1539](https://tools.hmcts.net/jira/browse/RIA-1539)


### Change description ###
pre-submit callback handlers are sorted based on dispatch priority and handler name (class name) value

Spring doesn't guarantee the same order of beans in injected list. There is a way to force Spring to use desired order.
[https://www.baeldung.com/spring-injecting-collections](https://www.baeldung.com/spring-injecting-collections) 5.1

I think the best way is sorting handlers in constructor than thinking about another annotation in handler bean component.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
