### PR TITLE
RIA-2964: Fixed issue of displaying old grounds of appeals under 'App…

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-230-protection-grounds.json
+++ b/src/functionalTest/resources/scenarios/RIA-230-protection-grounds.json
@@ -30,17 +30,7 @@
     "caseData": {
       "template": "minimal-appeal-started.json",
       "replacements": {
-        "appealGroundsProtection": {
-          "values": [
-            "refugeeConvention",
-            "humanitarianProtection"
-          ]
-        },
-        "appealGroundsHumanRights": {
-          "values": [
-            "humanRights"
-          ]
-        },
+        "appealGroundsProtection": null,
         "appealGroundsForDisplay": [
           "refugeeConvention",
           "humanitarianProtection",

--- a/src/functionalTest/resources/scenarios/RIA-236-revocation-grounds.json
+++ b/src/functionalTest/resources/scenarios/RIA-236-revocation-grounds.json
@@ -25,12 +25,8 @@
     "caseData": {
       "template": "minimal-appeal-started.json",
       "replacements": {
-        "appealGroundsRevocation": {
-          "values": [
-            "refugeeConvention",
-            "humanitarianProtection"
-          ]
-        },
+        "appealGroundsRevocation": null,
+        "appealGroundsProtection": null,
         "appealGroundsForDisplay": [
           "refugeeConvention",
           "humanitarianProtection"

--- a/src/functionalTest/resources/scenarios/RIA-2733-start-appeal-journey-update.json
+++ b/src/functionalTest/resources/scenarios/RIA-2733-start-appeal-journey-update.json
@@ -30,17 +30,8 @@
     "caseData": {
       "template": "minimal-appeal-started.json",
       "replacements": {
-        "appealGroundsProtection": {
-          "values": [
-            "refugeeConvention",
-            "humanitarianProtection"
-          ]
-        },
-        "appealGroundsHumanRights": {
-          "values": [
-            "humanRights"
-          ]
-        },
+        "appealGroundsProtection": null,
+        "appealGroundsHumanRights": null,
         "appealGroundsForDisplay": [
           "refugeeConvention",
           "humanitarianProtection",

--- a/src/functionalTest/resources/scenarios/RIA-583-draft-appeal-reference.json
+++ b/src/functionalTest/resources/scenarios/RIA-583-draft-appeal-reference.json
@@ -20,6 +20,7 @@
     "caseData": {
       "template": "minimal-appeal-started.json",
       "replacements": {
+        "appealGroundsProtection": null,
         "appealReferenceNumber": "DRAFT"
       }
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealGroundsForDisplayFormatter.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealGroundsForDisplayFormatter.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CheckValues;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
@@ -25,7 +26,9 @@ public class AppealGroundsForDisplayFormatter implements PreSubmitCallbackHandle
         requireNonNull(callbackStage, "callbackStage must not be null");
         requireNonNull(callback, "callback must not be null");
 
-        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+               && (callback.getEvent() == Event.START_APPEAL
+                   || callback.getEvent() == Event.EDIT_APPEAL);
     }
 
     public PreSubmitCallbackResponse<AsylumCase> handle(
@@ -83,6 +86,14 @@ public class AppealGroundsForDisplayFormatter implements PreSubmitCallbackHandle
             APPEAL_GROUNDS_FOR_DISPLAY,
             new ArrayList<>(appealGrounds)
         );
+
+        asylumCase.clear(APPEAL_GROUNDS_PROTECTION);
+        asylumCase.clear(APPEAL_GROUNDS_HUMAN_RIGHTS);
+        asylumCase.clear(APPEAL_GROUNDS_REVOCATION);
+        asylumCase.clear(APPEAL_GROUNDS_HUMAN_RIGHTS_REFUSAL);
+        asylumCase.clear(APPEAL_GROUNDS_DEPRIVATION_HUMAN_RIGHTS);
+        asylumCase.clear(APPEAL_GROUNDS_DEPRIVATION);
+        asylumCase.clear(APPEAL_GROUNDS_EU_REFUSAL);
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealGroundsForDisplayFormatterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealGroundsForDisplayFormatterTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.Test;
@@ -41,7 +42,7 @@ public class AppealGroundsForDisplayFormatterTest {
             ));
 
         final CheckValues<String> appealGroundsHumanRights =
-            new CheckValues<>(Arrays.asList(
+            new CheckValues<>(Collections.singletonList(
                 "ground3"
             ));
 
@@ -61,6 +62,7 @@ public class AppealGroundsForDisplayFormatterTest {
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.EDIT_APPEAL);
 
         when(asylumCase.read(APPEAL_GROUNDS_PROTECTION)).thenReturn(Optional.of(appealGroundsProtection));
         when(asylumCase.read(APPEAL_GROUNDS_HUMAN_RIGHTS)).thenReturn(Optional.of(appealGroundsHumanRights));
@@ -76,15 +78,25 @@ public class AppealGroundsForDisplayFormatterTest {
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
         verify(asylumCase, times(1)).write(APPEAL_GROUNDS_FOR_DISPLAY, expectedAppealGrounds);
+
+        verify(asylumCase).clear(APPEAL_GROUNDS_PROTECTION);
+        verify(asylumCase).clear(APPEAL_GROUNDS_HUMAN_RIGHTS);
+        verify(asylumCase).clear(APPEAL_GROUNDS_REVOCATION);
+        verify(asylumCase).clear(APPEAL_GROUNDS_HUMAN_RIGHTS_REFUSAL);
+        verify(asylumCase).clear(APPEAL_GROUNDS_DEPRIVATION_HUMAN_RIGHTS);
+        verify(asylumCase).clear(APPEAL_GROUNDS_DEPRIVATION);
+        verify(asylumCase).clear(APPEAL_GROUNDS_EU_REFUSAL);
+
     }
 
     @Test
     public void should_set_empty_grounds_if_ground_values_are_not_present() {
 
-        final List<String> expectedAppealGrounds = Arrays.asList();
+        final List<String> expectedAppealGrounds = Collections.emptyList();
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.EDIT_APPEAL);
 
         when(asylumCase.read(APPEAL_GROUNDS_PROTECTION)).thenReturn(Optional.empty());
         when(asylumCase.read(APPEAL_GROUNDS_HUMAN_RIGHTS)).thenReturn(Optional.empty());
@@ -100,6 +112,14 @@ public class AppealGroundsForDisplayFormatterTest {
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
         verify(asylumCase, times(1)).write(APPEAL_GROUNDS_FOR_DISPLAY, expectedAppealGrounds);
+        verify(asylumCase).clear(APPEAL_GROUNDS_PROTECTION);
+        verify(asylumCase).clear(APPEAL_GROUNDS_HUMAN_RIGHTS);
+        verify(asylumCase).clear(APPEAL_GROUNDS_REVOCATION);
+        verify(asylumCase).clear(APPEAL_GROUNDS_HUMAN_RIGHTS_REFUSAL);
+        verify(asylumCase).clear(APPEAL_GROUNDS_DEPRIVATION_HUMAN_RIGHTS);
+        verify(asylumCase).clear(APPEAL_GROUNDS_DEPRIVATION);
+        verify(asylumCase).clear(APPEAL_GROUNDS_EU_REFUSAL);
+
     }
 
     @Test
@@ -121,8 +141,8 @@ public class AppealGroundsForDisplayFormatterTest {
 
                 boolean canHandle = appealGroundsForDisplayFormatter.canHandle(callbackStage, callback);
 
-                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT) {
-
+                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                    && (callback.getEvent() == Event.START_APPEAL || callback.getEvent() == Event.EDIT_APPEAL)) {
                     assertTrue(canHandle);
                 } else {
                     assertFalse(canHandle);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-2964


### Change description ###
Fixed issue of displaying old grounds of appeals under 'Appeal' tab after edit appeal journey


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
