### PR TITLE
RIA-2191 Truncate the home office reference on appeal submitted

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-730-RIA-971-home-office-truncator.json
+++ b/src/functionalTest/resources/scenarios/RIA-730-RIA-971-home-office-truncator.json
@@ -4,10 +4,10 @@
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "LegalRepresentative",
     "input": {
-      "eventId": "startAppeal",
-      "state": "appealStarted",
+      "eventId": "submitAppeal",
+      "state": "appealSubmitted",
       "caseData": {
-        "template": "minimal-appeal-started.json",
+        "template": "minimal-appeal-submitted.json",
         "replacements": {
           "homeOfficeReferenceNumber": "Z12345678/001"
         }
@@ -18,7 +18,7 @@
     "status": 200,
     "errors": [],
     "caseData": {
-      "template": "minimal-appeal-started.json",
+      "template": "minimal-appeal-submitted.json",
       "replacements": {
         "homeOfficeReferenceNumber": "Z1234567"
       }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeReferenceNumberTruncator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeReferenceNumberTruncator.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
 
 import java.util.Optional;
 import org.springframework.stereotype.Component;
@@ -12,7 +11,6 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
@@ -25,11 +23,7 @@ public class HomeOfficeReferenceNumberTruncator implements PreSubmitCallbackHand
         requireNonNull(callbackStage, "callbackStage must not be null");
         requireNonNull(callback, "callback must not be null");
 
-        Optional<JourneyType> journeyTypeOptional = callback.getCaseDetails().getCaseData().read(JOURNEY_TYPE);
-        boolean isAipJourney = journeyTypeOptional.map(journeyType -> journeyType == JourneyType.AIP).orElse(false);
-
-        return !isAipJourney && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-               && (callback.getEvent() == Event.START_APPEAL || callback.getEvent() == Event.EDIT_APPEAL);
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT && callback.getEvent() == Event.SUBMIT_APPEAL;
     }
 
     public PreSubmitCallbackResponse<AsylumCase> handle(

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeReferenceNumberTruncatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeReferenceNumberTruncatorTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER;
@@ -15,13 +14,11 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.iacaseapi.domain.RequiredFieldMissingException;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
@@ -56,7 +53,7 @@ public class HomeOfficeReferenceNumberTruncatorTest {
                 final String output = inputOutput.getValue();
 
                 when(callback.getCaseDetails()).thenReturn(caseDetails);
-                when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+                when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
                 when(caseDetails.getCaseData()).thenReturn(asylumCase);
                 when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER)).thenReturn(Optional.of(input));
 
@@ -89,7 +86,7 @@ public class HomeOfficeReferenceNumberTruncatorTest {
                 final String output = inputOutput.getValue();
 
                 when(callback.getCaseDetails()).thenReturn(caseDetails);
-                when(callback.getEvent()).thenReturn(Event.EDIT_APPEAL);
+                when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
                 when(caseDetails.getCaseData()).thenReturn(asylumCase);
                 when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER)).thenReturn(Optional.of(input));
 
@@ -108,7 +105,7 @@ public class HomeOfficeReferenceNumberTruncatorTest {
     public void should_throw_when_home_office_reference_is_not_present() {
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER)).thenReturn(Optional.empty());
 
@@ -119,9 +116,6 @@ public class HomeOfficeReferenceNumberTruncatorTest {
 
     @Test
     public void handling_should_throw_if_cannot_actually_handle() {
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getCaseData()).thenReturn(asylumCase);
-
         assertThatThrownBy(() -> homeOfficeReferenceNumberTruncator.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
             .hasMessage("Cannot handle callback")
             .isExactlyInstanceOf(IllegalStateException.class);
@@ -145,7 +139,7 @@ public class HomeOfficeReferenceNumberTruncatorTest {
 
                 boolean canHandle = homeOfficeReferenceNumberTruncator.canHandle(callbackStage, callback);
 
-                if ((event == Event.START_APPEAL || event == Event.EDIT_APPEAL)
+                if ((event == Event.SUBMIT_APPEAL)
                     && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT) {
 
                     assertTrue(canHandle);
@@ -176,16 +170,5 @@ public class HomeOfficeReferenceNumberTruncatorTest {
         assertThatThrownBy(() -> homeOfficeReferenceNumberTruncator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
             .hasMessage("callback must not be null")
             .isExactlyInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    public void cannot_handle_api_case() {
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(AsylumCaseFieldDefinition.JOURNEY_TYPE)).thenReturn(Optional.of(JourneyType.AIP));
-
-        boolean canHandle = homeOfficeReferenceNumberTruncator.canHandle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
-
-        assertThat(canHandle, is(false));
     }
 }


### PR DESCRIPTION
Only truncate home office reference number when an appeal is submitted
not when it is edited or started. Then the aip or rep will see the
value they entered not the truncated version.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2191

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
