### PR TITLE
Ria 2960 Relist the case from adjourned state

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-2957-adjourn-without-a-date.json
+++ b/src/functionalTest/resources/scenarios/RIA-2957-adjourn-without-a-date.json
@@ -47,8 +47,8 @@
         "listCaseHearingDate": "2018-12-31T12:34:56",
         "uploadAdditionalEvidenceActionAvailable": "Yes",
         "ariaListingReference": "LP/12345/2019",
-        "stateBeforeAdjournWithoutDate": "decision",
-        "dateBeforeAdjournWithoutDate": "2020-04-07"
+        "stateBeforeAdjournWithoutDate": "listing",
+        "dateBeforeAdjournWithoutDate": "2018-12-31T12:34:56"
       }
     }
   }

--- a/src/functionalTest/resources/scenarios/RIA-2957-adjourn-without-a-date.json
+++ b/src/functionalTest/resources/scenarios/RIA-2957-adjourn-without-a-date.json
@@ -15,7 +15,6 @@
           "listCaseHearingDate": "2018-12-31T12:34:56",
           "uploadAdditionalEvidenceActionAvailable": "Yes",
           "ariaListingReference": "LP/12345/2019"
-
         }
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-2957-adjourn-without-a-date.json
+++ b/src/functionalTest/resources/scenarios/RIA-2957-adjourn-without-a-date.json
@@ -14,7 +14,8 @@
           "listCaseHearingLength": "60",
           "listCaseHearingDate": "2018-12-31T12:34:56",
           "uploadAdditionalEvidenceActionAvailable": "Yes",
-          "ariaListingReference": "LP/12345/2019"
+          "ariaListingReference": "LP/12345/2019",
+          "currentCaseStateVisibleToCaseOfficer": "listing"
         }
       }
     }
@@ -45,7 +46,9 @@
         "listCaseHearingLength": "60",
         "listCaseHearingDate": "2018-12-31T12:34:56",
         "uploadAdditionalEvidenceActionAvailable": "Yes",
-        "ariaListingReference": "LP/12345/2019"
+        "ariaListingReference": "LP/12345/2019",
+        "stateBeforeAdjournWithoutDate": "decision",
+        "dateBeforeAdjournWithoutDate": "2020-04-07"
       }
     }
   }

