### PR TITLE
RIA-2773 Enable AIP directions to respondent

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/AsylumCaseSendDirectionEventValidForJourneyTypeChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/AsylumCaseSendDirectionEventValidForJourneyTypeChecker.java
@@ -25,7 +25,7 @@ public class AsylumCaseSendDirectionEventValidForJourneyTypeChecker implements E
             Parties directionTo = asylumCase.read(SEND_DIRECTION_PARTIES, Parties.class)
                     .orElseThrow(() -> new IllegalStateException("sendDirectionParties is not present"));
 
-            if (journeyType == JourneyType.AIP) {
+            if (journeyType == JourneyType.AIP && directionTo != Parties.RESPONDENT) {
                 log.info("Cannot send a direction for an AIP case");
                 return new EventValid("You cannot use this function to send a direction to an appellant in person.");
             } else if (journeyType == REP && directionTo == Parties.APPELLANT) {

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/AsylumCaseSendDirectionEventValidForJourneyTypeCheckerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/AsylumCaseSendDirectionEventValidForJourneyTypeCheckerTest.java
@@ -35,6 +35,14 @@ public class AsylumCaseSendDirectionEventValidForJourneyTypeCheckerTest {
     }
 
     @Test
+    public void canSendDirectionForAipCaseToRespondent() {
+        setupCallback(Event.SEND_DIRECTION, JourneyType.AIP, Parties.RESPONDENT);
+        EventValid eventValid = new AsylumCaseSendDirectionEventValidForJourneyTypeChecker().check(callback);
+
+        assertThat(eventValid, is(EventValid.VALID_EVENT));
+    }
+
+    @Test
     public void cannotSendDirectionToAppellantForReppedCase() {
         setupCallback(Event.SEND_DIRECTION, JourneyType.REP, Parties.APPELLANT);
         EventValid eventValid = new AsylumCaseSendDirectionEventValidForJourneyTypeChecker().check(callback);


### PR DESCRIPTION
We disabled all SEND_DIRECTION events for AIP cases. This enables them
if they are going to the respondent as they don't see any difference
between a repped and aip journey.