### PR TITLE
RIA-2513: Removing flags

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-2513-remove-flag-confirmation.json
+++ b/src/functionalTest/resources/scenarios/RIA-2513-remove-flag-confirmation.json
@@ -1,0 +1,22 @@
+{
+  "description": "RIA-2513 Remove flag from case confirmation",
+  "request": {
+    "uri": "/asylum/ccdSubmitted",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "removeFlag",
+      "state": "awaitingRespondentEvidence",
+      "id": 1001,
+      "caseData": {
+        "template": "minimal-appeal-submitted.json"
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "confirmation": {
+      "header": "# You've removed the flag from this case",
+      "body": "#### What happens next\r\n\r\nThis flag has been removed from the case. The case will proceed as usual."
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-2513-remove-flag-preparer.json
+++ b/src/functionalTest/resources/scenarios/RIA-2513-remove-flag-preparer.json
@@ -1,0 +1,74 @@
+{
+  "description": "RIA-2513 Remove flag from case",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "removeFlag",
+      "state": "awaitingRespondentEvidence",
+      "id": 1001,
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "caseFlags": [
+            {
+              "id": "1",
+              "value": {
+                "caseFlagType": "complexCase",
+                "caseFlagAdditionalInformation": "some additional information"
+              }
+            },
+            {
+              "id": "2",
+              "value": {
+                "caseFlagType": "anonymity",
+                "caseFlagAdditionalInformation": "some additional information"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "caseFlags": [
+          {
+            "id": "1",
+            "value": {
+              "caseFlagType": "complexCase",
+              "caseFlagAdditionalInformation": "some additional information"
+            }
+          },
+          {
+            "id": "2",
+            "value": {
+              "caseFlagType": "anonymity",
+              "caseFlagAdditionalInformation": "some additional information"
+            }
+          }
+        ],
+        "removeFlagTypeOfFlag": {
+          "value": {
+            "code": "1",
+            "label": "Complex case"
+          },
+          "list_items": [
+            {
+              "code": "1",
+              "label": "Complex case"
+            },
+            {
+              "code": "2",
+              "label": "Anonymity"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-2513-remove-flag.json
+++ b/src/functionalTest/resources/scenarios/RIA-2513-remove-flag.json
@@ -1,0 +1,69 @@
+{
+  "description": "RIA-2513 Remove flag from case",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "removeFlag",
+      "state": "awaitingRespondentEvidence",
+      "id": 1001,
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "caseFlags": [
+            {
+              "id": "1",
+              "value": {
+                "caseFlagType": "complexCase",
+                "caseFlagAdditionalInformation": "some additional information"
+              }
+            },
+            {
+              "id": "2",
+              "value": {
+                "caseFlagType": "anonymity",
+                "caseFlagAdditionalInformation": "some additional information"
+              }
+            }
+          ],
+          "removeFlagTypeOfFlag": {
+            "value": {
+              "code": "1",
+              "label": "Complex case"
+            },
+            "list_items": [
+              {
+                "code": "1",
+                "label": "Complex case"
+              },
+              {
+                "code": "2",
+                "label": "Anonymity"
+              }
+            ]
+          },
+          "caseFlagComplexCaseExists": "Yes",
+          "flagCaseAdditionalInformation": "some additional information"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "caseFlags": [
+          {
+            "id": "2",
+            "value": {
+              "caseFlagType": "anonymity",
+              "caseFlagAdditionalInformation": "some additional information"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -688,7 +688,9 @@ public enum AsylumCaseFieldDefinition {
     IS_APPELLANT_MINOR(
         "isAppellantMinor", new TypeReference<YesOrNo>() {}),
     APPELLANT_DATE_OF_BIRTH(
-        "appellantDateOfBirth", new TypeReference<String>() {})
+        "appellantDateOfBirth", new TypeReference<String>() {}),
+    REMOVE_FLAG_TYPE_OF_FLAG(
+        "removeFlagTypeOfFlag", new TypeReference<DynamicList>() {}),
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/CaseFlagType.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/CaseFlagType.java
@@ -5,26 +5,32 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum CaseFlagType {
 
-    ANONYMITY("anonymity"),
-    COMPLEX_CASE("complexCase"),
-    DETAINED_IMMIGRATION_APPEAL("detainedImmigrationAppeal"),
-    FOREIGN_NATIONAL_OFFENDER("foreignNationalOffender"),
-    POTENTIALLY_VIOLENT_PERSON("potentiallyViolentPerson"),
-    UNACCEPTABLE_CUSTOMER_BEHAVIOUR("unacceptableCustomerBehaviour"),
-    UNACCOMPANIED_MINOR("unaccompaniedMinor"),
+    ANONYMITY("anonymity", "Anonymity"),
+    COMPLEX_CASE("complexCase", "Complex case"),
+    DETAINED_IMMIGRATION_APPEAL("detainedImmigrationAppeal", "Detained immigration appeal"),
+    FOREIGN_NATIONAL_OFFENDER("foreignNationalOffender", "Foreign national offender"),
+    POTENTIALLY_VIOLENT_PERSON("potentiallyViolentPerson", "Potentially violent person"),
+    UNACCEPTABLE_CUSTOMER_BEHAVIOUR("unacceptableCustomerBehaviour", "Unacceptable customer behaviour"),
+    UNACCOMPANIED_MINOR("unaccompaniedMinor", "Unaccompanied minor"),
 
     @JsonEnumDefaultValue
-    UNKNOWN("unknown");
+    UNKNOWN("unknown", "Unknown");
 
     @JsonValue
     private final String id;
+    private final String readableText;
 
-    CaseFlagType(String id) {
+    CaseFlagType(String id, String readableText) {
         this.id = id;
+        this.readableText = readableText;
     }
 
     @Override
     public String toString() {
         return id;
+    }
+
+    public String getReadableText() {
+        return readableText;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -65,6 +65,7 @@ public enum Event {
     REVIEW_TIME_EXTENSION("reviewTimeExtension"),
     SEND_DIRECTION_WITH_QUESTIONS("sendDirectionWithQuestions"),
     FLAG_CASE("flagCase"),
+    REMOVE_FLAG("removeFlag"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/flagcase/RemoveFlagConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/flagcase/RemoveFlagConfirmation.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit.flagcase;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+@Component
+public class RemoveFlagConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callback, "callback must not be null");
+
+        return callback.getEvent() == Event.REMOVE_FLAG;
+    }
+
+    public PostSubmitCallbackResponse handle(
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+
+        postSubmitResponse.setConfirmationHeader("# You've removed the flag from this case");
+        postSubmitResponse.setConfirmationBody(
+            "#### What happens next\r\n\r\n"
+                + "This flag has been removed from the case. The case will proceed as usual."
+        );
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/flagcase/RemoveFlagHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/flagcase/RemoveFlagHandler.java
@@ -1,0 +1,102 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.flagcase;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class RemoveFlagHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+            && callback.getEvent() == Event.REMOVE_FLAG;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        final DynamicList flagType = asylumCase.read(REMOVE_FLAG_TYPE_OF_FLAG, DynamicList.class)
+            .orElseThrow(() -> new IllegalStateException("removeFlagTypeOfFlag is missing"));
+
+        final Optional<List<IdValue<CaseFlag>>> maybeExistingCaseFlags = asylumCase.read(CASE_FLAGS);
+        final List<IdValue<CaseFlag>> existingCaseFlags = maybeExistingCaseFlags.orElse(Collections.emptyList());
+
+        final List<IdValue<CaseFlag>> newCaseFlags = new ArrayList<>();
+
+        for (IdValue<CaseFlag> idValue : existingCaseFlags) {
+            if (!idValue.getId().equals(flagType.getValue().getCode())) {
+                newCaseFlags.add(idValue);
+            } else {
+                clearDisplayFlags(idValue.getValue().getCaseFlagType(), asylumCase);
+            }
+        }
+
+        asylumCase.write(CASE_FLAGS, newCaseFlags);
+        asylumCase.clear(REMOVE_FLAG_TYPE_OF_FLAG);
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    public void clearDisplayFlags(CaseFlagType caseFlagType, AsylumCase asylumCase) {
+        switch (caseFlagType) {
+            case ANONYMITY:
+                asylumCase.clear(CASE_FLAG_ANONYMITY_EXISTS);
+                asylumCase.clear(CASE_FLAG_ANONYMITY_ADDITIONAL_INFORMATION);
+                break;
+            case COMPLEX_CASE:
+                asylumCase.clear(CASE_FLAG_COMPLEX_CASE_EXISTS);
+                asylumCase.clear(CASE_FLAG_COMPLEX_CASE_ADDITIONAL_INFORMATION);
+                break;
+            case DETAINED_IMMIGRATION_APPEAL:
+                asylumCase.clear(CASE_FLAG_DETAINED_IMMIGRATION_APPEAL_EXISTS);
+                asylumCase.clear(CASE_FLAG_DETAINED_IMMIGRATION_APPEAL_ADDITIONAL_INFORMATION);
+                break;
+            case FOREIGN_NATIONAL_OFFENDER:
+                asylumCase.clear(CASE_FLAG_FOREIGN_NATIONAL_OFFENDER_EXISTS);
+                asylumCase.clear(CASE_FLAG_FOREIGN_NATIONAL_OFFENDER_ADDITIONAL_INFORMATION);
+                break;
+            case POTENTIALLY_VIOLENT_PERSON:
+                asylumCase.clear(CASE_FLAG_POTENTIALLY_VIOLENT_PERSON_EXISTS);
+                asylumCase.clear(CASE_FLAG_POTENTIALLY_VIOLENT_PERSON_ADDITIONAL_INFORMATION);
+                break;
+            case UNACCEPTABLE_CUSTOMER_BEHAVIOUR:
+                asylumCase.clear(CASE_FLAG_UNACCEPTABLE_CUSTOMER_BEHAVIOUR_EXISTS);
+                asylumCase.clear(CASE_FLAG_UNACCEPTABLE_CUSTOMER_BEHAVIOUR_ADDITIONAL_INFORMATION);
+                break;
+            case UNACCOMPANIED_MINOR:
+                asylumCase.clear(CASE_FLAG_UNACCOMPANIED_MINOR_EXISTS);
+                asylumCase.clear(CASE_FLAG_UNACCOMPANIED_MINOR_ADDITIONAL_INFORMATION);
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/flagcase/RemoveFlagPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/flagcase/RemoveFlagPreparer.java
@@ -1,0 +1,80 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.flagcase;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class RemoveFlagPreparer implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public RemoveFlagPreparer() {
+
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
+            && callback.getEvent() == Event.REMOVE_FLAG;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        final Optional<List<IdValue<CaseFlag>>> maybeExistingCaseFlags = asylumCase.read(CASE_FLAGS);
+
+        final List<Value> existingCaseFlagListElements =
+            getExistingCaseFlagListElements(maybeExistingCaseFlags.orElse(Collections.emptyList()));
+
+        if (existingCaseFlagListElements.isEmpty()) {
+            PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
+            response.addError("There are no flags in this case");
+            return response;
+        }
+
+        DynamicList caseFlagTypes = createDynamicList(existingCaseFlagListElements);
+
+        asylumCase.write(REMOVE_FLAG_TYPE_OF_FLAG, caseFlagTypes);
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    public List<Value> getExistingCaseFlagListElements(List<IdValue<CaseFlag>> existingCaseFlags) {
+        requireNonNull(existingCaseFlags, "existingCaseFlags must not be null");
+        return existingCaseFlags
+            .stream()
+            .map(idValue -> new Value(idValue.getId(), idValue.getValue().getCaseFlagType().getReadableText()))
+            .collect(Collectors.toList());
+    }
+
+    public DynamicList createDynamicList(List<Value> elementsList) {
+        requireNonNull(elementsList, "elementsList must not be null");
+        return new DynamicList(elementsList.get(0), elementsList);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -178,6 +178,7 @@ security:
       - "reviewTimeExtension"
       - "sendDirectionWithQuestions"
       - "flagCase"
+      - "removeFlag"
     caseworker-ia-admofficer:
       - "listCase"
       - "recordAttendeesAndDuration"
@@ -186,6 +187,7 @@ security:
       - "sendDecisionAndReasons"
       - "recordAllocatedJudge"
       - "flagCase"
+      - "removeFlag"
     caseworker-ia-homeofficeapc:
       - "uploadHomeOfficeBundle"
       - "uploadAdditionalEvidenceHomeOffice"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/CaseFlagTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/CaseFlagTypeTest.java
@@ -16,6 +16,15 @@ public class CaseFlagTypeTest {
         assertEquals("unacceptableCustomerBehaviour", CaseFlagType.UNACCEPTABLE_CUSTOMER_BEHAVIOUR.toString());
         assertEquals("unaccompaniedMinor", CaseFlagType.UNACCOMPANIED_MINOR.toString());
         assertEquals("unknown", CaseFlagType.UNKNOWN.toString());
+
+        assertEquals("Anonymity", CaseFlagType.ANONYMITY.getReadableText());
+        assertEquals("Complex case", CaseFlagType.COMPLEX_CASE.getReadableText());
+        assertEquals("Detained immigration appeal", CaseFlagType.DETAINED_IMMIGRATION_APPEAL.getReadableText());
+        assertEquals("Foreign national offender", CaseFlagType.FOREIGN_NATIONAL_OFFENDER.getReadableText());
+        assertEquals("Potentially violent person", CaseFlagType.POTENTIALLY_VIOLENT_PERSON.getReadableText());
+        assertEquals("Unacceptable customer behaviour", CaseFlagType.UNACCEPTABLE_CUSTOMER_BEHAVIOUR.getReadableText());
+        assertEquals("Unaccompanied minor", CaseFlagType.UNACCOMPANIED_MINOR.getReadableText());
+        assertEquals("Unknown", CaseFlagType.UNKNOWN.getReadableText());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -66,6 +66,7 @@ public class EventTest {
         assertEquals("reviewTimeExtension", Event.REVIEW_TIME_EXTENSION.toString());
         assertEquals("sendDirectionWithQuestions", Event.SEND_DIRECTION_WITH_QUESTIONS.toString());
         assertEquals("flagCase", Event.FLAG_CASE.toString());
+        assertEquals("removeFlag", Event.REMOVE_FLAG.toString());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -71,6 +71,6 @@ public class EventTest {
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(61, Event.values().length);
+        assertEquals(62, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/flagcase/RemoveFlagConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/flagcase/RemoveFlagConfirmationTest.java
@@ -1,0 +1,96 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit.flagcase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoveFlagConfirmationTest {
+
+    @Mock private Callback<AsylumCase> callback;
+
+    private RemoveFlagConfirmation removeFlagConfirmation =
+        new RemoveFlagConfirmation();
+
+    @Test
+    public void should_return_confirmation() {
+
+        when(callback.getEvent()).thenReturn(Event.REMOVE_FLAG);
+
+        PostSubmitCallbackResponse callbackResponse =
+            removeFlagConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        assertThat(
+            callbackResponse.getConfirmationHeader().get(),
+            containsString("You've removed the flag from this case")
+        );
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get(),
+            containsString("What happens next")
+        );
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get(),
+            containsString(
+                "This flag has been removed from the case. The case will proceed as usual."
+            )
+        );
+    }
+
+    @Test
+    public void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> removeFlagConfirmation.handle(callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            boolean canHandle = removeFlagConfirmation.canHandle(callback);
+
+            if (event == Event.REMOVE_FLAG) {
+
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> removeFlagConfirmation.canHandle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> removeFlagConfirmation.handle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/flagcase/RemoveFlagHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/flagcase/RemoveFlagHandlerTest.java
@@ -1,0 +1,131 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.flagcase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoveFlagHandlerTest {
+
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+    @Mock private CaseFlag expectedCaseFlag;
+    @Mock private CaseFlag expectedCaseFlag2;
+
+    private List<IdValue<CaseFlag>> expectedList;
+    private IdValue<CaseFlag> expectedIdValue;
+    private RemoveFlagHandler removeFlagHandler;
+
+    @Before
+    public void setUp() {
+        when(callback.getEvent()).thenReturn(Event.REMOVE_FLAG);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetails().getCaseData()).thenReturn(asylumCase);
+        when(expectedCaseFlag.getCaseFlagType()).thenReturn(CaseFlagType.COMPLEX_CASE);
+        when(expectedCaseFlag2.getCaseFlagType()).thenReturn(CaseFlagType.ANONYMITY);
+
+        removeFlagHandler = new RemoveFlagHandler();
+        expectedIdValue = new IdValue<>("2", expectedCaseFlag2);
+        expectedList = Arrays.asList(
+            new IdValue<>("1", expectedCaseFlag),
+            expectedIdValue
+        );
+    }
+
+    @Test
+    public void removes_a_specified_flag() {
+        final List<Value> expectedElements = Optional.of(expectedList)
+            .orElse(Collections.emptyList())
+            .stream()
+            .map(idValue -> new Value(idValue.getId(), idValue.getValue().getCaseFlagType().getReadableText()))
+            .collect(Collectors.toList());
+
+        final DynamicList dynamicList = new DynamicList(expectedElements.get(0), expectedElements);
+        final List<IdValue<CaseFlag>> expectedCaseFlagList = new ArrayList<>();
+        expectedCaseFlagList.add(expectedIdValue);
+
+        when(asylumCase.read(REMOVE_FLAG_TYPE_OF_FLAG, DynamicList.class)).thenReturn(Optional.of(dynamicList));
+        when(asylumCase.read(CASE_FLAGS)).thenReturn(Optional.of(expectedList));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            removeFlagHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).read(REMOVE_FLAG_TYPE_OF_FLAG, DynamicList.class);
+        verify(asylumCase, times(1)).read(CASE_FLAGS);
+
+        verify(asylumCase, times(1)).write(CASE_FLAGS, expectedCaseFlagList);
+        verify(asylumCase, times(1)).clear(REMOVE_FLAG_TYPE_OF_FLAG);
+    }
+
+    @Test
+    public void clear_display_flags_test() {
+        removeFlagHandler.clearDisplayFlags(CaseFlagType.ANONYMITY, asylumCase);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_ANONYMITY_EXISTS);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_ANONYMITY_ADDITIONAL_INFORMATION);
+
+        removeFlagHandler.clearDisplayFlags(CaseFlagType.COMPLEX_CASE, asylumCase);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_COMPLEX_CASE_EXISTS);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_COMPLEX_CASE_ADDITIONAL_INFORMATION);
+
+        removeFlagHandler.clearDisplayFlags(CaseFlagType.DETAINED_IMMIGRATION_APPEAL, asylumCase);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_DETAINED_IMMIGRATION_APPEAL_EXISTS);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_DETAINED_IMMIGRATION_APPEAL_ADDITIONAL_INFORMATION);
+
+        removeFlagHandler.clearDisplayFlags(CaseFlagType.FOREIGN_NATIONAL_OFFENDER, asylumCase);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_FOREIGN_NATIONAL_OFFENDER_EXISTS);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_FOREIGN_NATIONAL_OFFENDER_ADDITIONAL_INFORMATION);
+
+        removeFlagHandler.clearDisplayFlags(CaseFlagType.POTENTIALLY_VIOLENT_PERSON, asylumCase);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_POTENTIALLY_VIOLENT_PERSON_EXISTS);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_POTENTIALLY_VIOLENT_PERSON_ADDITIONAL_INFORMATION);
+
+        removeFlagHandler.clearDisplayFlags(CaseFlagType.UNACCEPTABLE_CUSTOMER_BEHAVIOUR, asylumCase);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_UNACCEPTABLE_CUSTOMER_BEHAVIOUR_EXISTS);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_UNACCEPTABLE_CUSTOMER_BEHAVIOUR_ADDITIONAL_INFORMATION);
+
+        removeFlagHandler.clearDisplayFlags(CaseFlagType.UNACCOMPANIED_MINOR, asylumCase);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_UNACCOMPANIED_MINOR_EXISTS);
+        verify(asylumCase, times(1)).clear(CASE_FLAG_UNACCOMPANIED_MINOR_ADDITIONAL_INFORMATION);
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> removeFlagHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> removeFlagHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> removeFlagHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> removeFlagHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/flagcase/RemoveFlagPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/flagcase/RemoveFlagPreparerTest.java
@@ -1,0 +1,166 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.flagcase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoveFlagPreparerTest {
+
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+    @Mock private CaseFlag expectedCaseFlag;
+
+    private List<IdValue<CaseFlag>> expectedList;
+    private RemoveFlagPreparer removeFlagPreparer;
+
+    @Before
+    public void setUp() {
+        when(callback.getEvent()).thenReturn(Event.REMOVE_FLAG);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetails().getCaseData()).thenReturn(asylumCase);
+        when(expectedCaseFlag.getCaseFlagType()).thenReturn(CaseFlagType.COMPLEX_CASE);
+
+        removeFlagPreparer = spy(RemoveFlagPreparer.class);
+        expectedList = Collections.singletonList(new IdValue<>("1", expectedCaseFlag));
+
+        when(asylumCase.read(CASE_FLAGS)).thenReturn(Optional.of(expectedList));
+    }
+
+    @Test
+    public void should_set_available_flags_to_remove() {
+
+        final List<Value> expectedElements = Optional.of(expectedList)
+            .orElse(Collections.emptyList())
+            .stream()
+            .map(idValue -> new Value(idValue.getId(), idValue.getValue().getCaseFlagType().getReadableText()))
+            .collect(Collectors.toList());
+
+        final DynamicList dynamicList = new DynamicList(expectedElements.get(0), expectedElements);
+
+        doReturn(expectedElements).when(removeFlagPreparer).getExistingCaseFlagListElements(expectedList);
+        doReturn(dynamicList).when(removeFlagPreparer).createDynamicList(expectedElements);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            removeFlagPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).write(REMOVE_FLAG_TYPE_OF_FLAG, dynamicList);
+    }
+
+    @Test
+    public void should_throw_error_when_no_case_flags_present() {
+
+        final List<Value> expectedElements = Optional.of(expectedList)
+            .orElse(Collections.emptyList())
+            .stream()
+            .map(idValue -> new Value(idValue.getId(), idValue.getValue().getCaseFlagType().getReadableText()))
+            .collect(Collectors.toList());
+
+        final DynamicList dynamicList = new DynamicList(expectedElements.get(0), expectedElements);
+
+        when(asylumCase.read(CASE_FLAGS)).thenReturn(Optional.of(Collections.emptyList()));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            removeFlagPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, never()).write(REMOVE_FLAG_TYPE_OF_FLAG, dynamicList);
+    }
+
+    @Test
+    public void should_get_existing_case_flag_elements_as_list() {
+
+        final List<Value> actualList = removeFlagPreparer.getExistingCaseFlagListElements(expectedList);
+        assertEquals(1, actualList.size());
+        assertEquals(expectedCaseFlag.getCaseFlagType().getReadableText(), actualList.get(0).getLabel());
+    }
+
+    @Test
+    public void creates_dynamic_list_from_element_list() {
+        final List<Value> expectedElements = Optional.of(expectedList)
+            .orElse(Collections.emptyList())
+            .stream()
+            .map(idValue -> new Value(idValue.getId(), idValue.getValue().getCaseFlagType().getReadableText()))
+            .collect(Collectors.toList());
+
+        final DynamicList actualDynamicList = removeFlagPreparer.createDynamicList(expectedElements);
+
+        assertEquals(1, actualDynamicList.getListItems().size());
+        assertEquals(expectedCaseFlag.getCaseFlagType().getReadableText(), actualDynamicList.getValue().getLabel());
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> removeFlagPreparer.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> removeFlagPreparer.canHandle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> removeFlagPreparer.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> removeFlagPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> removeFlagPreparer.createDynamicList(null))
+            .hasMessage("elementsList must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> removeFlagPreparer.getExistingCaseFlagListElements(null))
+            .hasMessage("existingCaseFlags must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = removeFlagPreparer.canHandle(callbackStage, callback);
+
+                if (event == Event.REMOVE_FLAG
+                    && callbackStage == PreSubmitCallbackStage.ABOUT_TO_START) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+            reset(callback);
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/CaseFlagAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/CaseFlagAppenderTest.java
@@ -20,6 +20,8 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
 @RunWith(MockitoJUnitRunner.class)
 public class CaseFlagAppenderTest {
 
+    @Mock private CaseFlag caseFlag1;
+    @Mock private CaseFlag caseFlag2;
     @Mock private IdValue<CaseFlag> existingCaseFlagById1;
     @Mock private IdValue<CaseFlag> existingCaseFlagById2;
 
@@ -31,15 +33,17 @@ public class CaseFlagAppenderTest {
     @Before
     public void setUp() {
         caseFlagAppender = new CaseFlagAppender();
+        when(caseFlag1.getCaseFlagType()).thenReturn(CaseFlagType.COMPLEX_CASE);
+        when(caseFlag2.getCaseFlagType()).thenReturn(CaseFlagType.UNACCOMPANIED_MINOR);
     }
 
     @Test
     public void should_append_new_case_flag_in_first_position() {
 
-        CaseFlag existingCaseFlag1 = mock(CaseFlag.class);
+        CaseFlag existingCaseFlag1 = caseFlag1;
         when(existingCaseFlagById1.getValue()).thenReturn(existingCaseFlag1);
 
-        CaseFlag existingCaseFlag2 = mock(CaseFlag.class);
+        CaseFlag existingCaseFlag2 = caseFlag2;
         when(existingCaseFlagById2.getValue()).thenReturn(existingCaseFlag2);
 
         List<IdValue<CaseFlag>> existingCaseFlags = Arrays.asList(existingCaseFlagById1, existingCaseFlagById2);
@@ -56,15 +60,16 @@ public class CaseFlagAppenderTest {
         assertNotNull(allCaseFlags);
         assertEquals(3, allCaseFlags.size());
 
-        assertEquals("3", allCaseFlags.get(0).getId());
-        assertEquals(newCaseFlagType, allCaseFlags.get(0).getValue().getCaseFlagType());
-        assertEquals(newCaseFlagAdditionalInformation, allCaseFlags.get(0).getValue().getCaseFlagAdditionalInformation());
+        assertEquals("1", allCaseFlags.get(2).getId());
+
+        assertEquals(newCaseFlagType, allCaseFlags.get(2).getValue().getCaseFlagType());
+        assertEquals(newCaseFlagAdditionalInformation, allCaseFlags.get(2).getValue().getCaseFlagAdditionalInformation());
 
         assertEquals("2", allCaseFlags.get(1).getId());
-        assertEquals(existingCaseFlag1, allCaseFlags.get(1).getValue());
+        assertEquals(existingCaseFlag2, allCaseFlags.get(1).getValue());
 
-        assertEquals("1", allCaseFlags.get(2).getId());
-        assertEquals(existingCaseFlag2, allCaseFlags.get(2).getValue());
+        assertEquals("3", allCaseFlags.get(0).getId());
+        assertEquals(existingCaseFlag1, allCaseFlags.get(0).getValue());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/CaseFlagAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/CaseFlagAppenderTest.java
@@ -20,8 +20,6 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
 @RunWith(MockitoJUnitRunner.class)
 public class CaseFlagAppenderTest {
 
-    @Mock private CaseFlag caseFlag1;
-    @Mock private CaseFlag caseFlag2;
     @Mock private IdValue<CaseFlag> existingCaseFlagById1;
     @Mock private IdValue<CaseFlag> existingCaseFlagById2;
 
@@ -33,17 +31,15 @@ public class CaseFlagAppenderTest {
     @Before
     public void setUp() {
         caseFlagAppender = new CaseFlagAppender();
-        when(caseFlag1.getCaseFlagType()).thenReturn(CaseFlagType.COMPLEX_CASE);
-        when(caseFlag2.getCaseFlagType()).thenReturn(CaseFlagType.UNACCOMPANIED_MINOR);
     }
 
     @Test
     public void should_append_new_case_flag_in_first_position() {
 
-        CaseFlag existingCaseFlag1 = caseFlag1;
+        CaseFlag existingCaseFlag1 = mock(CaseFlag.class);
         when(existingCaseFlagById1.getValue()).thenReturn(existingCaseFlag1);
 
-        CaseFlag existingCaseFlag2 = caseFlag2;
+        CaseFlag existingCaseFlag2 = mock(CaseFlag.class);
         when(existingCaseFlagById2.getValue()).thenReturn(existingCaseFlag2);
 
         List<IdValue<CaseFlag>> existingCaseFlags = Arrays.asList(existingCaseFlagById1, existingCaseFlagById2);
@@ -60,16 +56,15 @@ public class CaseFlagAppenderTest {
         assertNotNull(allCaseFlags);
         assertEquals(3, allCaseFlags.size());
 
-        assertEquals("1", allCaseFlags.get(2).getId());
-
-        assertEquals(newCaseFlagType, allCaseFlags.get(2).getValue().getCaseFlagType());
-        assertEquals(newCaseFlagAdditionalInformation, allCaseFlags.get(2).getValue().getCaseFlagAdditionalInformation());
+        assertEquals("3", allCaseFlags.get(0).getId());
+        assertEquals(newCaseFlagType, allCaseFlags.get(0).getValue().getCaseFlagType());
+        assertEquals(newCaseFlagAdditionalInformation, allCaseFlags.get(0).getValue().getCaseFlagAdditionalInformation());
 
         assertEquals("2", allCaseFlags.get(1).getId());
-        assertEquals(existingCaseFlag2, allCaseFlags.get(1).getValue());
+        assertEquals(existingCaseFlag1, allCaseFlags.get(1).getValue());
 
-        assertEquals("3", allCaseFlags.get(0).getId());
-        assertEquals(existingCaseFlag1, allCaseFlags.get(0).getValue());
+        assertEquals("1", allCaseFlags.get(2).getId());
+        assertEquals(existingCaseFlag2, allCaseFlags.get(2).getValue());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-2513


### Change description ###
 - A new handler created to handle the removing a flag event.
 - A preparer created to collate the current flags in the case, to create a dynamic list of the flags.
 - Functional tests added.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