--- a/src/functionalTest/resources/scenarios/RIA-2960-restore-case-state.json
+++ b/src/functionalTest/resources/scenarios/RIA-2960-restore-case-state.json
@@ -1,0 +1,32 @@
+{
+  "description": "RIA-2960 Restore state from adjourned",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 1234,
+      "eventId": "restoreStateFromAdjourn",
+      "state": "adjourned",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "dateBeforeAdjournWithoutDate": "2020-04-07",
+          "stateBeforeAdjournWithoutDate": "decision"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "state": "decision",
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "listCaseHearingDate": "2020-04-07",
+        "doesTheCaseNeedToBeRelisted": "Yes",
+        "sendDirectionActionAvailable": "No"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -759,7 +759,6 @@ public enum AsylumCaseFieldDefinition {
 
     DOES_THE_CASE_NEED_TO_BE_RELISTED(
         "doesTheCaseNeedToBeRelisted", new TypeReference<YesOrNo>(){}),
-
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -751,6 +751,15 @@ public enum AsylumCaseFieldDefinition {
     REASON_TO_FORCE_CASE_TO_SUBMIT_HEARING_REQUIREMENTS(
         "reasonToForceCaseToSubmitHearingRequirements", new TypeReference<String>() {}),
 
+    STATE_BEFORE_ADJOURN_WITHOUT_DATE(
+        "stateBeforeAdjournWithoutDate", new TypeReference<String>(){}),
+
+    DATE_BEFORE_ADJOURN_WITHOUT_DATE(
+        "dateBeforeAdjournWithoutDate", new TypeReference<String>(){}),
+
+    DOES_THE_CASE_NEED_TO_BE_RELISTED(
+        "doesTheCaseNeedToBeRelisted", new TypeReference<YesOrNo>(){}),
+
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -75,6 +75,7 @@ public enum Event {
     FORCE_CASE_TO_SUBMIT_HEARING_REQUIREMENTS("forceCaseToSubmitHearingRequirements"),
     UPDATE_LEGAL_REPRESENTATIVES_DETAILS("updateLegalRepDetails"),
     ADJOURN_HEARING_WITHOUT_DATE("adjournHearingWithoutDate"),
+    RESTORE_STATE_FROM_ADJOURN("restoreStateFromAdjourn"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandler.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE_ADJOURNED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.ADJOURN_HEARING_WITHOUT_DATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE_ADJOURNED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.ADJOURN_HEARING_WITHOUT_DATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
@@ -31,6 +32,7 @@ public class AdjournWithoutDateHandler implements PreSubmitCallbackHandler<Asylu
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
         asylumCase.write(LIST_CASE_HEARING_DATE_ADJOURNED, "Adjourned");
+        asylumCase.clear(LIST_CASE_HEARING_DATE);
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandler.java
@@ -32,6 +32,7 @@ public class AdjournWithoutDateHandler implements PreSubmitCallbackHandler<Asylu
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
         asylumCase.write(LIST_CASE_HEARING_DATE_ADJOURNED, "Adjourned");
+        asylumCase.clear(LIST_CASE_HEARING_DATE);
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandler.java
@@ -32,7 +32,6 @@ public class AdjournWithoutDateHandler implements PreSubmitCallbackHandler<Asylu
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
         asylumCase.write(LIST_CASE_HEARING_DATE_ADJOURNED, "Adjourned");
-        asylumCase.clear(LIST_CASE_HEARING_DATE);
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandler.java
@@ -1,12 +1,17 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_CASE_OFFICER;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_BEFORE_ADJOURN_WITHOUT_DATE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE_ADJOURNED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.STATE_BEFORE_ADJOURN_WITHOUT_DATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.ADJOURN_HEARING_WITHOUT_DATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
@@ -30,7 +35,14 @@ public class AdjournWithoutDateHandler implements PreSubmitCallbackHandler<Asylu
 
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
+        State currentState = asylumCase.read(CURRENT_CASE_STATE_VISIBLE_TO_CASE_OFFICER, State.class)
+            .orElse(State.UNKNOWN);
+        String currentHearingDate = asylumCase.read(LIST_CASE_HEARING_DATE, String.class)
+            .orElseThrow(() -> new IllegalStateException("listCaseHearingDate is missing."));
+
         asylumCase.write(LIST_CASE_HEARING_DATE_ADJOURNED, "Adjourned");
+        asylumCase.write(STATE_BEFORE_ADJOURN_WITHOUT_DATE, currentState.toString());
+        asylumCase.write(DATE_BEFORE_ADJOURN_WITHOUT_DATE, currentHearingDate);
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
@@ -56,7 +56,9 @@ public class ListEditCaseHandler implements PreSubmitCallbackHandler<AsylumCase>
         } else {
             asylumCase.write(HEARING_CENTRE, maybeHearingCentre);
         }
+
         asylumCase.clear(REVIEWED_UPDATED_HEARING_REQUIREMENTS);
+        asylumCase.clear(DOES_THE_CASE_NEED_TO_BE_RELISTED);
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RestoreStateFromAdjournHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RestoreStateFromAdjournHandler.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static com.google.common.base.CaseFormat.LOWER_CAMEL;
+import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.RESTORE_STATE_FROM_ADJOURN;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackStateHandler;
+
+@Component
+public class RestoreStateFromAdjournHandler implements PreSubmitCallbackStateHandler<AsylumCase> {
+    @Override
+    public boolean canHandle(PreSubmitCallbackStage callbackStage, Callback<AsylumCase> callback) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+        return callbackStage.equals(ABOUT_TO_SUBMIT) && callback.getEvent().equals(RESTORE_STATE_FROM_ADJOURN);
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<AsylumCase> handle(PreSubmitCallbackStage callbackStage,
+                                                        Callback<AsylumCase> callback,
+                                                        PreSubmitCallbackResponse<AsylumCase> callbackResponse) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        String previousHearingDate = asylumCase.read(DATE_BEFORE_ADJOURN_WITHOUT_DATE, String.class)
+            .orElseThrow(() -> new IllegalStateException("dateBeforeAdjournWithoutDate is missing."));
+
+        asylumCase.write(DOES_THE_CASE_NEED_TO_BE_RELISTED, YesOrNo.YES);
+        asylumCase.write(LIST_CASE_HEARING_DATE, previousHearingDate);
+
+        asylumCase.clear(DATE_BEFORE_ADJOURN_WITHOUT_DATE);
+
+        String maybePreviousStateId = asylumCase.read(STATE_BEFORE_ADJOURN_WITHOUT_DATE, String.class)
+            .orElseThrow(() -> new IllegalStateException("stateBeforeAdjournWithoutDate is missing."));
+
+        State previousState = State.valueOf(LOWER_CAMEL.to(UPPER_UNDERSCORE, maybePreviousStateId));
+
+        asylumCase.clear(STATE_BEFORE_ADJOURN_WITHOUT_DATE);
+
+        return new PreSubmitCallbackResponse<>(asylumCase, previousState);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -190,6 +190,7 @@ security:
       - "forceCaseToCaseUnderReview"
       - "forceCaseToSubmitHearingRequirements"
       - "adjournHearingWithoutDate"
+      - "restoreStateFromAdjourn"
     caseworker-ia-admofficer:
       - "listCase"
       - "recordAttendeesAndDuration"
@@ -200,6 +201,7 @@ security:
       - "flagCase"
       - "removeFlag"
       - "adjournHearingWithoutDate"
+      - "restoreStateFromAdjourn"
     caseworker-ia-homeofficeapc:
       - "uploadHomeOfficeBundle"
       - "uploadAdditionalEvidenceHomeOffice"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -81,6 +81,6 @@ public class EventTest {
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(71, Event.values().length);
+        assertEquals(72, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -76,6 +76,7 @@ public class EventTest {
         assertEquals("updateLegalRepDetails", Event.UPDATE_LEGAL_REPRESENTATIVES_DETAILS.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
         assertEquals("adjournHearingWithoutDate", Event.ADJOURN_HEARING_WITHOUT_DATE.toString());
+        assertEquals("restoreStateFromAdjourn", Event.RESTORE_STATE_FROM_ADJOURN.toString());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandlerTest.java
@@ -125,7 +125,5 @@ public class AdjournWithoutDateHandlerTest {
 
         then(asylumCase).should(times(1))
             .write(eq(AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE_ADJOURNED), eq("Adjourned"));
-        then(asylumCase).should(times(1))
-            .clear(eq(AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandlerTest.java
@@ -125,5 +125,7 @@ public class AdjournWithoutDateHandlerTest {
 
         then(asylumCase).should(times(1))
             .write(eq(AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE_ADJOURNED), eq("Adjourned"));
+        then(asylumCase).should(times(1))
+            .clear(eq(AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdjournWithoutDateHandlerTest.java
@@ -7,12 +7,15 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_CASE_OFFICER;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import lombok.Value;
@@ -27,6 +30,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 
@@ -120,10 +124,16 @@ public class AdjournWithoutDateHandlerTest {
         given(callback.getEvent()).willReturn(Event.ADJOURN_HEARING_WITHOUT_DATE);
         given(callback.getCaseDetails()).willReturn(caseDetails);
         given(caseDetails.getCaseData()).willReturn(asylumCase);
+        given(asylumCase.read(CURRENT_CASE_STATE_VISIBLE_TO_CASE_OFFICER, State.class)).willReturn(Optional.of(State.PREPARE_FOR_HEARING));
+        given(asylumCase.read(LIST_CASE_HEARING_DATE, String.class)).willReturn(Optional.of("05/05/2020"));
 
         handler.handle(ABOUT_TO_SUBMIT, callback);
 
         then(asylumCase).should(times(1))
             .write(eq(AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE_ADJOURNED), eq("Adjourned"));
+        then(asylumCase).should(times(1))
+            .write(eq(AsylumCaseFieldDefinition.STATE_BEFORE_ADJOURN_WITHOUT_DATE), eq("prepareForHearing"));
+        then(asylumCase).should(times(1))
+            .write(eq(AsylumCaseFieldDefinition.DATE_BEFORE_ADJOURN_WITHOUT_DATE), eq("05/05/2020"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandlerTest.java
@@ -3,9 +3,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_CENTRE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DOES_THE_CASE_NEED_TO_BE_RELISTED;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_CENTRE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandlerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_CENTRE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DOES_THE_CASE_NEED_TO_BE_RELISTED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_CENTRE;
 
 import org.junit.Before;
@@ -54,6 +55,7 @@ public class ListEditCaseHandlerTest {
 
         verify(asylumCase, times(1)).write(LIST_CASE_HEARING_CENTRE, HearingCentre.TAYLOR_HOUSE);
         verify(asylumCase, times(1)).write(HEARING_CENTRE, HearingCentre.TAYLOR_HOUSE);
+        verify(asylumCase, times(1)).clear(DOES_THE_CASE_NEED_TO_BE_RELISTED);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RestoreStateFromAdjournHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RestoreStateFromAdjournHandlerTest.java
@@ -1,0 +1,115 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RestoreStateFromAdjournHandlerTest {
+
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+    @Mock private PreSubmitCallbackResponse<AsylumCase> callbackResponse;
+
+    private final String listCaseHearingDate = "05/05/2020";
+
+    private RestoreStateFromAdjournHandler restoreStateFromAdjournHandler;
+
+    @Before
+    public void setUp() {
+        restoreStateFromAdjournHandler = new RestoreStateFromAdjournHandler();
+    }
+
+    @Test
+    public void should_return_updated_state_for_return_state_from_adjourn_adjourned_state() {
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.RESTORE_STATE_FROM_ADJOURN);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(STATE_BEFORE_ADJOURN_WITHOUT_DATE, String.class)).thenReturn(Optional.of(State.PREPARE_FOR_HEARING.toString()));
+        when(asylumCase.read(DATE_BEFORE_ADJOURN_WITHOUT_DATE, String.class)).thenReturn(Optional.of(listCaseHearingDate));
+
+        PreSubmitCallbackResponse<AsylumCase> returnedCallbackResponse =
+            restoreStateFromAdjournHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback, callbackResponse);
+
+        assertNotNull(returnedCallbackResponse);
+        Assertions.assertThat(returnedCallbackResponse.getState()).isEqualTo(State.PREPARE_FOR_HEARING);
+        assertEquals(asylumCase, returnedCallbackResponse.getData());
+
+        verify(asylumCase, times(1)).write(DOES_THE_CASE_NEED_TO_BE_RELISTED, YesOrNo.YES);
+        verify(asylumCase, times(1)).write(LIST_CASE_HEARING_DATE, listCaseHearingDate);
+        verify(asylumCase, times(1)).clear(DATE_BEFORE_ADJOURN_WITHOUT_DATE);
+        verify(asylumCase, times(1)).clear(STATE_BEFORE_ADJOURN_WITHOUT_DATE);
+    }
+
+    @Test
+    public void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> restoreStateFromAdjournHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback, callbackResponse))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = restoreStateFromAdjournHandler.canHandle(callbackStage, callback);
+
+                if (event == Event.RESTORE_STATE_FROM_ADJOURN
+                    && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> restoreStateFromAdjournHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> restoreStateFromAdjournHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> restoreStateFromAdjournHandler.handle(null, callback, callbackResponse))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> restoreStateFromAdjournHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-2960


### Change description ###

- Created a new handler for restoreStateFromAdjourn event.
- Updated adjournHearingWithoutDate handler to keep previous state and listing date.
- Updated functional tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
