### PR TITLE
RIA-2162 Create AIP case

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -394,3 +394,5 @@ bootJar {
 // this setting only applies when running via gradle bootRun -- see web.config for the
 // java flag that configures the deployed appllications
 applicationDefaultJvmArgs = ["-Dfile.encoding=UTF-8"]
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -394,4 +394,3 @@ bootJar {
 // this setting only applies when running via gradle bootRun -- see web.config for the
 // java flag that configures the deployed appllications
 applicationDefaultJvmArgs = ["-Dfile.encoding=UTF-8"]
-

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/CcdScenarioRunnerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/CcdScenarioRunnerTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi;
 
+import static org.junit.Assert.assertFalse;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
@@ -52,6 +54,19 @@ public class CcdScenarioRunnerTest {
 
     @Test
     public void scenarios_should_behave_as_specified() throws IOException {
+
+        loadPropertiesIntoMapValueExpander();
+
+        for (Fixture fixture : fixtures) {
+            fixture.prepare();
+        }
+
+
+        assertFalse(
+            "Verifiers are configured",
+            verifiers.isEmpty()
+        );
+
         String scenarioPattern = System.getProperty("scenario");
         if (scenarioPattern == null) {
             scenarioPattern = "*.json";
@@ -71,8 +86,6 @@ public class CcdScenarioRunnerTest {
         for (String scenarioSource : scenarioSources) {
 
             Map<String, Object> scenario = deserializeWithExpandedValues(scenarioSource);
-
-            final Headers authorizationHeaders = getAuthorizationHeaders(scenario);
 
             String description = MapValueExtractor.extract(scenario, "description");
 
@@ -117,7 +130,7 @@ public class CcdScenarioRunnerTest {
                 templatesByFilename
             );
 
-
+            final Headers authorizationHeaders = getAuthorizationHeaders(scenario);
             final String requestUri = MapValueExtractor.extract(scenario, "request.uri");
             final int expectedStatus = MapValueExtractor.extractOrDefault(scenario, "expectation.status", 200);
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/CcdScenarioRunnerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/CcdScenarioRunnerTest.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.reform.iacaseapi;
 
-import static org.junit.Assert.assertFalse;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.restassured.RestAssured;
@@ -54,19 +52,6 @@ public class CcdScenarioRunnerTest {
 
     @Test
     public void scenarios_should_behave_as_specified() throws IOException {
-
-        loadPropertiesIntoMapValueExpander();
-
-        for (Fixture fixture : fixtures) {
-            fixture.prepare();
-        }
-
-
-        assertFalse(
-            "Verifiers are configured",
-            verifiers.isEmpty()
-        );
-
         String scenarioPattern = System.getProperty("scenario");
         if (scenarioPattern == null) {
             scenarioPattern = "*.json";
@@ -86,6 +71,8 @@ public class CcdScenarioRunnerTest {
         for (String scenarioSource : scenarioSources) {
 
             Map<String, Object> scenario = deserializeWithExpandedValues(scenarioSource);
+
+            final Headers authorizationHeaders = getAuthorizationHeaders(scenario);
 
             String description = MapValueExtractor.extract(scenario, "description");
 
@@ -130,7 +117,7 @@ public class CcdScenarioRunnerTest {
                 templatesByFilename
             );
 
-            final Headers authorizationHeaders = getAuthorizationHeaders(scenario);
+
             final String requestUri = MapValueExtractor.extract(scenario, "request.uri");
             final int expectedStatus = MapValueExtractor.extractOrDefault(scenario, "expectation.status", 200);
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CheckValues;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.AddressUk;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.*;
 
 public enum AsylumCaseFieldDefinition {
 
@@ -312,8 +309,10 @@ public enum AsylumCaseFieldDefinition {
         "amendResponseActionAvailable", new TypeReference<YesOrNo>(){}),
 
     APPEAL_SUBMISSION_DATE(
-        "appealSubmissionDate", new TypeReference<String>(){})
+        "appealSubmissionDate", new TypeReference<String>(){}),
 
+    JOURNEY_TYPE(
+            "journeyType", new TypeReference<JourneyType>(){})
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/field/JourneyType.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/field/JourneyType.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum  JourneyType {
+    AIP("aip"),
+    REP("rep");
+
+    @JsonValue
+    private final String id;
+
+    JourneyType(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantNameForDisplayFormatter.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantNameForDisplayFormatter.java
@@ -3,11 +3,14 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
@@ -20,7 +23,11 @@ public class AppellantNameForDisplayFormatter implements PreSubmitCallbackHandle
         requireNonNull(callbackStage, "callbackStage must not be null");
         requireNonNull(callback, "callback must not be null");
 
-        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+        Optional<JourneyType> journeyTypeOptional = callback.getCaseDetails().getCaseData().read(JOURNEY_TYPE);
+        boolean isAipJourney = journeyTypeOptional.map(journeyType -> journeyType == JourneyType.AIP).orElse(false);
+        Event event = callback.getEvent();
+        boolean isStartOrEditAipEvent = isAipJourney && (event == Event.START_APPEAL || event == Event.EDIT_APPEAL);
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT && !isStartOrEditAipEvent;
     }
 
     public PreSubmitCallbackResponse<AsylumCase> handle(

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeReferenceNumberTruncator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeReferenceNumberTruncator.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
 
 import java.util.Optional;
 import org.springframework.stereotype.Component;
@@ -11,6 +12,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
@@ -23,7 +25,10 @@ public class HomeOfficeReferenceNumberTruncator implements PreSubmitCallbackHand
         requireNonNull(callbackStage, "callbackStage must not be null");
         requireNonNull(callback, "callback must not be null");
 
-        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+        Optional<JourneyType> journeyTypeOptional = callback.getCaseDetails().getCaseData().read(JOURNEY_TYPE);
+        boolean isAipJourney = journeyTypeOptional.map(journeyType -> journeyType == JourneyType.AIP).orElse(false);
+
+        return !isAipJourney && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                && (callback.getEvent() == Event.START_APPEAL || callback.getEvent() == Event.EDIT_APPEAL);
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -97,6 +97,7 @@ security:
     - "iac"
   authorisedRoles:
     - "caseworker-ia"
+    - "citizen"
   roleEventAccess:
     caseworker-ia-legalrep-solicitor:
       - "startAppeal"
@@ -145,6 +146,13 @@ security:
       - "uploadHomeOfficeBundle"
       - "uploadHomeOfficeAppealResponse"
       - "uploadAdditionalEvidenceHomeOffice"
+    citizen:
+      - "startAppeal"
+      - "editAppeal"
+      - "submitAppeal"
+      - "buildCase"
+      - "submitCase"
+      - "uploadAdditionalEvidence"
 
 ### dependency configuration
 ccdGatewayUrl: ${CCD_GW_URL:http://localhost:3453}


### PR DESCRIPTION
When we create a case for AIP there will be a few difference,
- We will create an AIP case using a citizen user
- The case may not have any data when it is created so we cannot
generate the display name and truncate the home office reference until
the appeal is submitted.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2162

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
