### PR TITLE
silent zap alerts related to server not application

### DIFF
--- a/zap-known-issues.xml
+++ b/zap-known-issues.xml
@@ -1,5 +1,7 @@
-<?xml version="1.0"?><OWASPZAPReport version="D-2019-03-11" generated="Wed, 13 Mar 2019 14:37:13">
-<site name="https://ia-case-api-aat.service.core-compute-aat.internal" host="ia-case-api-aat.service.core-compute-aat.internal" port="443" ssl="true"><alerts><alertitem>
+<?xml version="1.0"?><OWASPZAPReport version="D-2019-08-27" generated="Thu, 29 Aug 2019 22:11:33">
+<site name="https://ia-case-api-aat.service.core-compute-aat.internal" host="ia-case-api-aat.service.core-compute-aat.internal" port="443" ssl="true">
+<alerts>
+<alertitem>
   <pluginid>100000</pluginid>
   <alert>A Client Error response code was returned by the server</alert>
   <name>A Client Error response code was returned by the server</name>
@@ -14,12 +16,12 @@
   <evidence>HTTP/1.1 403</evidence>
   </instance>
   <instance>
-  <uri>https://ia-case-api-aat.service.core-compute-aat.internal/asylum/ccdAboutToStart</uri>
+  <uri>https://ia-case-api-aat.service.core-compute-aat.internal/asylum/ccdAboutToSubmit</uri>
   <method>POST</method>
   <evidence>HTTP/1.1 403</evidence>
   </instance>
   <instance>
-  <uri>https://ia-case-api-aat.service.core-compute-aat.internal/asylum/ccdAboutToSubmit</uri>
+  <uri>https://ia-case-api-aat.service.core-compute-aat.internal/asylum/ccdAboutToStart</uri>
   <method>POST</method>
   <evidence>HTTP/1.1 403</evidence>
   </instance>
@@ -32,31 +34,101 @@
   <sourceid>4</sourceid>
 </alertitem>
 <alertitem>
-  <pluginid>10021</pluginid>
-  <alert>X-Content-Type-Options Header Missing</alert>
-  <name>X-Content-Type-Options Header Missing</name>
+   <pluginid>10021</pluginid>
+   <alert>X-Content-Type-Options Header Missing</alert>
+   <name>X-Content-Type-Options Header Missing</name>
+   <riskcode>1</riskcode>
+   <confidence>2</confidence>
+   <riskdesc>Low (Medium)</riskdesc>
+   <desc>&lt;p&gt;The Anti-MIME-Sniffing header X-Content-Type-Options was not set to &apos;nosniff&apos;. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.&lt;/p&gt;</desc>
+   <instances>
+   <instance>
+   <uri>https://ia-case-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
+   <method>GET</method>
+   <param>X-Content-Type-Options</param>
+   </instance>
+   <instance>
+   <uri>https://ia-case-api-aat.service.core-compute-aat.internal/</uri>
+   <method>GET</method>
+   <param>X-Content-Type-Options</param>
+   </instance>
+   </instances>
+   <count>2</count>
+   <solution>&lt;p&gt;Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to &apos;nosniff&apos; for all web pages.&lt;/p&gt;&lt;p&gt;If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.&lt;/p&gt;</solution>
+   <otherinfo>&lt;p&gt;This issue still applies to error type pages (401, 403, 500, etc) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.&lt;/p&gt;&lt;p&gt;At &quot;High&quot; threshold this scanner will not alert on client or server error responses.&lt;/p&gt;</otherinfo>
+   <reference>&lt;p&gt;http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx&lt;/p&gt;&lt;p&gt;https://www.owasp.org/index.php/List_of_useful_HTTP_headers&lt;/p&gt;</reference>
+   <cweid>16</cweid>
+   <wascid>15</wascid>
+   <sourceid>3</sourceid>
+ </alertitem>
+<alertitem>
+   <pluginid>10037</pluginid>
+   <alert>Server Leaks Information via &quot;X-Powered-By&quot; HTTP Response Header Field(s)</alert>
+   <name>Server Leaks Information via &quot;X-Powered-By&quot; HTTP Response Header Field(s)</name>
+   <riskcode>1</riskcode>
+   <confidence>2</confidence>
+   <riskdesc>Low (Medium)</riskdesc>
+   <desc>&lt;p&gt;The web/application server is leaking information via one or more &quot;X-Powered-By&quot; HTTP response headers. Access to such information may facilitate attackers identifying other frameworks/components your web application is reliant upon and the vulnerabilities such components may be subject to.&lt;/p&gt;</desc>
+   <instances>
+   <instance>
+   <uri>https://ia-case-api-aat.service.core-compute-aat.internal/asylum/ccdSubmitted</uri>
+   <method>POST</method>
+   <evidence>X-Powered-By: ASP.NET</evidence>
+   </instance>
+   <instance>
+   <uri>https://ia-case-api-aat.service.core-compute-aat.internal/</uri>
+   <method>GET</method>
+   <evidence>X-Powered-By: ASP.NET</evidence>
+   </instance>
+   <instance>
+   <uri>https://ia-case-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
+   <method>GET</method>
+   <evidence>X-Powered-By: ASP.NET</evidence>
+   </instance>
+   <instance>
+   <uri>https://ia-case-api-aat.service.core-compute-aat.internal/asylum/ccdAboutToStart</uri>
+   <method>POST</method>
+   <evidence>X-Powered-By: ASP.NET</evidence>
+   </instance>
+   <instance>
+   <uri>https://ia-case-api-aat.service.core-compute-aat.internal/asylum/ccdAboutToSubmit</uri>
+   <method>POST</method>
+   <evidence>X-Powered-By: ASP.NET</evidence>
+   </instance>
+   </instances>
+   <count>5</count>
+   <solution>&lt;p&gt;Ensure that your web server, application server, load balancer, etc. is configured to suppress &quot;X-Powered-By&quot; headers.&lt;/p&gt;</solution>
+   <reference>&lt;p&gt;http://blogs.msdn.com/b/varunm/archive/2013/04/23/remove-unwanted-http-response-headers.aspx&lt;/p&gt;&lt;p&gt;http://www.troyhunt.com/2012/02/shhh-dont-let-your-response-headers.html&lt;/p&gt;</reference>
+   <cweid>200</cweid>
+   <wascid>13</wascid>
+   <sourceid>3</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>10015</pluginid>
+  <alert>Incomplete or No Cache-control and Pragma HTTP Header Set</alert>
+  <name>Incomplete or No Cache-control and Pragma HTTP Header Set</name>
   <riskcode>1</riskcode>
   <confidence>2</confidence>
   <riskdesc>Low (Medium)</riskdesc>
