### PR TITLE
RIA-2493 Prevent AIP events being triggered for Repped journey

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-2493-reasons-for-appeal-repped.json
+++ b/src/functionalTest/resources/scenarios/RIA-2493-reasons-for-appeal-repped.json
@@ -1,0 +1,22 @@
+{
+  "description": "RIA-2493: Case officer cannot send request reasons for appeal event for a repped case",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 1122,
+      "eventId": "requestReasonsForAppeal",
+      "state": "awaitingRespondentEvidence",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json"
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [ "You've made an invalid request. The hearing must be submitted by an appellant to make this request." ],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json"
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-2493-reasons-for-appeal.json
+++ b/src/functionalTest/resources/scenarios/RIA-2493-reasons-for-appeal.json
@@ -1,0 +1,22 @@
+{
+  "description": "RIA-2493: Case officer can send request reasons for appeal event for a AIP case",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 1122,
+      "eventId": "requestReasonsForAppeal",
+      "state": "awaitingRespondentEvidence",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json"
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json"
+    }
+  }
+}

--- a/src/functionalTest/resources/templates/minimal-aip-appeal-submitted.json
+++ b/src/functionalTest/resources/templates/minimal-aip-appeal-submitted.json
@@ -1,0 +1,34 @@
+{
+  "homeOfficeReferenceNumber": "A123456",
+  "homeOfficeDecisionDate": "{$TODAY}",
+  "appellantTitle": "Mr",
+  "appellantGivenNames": "Talha",
+  "appellantFamilyName": "Awan",
+  "appellantDateOfBirth": "{$TODAY-7300}",
+  "appellantNationalities": [
+    {
+      "id": "1",
+      "value": {
+        "Iceland": "IS"
+      }
+    }
+  ],
+  "appellantHasFixedAddress": "No",
+  "appealType": "protection",
+  "appealGroundsProtection": {
+    "values": [
+      "refugeeConvention"
+    ]
+  },
+  "hasNewMatters": "No",
+  "hasOtherAppeals": "No",
+  "appellantNameForDisplay": "Talha Awan",
+  "appealReferenceNumber": "PA/12345/2018",
+  "legalRepresentativeName": "A Legal Rep",
+  "legalRepresentativeEmailAddress": "{$TEST_LAW_FIRM_A_USERNAME}",
+  "sendDirectionActionAvailable": "Yes",
+  "hearingCentre": "taylorHouse",
+  "submissionOutOfTime": "No",
+  "uploadAdditionalEvidenceActionAvailable": "No",
+  "journeyType": "aip"
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -50,6 +50,11 @@ public enum Event {
 
     SHARE_A_CASE("shareACase"),
 
+    REQUEST_REASONS_FOR_APPEAL("requestReasonsForAppeal"),
+    SUBMIT_REASONS_FOR_APPEAL("submitReasonsForAppeal"),
+    REQUEST_CLARIFYING_ANSWERS("requestClarifyingAnswers"),
+    SUBMIT_CLARIFYING_ANSWERS("submitClarifyingAnswers"),
+
     @JsonEnumDefaultValue
     UNKNOWN("unknown");
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/State.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/State.java
@@ -21,6 +21,10 @@ public enum State {
     DECIDED("decided"),
     ENDED("ended"),
     APPEAL_TAKEN_OFFLINE("appealTakenOffline"),
+    AWAITING_REASONS_FOR_APPEAL("awaitingReasonsForAppeal"),
+    REASONS_FOR_APPEAL_SUBMITTED("reasonsForAppealSubmitted"),
+    AWAITING_CLARIFYING_ANSWERS("awaitingClarifyingAnswers"),
+    CLARIFYING_ANSWERS_SUBMITTED("clarifyingAnswersSubmitted"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/AsylumCaseEventValidForJourneyTypeChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/AsylumCaseEventValidForJourneyTypeChecker.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.iacaseapi.infrastructure.eventvalidation;
+
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType.AIP;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType.REP;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+
+@Slf4j
+@Component
+public class AsylumCaseEventValidForJourneyTypeChecker implements EventValidForJourneyTypeChecker<AsylumCase> {
+    private final List<Event> aipOnlyEvent = Arrays.asList(
+            Event.REQUEST_REASONS_FOR_APPEAL,
+            Event.SUBMIT_REASONS_FOR_APPEAL,
+            Event.REQUEST_CLARIFYING_ANSWERS,
+            Event.SUBMIT_CLARIFYING_ANSWERS);
+    private final List<Event> reppedOnlyEvent = Arrays.asList(
+            Event.UPLOAD_RESPONDENT_EVIDENCE,
+            Event.REQUEST_CASE_BUILDING
+    );
+
+    @Override
+    public EventValidForJourneyType check(Callback<AsylumCase> callback) {
+        final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+        final JourneyType journeyType = asylumCase.<JourneyType>read(AsylumCaseFieldDefinition.JOURNEY_TYPE).orElse(REP);
+        final Event event = callback.getEvent();
+
+        if (aipOnlyEvent.contains(event) && !AIP.equals(journeyType)) {
+            log.info(String.format("[%s] is invalid for case id [%s] the hearing must be submitted by an appellant to handle this event.", event, callback.getCaseDetails().getId()));
+            return new EventValidForJourneyType("You've made an invalid request. The hearing must be submitted by an appellant to make this request.");
+        }
+        if (reppedOnlyEvent.contains(event) && !REP.equals(journeyType)) {
+            log.info(String.format("[%s] is invalid for case id [%s] the hearing must be submitted by a representative to handle this event.", event, callback.getCaseDetails().getId()));
+            return new EventValidForJourneyType("You've made an invalid request. The hearing must be submitted by a representative to make this request.");
+        }
+
+        return new EventValidForJourneyType();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/EventValidForJourneyType.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/EventValidForJourneyType.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.iacaseapi.infrastructure.eventvalidation;
+
+public class EventValidForJourneyType {
+    private final String invalidReason;
+
+    public EventValidForJourneyType() {
+        this(null);
+    }
+
+    public EventValidForJourneyType(String invalidReason) {
+        this.invalidReason = invalidReason;
+    }
+
+    public boolean isValid() {
+        return invalidReason == null;
+    }
+
+    public String getInvalidReason() {
+        return invalidReason;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/EventValidForJourneyTypeChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/EventValidForJourneyTypeChecker.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.reform.iacaseapi.infrastructure.eventvalidation;
+
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseData;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.infrastructure.eventvalidation.EventValidForJourneyType;
+
+public interface EventValidForJourneyTypeChecker<T extends CaseData> {
+    EventValidForJourneyType check(Callback<T> callback);
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -139,6 +139,8 @@ security:
       - "removeAppealFromOnline"
       - "reviewHearingRequirements"
       - "listCaseWithoutHearingRequirements"
+      - "requestReasonsForAppeal"
+      - "requestClarifyingAnswers"
     caseworker-ia-admofficer:
       - "listCase"
       - "recordAttendeesAndDuration"
@@ -167,6 +169,8 @@ security:
       - "buildCase"
       - "submitCase"
       - "uploadAdditionalEvidence"
+      - "submitReasonsForAppeal"
+      - "submitClarifyingAnswers"
 
 ### dependency configuration
 ccdGatewayUrl: ${CCD_GW_URL:http://localhost:3453}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -54,6 +54,6 @@ public class EventTest {
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(43, Event.values().length);
+        assertEquals(47, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/StateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/StateTest.java
@@ -29,6 +29,6 @@ public class StateTest {
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(17, State.values().length);
+        assertEquals(21, State.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/AsylumCaseEventValidForJourneyTypeCheckerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/AsylumCaseEventValidForJourneyTypeCheckerTest.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.reform.iacaseapi.infrastructure.eventvalidation;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType.AIP;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType.REP;
+
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AsylumCaseEventValidForJourneyTypeCheckerTest {
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    private AsylumCaseEventValidForJourneyTypeChecker asylumCaseEventValidForJourneyTypeChecker = new AsylumCaseEventValidForJourneyTypeChecker();
+
+
+    private void setupCallback(Event sendDirection, JourneyType journeyType) {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(sendDirection);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(AsylumCaseFieldDefinition.JOURNEY_TYPE)).thenReturn(Optional.of(journeyType));
+    }
+
+    @Test
+    public void canSendValidEvents() {
+        setupCallback(Event.SEND_DIRECTION, AIP);
+
+        EventValidForJourneyType check = asylumCaseEventValidForJourneyTypeChecker.check(callback);
+
+        assertThat(check.isValid(), is(true));
+    }
+
+    @Test
+    public void cannotSendInvalidEventsForAip() {
+        setupCallback(Event.REQUEST_CASE_BUILDING, AIP);
+
+        EventValidForJourneyType check = asylumCaseEventValidForJourneyTypeChecker.check(callback);
+
+        assertThat(check.isValid(), is(false));
+        assertThat(check.getInvalidReason(), is("You've made an invalid request. The hearing must be submitted by a representative to make this request."));
+    }
+
+    @Test
+    public void cannotSendInvalidEventsForLegalRep() {
+        setupCallback(Event.REQUEST_REASONS_FOR_APPEAL, REP);
+
+        EventValidForJourneyType check = asylumCaseEventValidForJourneyTypeChecker.check(callback);
+
+        assertThat(check.isValid(), is(false));
+        assertThat(check.getInvalidReason(), is("You've made an invalid request. The hearing must be submitted by an appellant to make this request."));
+    }
+
+}


### PR DESCRIPTION
As part of the aip flow we are adding new states and events. The TCW
could trigger those events so we want to prevent this by returning them
an error. Added a new handler that will check the journey type for
certain events and throw an exception to prevent any further handlers
firing. The exception is then handled and an error returned to CCD.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2493