### PR TITLE
RIA-1500 fix for record an application link

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -383,7 +383,7 @@ public enum AsylumCaseFieldDefinition {
         "interpreterLanguageReadonly", new TypeReference<List<IdValue<InterpreterLanguage>>>() {}),
 
     SUBMIT_HEARING_REQUIREMENTS_AVAILABLE(
-        "submitHearingRequirementsAvailable", new TypeReference<YesOrNo>() {})
+        "submitHearingRequirementsAvailable", new TypeReference<YesOrNo>() {}),
 
     ;
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RemoveAppealFromOnlineHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RemoveAppealFromOnlineHandler.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.*;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ADD_CASE_NOTE_ACTION_DISABLED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
@@ -45,6 +45,7 @@ public class RemoveAppealFromOnlineHandler implements PreSubmitCallbackHandler<A
 
         asylumCase.write(AsylumCaseFieldDefinition.REMOVE_APPEAL_FROM_ONLINE_DATE, dateProvider.now().toString());
         asylumCase.write(ADD_CASE_NOTE_ACTION_DISABLED, YesOrNo.YES);
+        asylumCase.write(RECORD_APPLICATION_ACTION_DISABLED, YesOrNo.YES);
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RemoveAppealFromOnlineHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RemoveAppealFromOnlineHandlerTest.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
@@ -55,6 +56,7 @@ public class RemoveAppealFromOnlineHandlerTest {
         assertEquals(asylumCase, callbackResponse.getData());
 
         verify(asylumCase).write(REMOVE_APPEAL_FROM_ONLINE_DATE, date.toString());
+        verify(asylumCase, times(1)).write(RECORD_APPLICATION_ACTION_DISABLED, YesOrNo.YES);
     }
 
     @Test


### PR DESCRIPTION
Fix for RIA-1500. 

### JIRA link (if applicable) ###

[RIA-1500](https://tools.hmcts.net/jira/browse/RIA-1500)


### Change description ###

_Record an application_ link removed from Applications tab for the **removeAppealFromOnline** event.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