-  <desc>&lt;p&gt;The Anti-MIME-Sniffing header X-Content-Type-Options was not set to &apos;nosniff&apos;. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.&lt;/p&gt;</desc>
+  <desc>&lt;p&gt;The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.&lt;/p&gt;</desc>
   <instances>
-  <instance>
-  <uri>https://ia-case-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
-  <method>GET</method>
-  <param>X-Content-Type-Options</param>
-  </instance>
   <instance>
   <uri>https://ia-case-api-aat.service.core-compute-aat.internal/</uri>
   <method>GET</method>
-  <param>X-Content-Type-Options</param>
+  <param>Cache-Control</param>
+  <evidence>no-cache</evidence>
+  </instance>
+  <instance>
+  <uri>https://ia-case-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
+  <method>GET</method>
+  <param>Cache-Control</param>
   </instance>
   </instances>
   <count>2</count>
-  <solution>&lt;p&gt;Ensure that the application/web server sets the Content-Type header appropriately, and that it sets the X-Content-Type-Options header to &apos;nosniff&apos; for all web pages.&lt;/p&gt;&lt;p&gt;If possible, ensure that the end user uses a standards-compliant and modern web browser that does not perform MIME-sniffing at all, or that can be directed by the web application/web server to not perform MIME-sniffing.&lt;/p&gt;</solution>
-  <otherinfo>&lt;p&gt;This issue still applies to error type pages (401, 403, 500, etc) as those pages are often still affected by injection issues, in which case there is still concern for browsers sniffing pages away from their actual content type.&lt;/p&gt;&lt;p&gt;At &quot;High&quot; threshold this scanner will not alert on client or server error responses.&lt;/p&gt;</otherinfo>
-  <reference>&lt;p&gt;http://msdn.microsoft.com/en-us/library/ie/gg622941%28v=vs.85%29.aspx&lt;/p&gt;&lt;p&gt;https://www.owasp.org/index.php/List_of_useful_HTTP_headers&lt;/p&gt;</reference>
-  <cweid>16</cweid>
-  <wascid>15</wascid>
+  <solution>&lt;p&gt;Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Web_Content_Caching&lt;/p&gt;</reference>
+  <cweid>525</cweid>
+  <wascid>13</wascid>
   <sourceid>3</sourceid>
 </alertitem>
 <alertitem>
@@ -82,53 +154,25 @@
   <sourceid>3</sourceid>
 </alertitem>
 <alertitem>
