### PR TITLE
RIA-2484 - Reasons For Appeal

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -51,6 +51,7 @@ public enum Event {
     SHARE_A_CASE("shareACase"),
 
     REQUEST_REASONS_FOR_APPEAL("requestReasonsForAppeal"),
+    EDIT_REASONS_FOR_APPEAL("editReasonsForAppeal"),
     SUBMIT_REASONS_FOR_APPEAL("submitReasonsForAppeal"),
     REQUEST_CLARIFYING_ANSWERS("requestClarifyingAnswers"),
     SUBMIT_CLARIFYING_ANSWERS("submitClarifyingAnswers"),

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -64,7 +64,9 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
                    Event.UPLOAD_ADDITIONAL_EVIDENCE_HOME_OFFICE,
                    Event.UPLOAD_ADDENDUM_EVIDENCE,
                    Event.UPLOAD_ADDENDUM_EVIDENCE_LEGAL_REP,
-                   Event.UPLOAD_ADDENDUM_EVIDENCE_HOME_OFFICE
+                   Event.UPLOAD_ADDENDUM_EVIDENCE_HOME_OFFICE,
+                   Event.REQUEST_REASONS_FOR_APPEAL,
+                   Event.SUBMIT_REASONS_FOR_APPEAL
                ).contains(callback.getEvent());
     }
 
@@ -81,4 +83,3 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
         return new PreSubmitCallbackResponse<>(asylumCaseWithNotificationMarker);
     }
 }
-

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/AsylumCaseEventValidForJourneyTypeChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/AsylumCaseEventValidForJourneyTypeChecker.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 public class AsylumCaseEventValidForJourneyTypeChecker implements EventValidForJourneyTypeChecker<AsylumCase> {
     private final List<Event> aipOnlyEvent = Arrays.asList(
             Event.REQUEST_REASONS_FOR_APPEAL,
+            Event.EDIT_REASONS_FOR_APPEAL,
             Event.SUBMIT_REASONS_FOR_APPEAL,
             Event.REQUEST_CLARIFYING_ANSWERS,
             Event.SUBMIT_CLARIFYING_ANSWERS);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -172,6 +172,7 @@ security:
       - "buildCase"
       - "submitCase"
       - "uploadAdditionalEvidence"
+      - "editReasonsForAppeal"
       - "submitReasonsForAppeal"
       - "submitClarifyingAnswers"
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -49,11 +49,12 @@ public class EventTest {
         assertEquals("uploadAddendumEvidenceHomeOffice", Event.UPLOAD_ADDENDUM_EVIDENCE_HOME_OFFICE.toString());
         assertEquals("removeAppealFromOnline", Event.REMOVE_APPEAL_FROM_ONLINE.toString());
         assertEquals("shareACase", Event.SHARE_A_CASE.toString());
+        assertEquals("editReasonsForAppeal", Event.EDIT_REASONS_FOR_APPEAL.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(47, Event.values().length);
+        assertEquals(48, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -50,6 +50,8 @@ public class EventTest {
         assertEquals("removeAppealFromOnline", Event.REMOVE_APPEAL_FROM_ONLINE.toString());
         assertEquals("shareACase", Event.SHARE_A_CASE.toString());
         assertEquals("editReasonsForAppeal", Event.EDIT_REASONS_FOR_APPEAL.toString());
+        assertEquals("requestReasonsForAppeal", Event.REQUEST_REASONS_FOR_APPEAL.toString());
+        assertEquals("submitReasonsForAppeal", Event.SUBMIT_REASONS_FOR_APPEAL.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
@@ -162,7 +162,9 @@ public class SendNotificationHandlerTest {
                         Event.UPLOAD_ADDITIONAL_EVIDENCE_HOME_OFFICE,
                         Event.UPLOAD_ADDENDUM_EVIDENCE,
                         Event.UPLOAD_ADDENDUM_EVIDENCE_LEGAL_REP,
-                        Event.UPLOAD_ADDENDUM_EVIDENCE_HOME_OFFICE
+                        Event.UPLOAD_ADDENDUM_EVIDENCE_HOME_OFFICE,
+                        Event.REQUEST_REASONS_FOR_APPEAL,
+                        Event.SUBMIT_REASONS_FOR_APPEAL
                     ).contains(event)) {
 
                     assertTrue(canHandle);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2484

### Change description ###
- Adds new events requestReasonsForAppeal and submitReasonsForAppeal to be forwarded into the notification service
- Adds editReasonsForAppeal event used in citizen AIP journeys

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