-  <pluginid>10023</pluginid>
-  <alert>Information Disclosure - Debug Error Messages</alert>
-  <name>Information Disclosure - Debug Error Messages</name>
-  <riskcode>1</riskcode>
-  <confidence>2</confidence>
-  <riskdesc>Low (Medium)</riskdesc>
-  <desc>&lt;p&gt;The response appeared to contain common error messages returned by platforms such as ASP.NET, and Web-servers such as IIS and Apache. You can configure the list of common debug messages.&lt;/p&gt;</desc>
-  <instances>
-  <instance>
-  <uri>https://ia-case-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
-  <method>GET</method>
-  <evidence>Internal Server Error</evidence>
-  </instance>
-  </instances>
-  <count>1</count>
-  <solution>&lt;p&gt;Disable debugging messages before pushing to production.&lt;/p&gt;</solution>
-  <reference>&lt;p&gt;&lt;/p&gt;</reference>
-  <cweid>200</cweid>
-  <wascid>13</wascid>
-  <sourceid>3</sourceid>
-</alertitem>
-<alertitem>
-  <pluginid>10015</pluginid>
-  <alert>Incomplete or No Cache-control and Pragma HTTP Header Set</alert>
-  <name>Incomplete or No Cache-control and Pragma HTTP Header Set</name>
-  <riskcode>1</riskcode>
-  <confidence>2</confidence>
-  <riskdesc>Low (Medium)</riskdesc>
-  <desc>&lt;p&gt;The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.&lt;/p&gt;</desc>
-  <instances>
-  <instance>
-  <uri>https://ia-case-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
-  <method>GET</method>
-  <param>Cache-Control</param>
-  </instance>
-  <instance>
-  <uri>https://ia-case-api-aat.service.core-compute-aat.internal/</uri>
-  <method>GET</method>
-  <param>Cache-Control</param>
-  <evidence>no-cache</evidence>
-  </instance>
-  </instances>
-  <count>2</count>
-  <solution>&lt;p&gt;Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.&lt;/p&gt;</solution>
-  <reference>&lt;p&gt;https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Web_Content_Caching&lt;/p&gt;</reference>
-  <cweid>525</cweid>
-  <wascid>13</wascid>
-  <sourceid>3</sourceid>
-</alertitem>
+   <pluginid>10023</pluginid>
+   <alert>Information Disclosure - Debug Error Messages</alert>
+   <name>Information Disclosure - Debug Error Messages</name>
+   <riskcode>1</riskcode>
+   <confidence>2</confidence>
+   <riskdesc>Low (Medium)</riskdesc>
+   <desc>&lt;p&gt;The response appeared to contain common error messages returned by platforms such as ASP.NET, and Web-servers such as IIS and Apache. You can configure the list of common debug messages.&lt;/p&gt;</desc>
+   <instances>
+   <instance>
+   <uri>https://ia-case-api-aat.service.core-compute-aat.internal/v2/api-docs</uri>
+   <method>GET</method>
+   <evidence>Internal Server Error</evidence>
+   </instance>
+   </instances>
+   <count>1</count>
+   <solution>&lt;p&gt;Disable debugging messages before pushing to production.&lt;/p&gt;</solution>
+   <reference>&lt;p&gt;&lt;/p&gt;</reference>
+   <cweid>200</cweid>
+   <wascid>13</wascid>
+   <sourceid>3</sourceid>
+ </alertitem>
 </alerts></site></OWASPZAPReport>


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-1643](https://tools.hmcts.net/jira/browse/RIA-1643)

### Change description ###
zap alerts
Some warnings are already ignored, but there is a new one too:
- A Client Error response code was returned by the server: Existing
https://ia-case-api-aat.service.core-compute-aat.internal/asylum/ccdSubmitted
https://ia-case-api-aat.service.core-compute-aat.internal/asylum/ccdAboutToSubmit
https://ia-case-api-aat.service.core-compute-aat.internal/asylum/ccdAboutToStart
We do not provide authentication to the ZAP worker so getting 403 status is ok. We do not perform testing for authenticated user.
- X-Content-Type-Options Header Missing: Existing
https://ia-case-api-aat.service.core-compute-aat.internal/v2/api-docs
https://ia-case-api-aat.service.core-compute-aat.internal/
ZAP report suggests to X-Content-Type-Options header to "nosniff" as we can do fix by adding filter to the application, /v2/api-docs is Swagger endpoint where response headers are cleared, I did not find the way to enforce returning correct header by Swagger endpoints. Need more time to investigate.
- Server Leaks Information via X-Powered-By HTTP Response Header Field(s): New
All urls responses have this with value "X-Powered-By: ASP.NET" I think it is added by one of the infrastructure component. If I perform ZAP tests locally I do not get this issue.
- Incomplete or No Cache-control and Pragma HTTP Header Set: Existing
https://ia-case-api-aat.service.core-compute-aat.internal/
https://ia-case-api-aat.service.core-compute-aat.internal/v2/api-docs
Similar issue with setting Headers: ZAP report suggests to ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate
- Application Error Disclosure: Existing
https://ia-case-api-aat.service.core-compute-aat.internal/v2/api-docs
It seems that Swagger shows to much information in case of error message.
- Information Disclosure - Debug Error Messages: Existing
https://ia-case-api-aat.service.core-compute-aat.internal/v2/api-docs
Similar like above, there are debug messages returned in response.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
