### PR TITLE
RIA-2873: time extension submission re-write

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -63,4 +63,20 @@
          ]]></notes>
     <cve>CVE-2020-9488</cve>
   </suppress>
+  <suppress until="2030-01-01">
+    <notes><![CDATA[
+     Suppressing SAML vulnerability as it is not used in this project (see: https://nvd.nist.gov/vuln/detail/CVE-2020-5407)
+   ]]></notes>
+    <gav regex="true">org.springframework.security:spring-security-*.*</gav>
+    <cpe>cpe:2.3:a:security-framework_project:security-framework:5.2.1:*:*:*:*:*:*:*</cpe>
+    <cve>CVE-2020-5407</cve>
+  </suppress>
+  <suppress until="2030-01-01">
+    <notes><![CDATA[
+     Suppressing SAML vulnerability as it is not used in this project (see: https://nvd.nist.gov/vuln/detail/CVE-2020-5408)
+   ]]></notes>
+    <gav regex="true">org.springframework.security:spring-security-*.*</gav>
+    <cpe>cpe:2.3:a:security-framework_project:security-framework:5.2.1:*:*:*:*:*:*:*</cpe>
+    <cve>CVE-2020-5408</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
-  <suppress>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress until="2030-01-01">
     <notes><![CDATA[
    file name: groovy-xml-2.4.15.jar
    ]]></notes>
     <gav regex="true">^org\.codehaus\.groovy:groovy-xml:.*$</gav>
     <cpe>cpe:/a:apache:groovy</cpe>
   </suppress>
-  <suppress>
+  <suppress until="2030-01-01">
     <notes><![CDATA[
    file name: groovy-json-2.4.15.jar
    ]]></notes>
     <gav regex="true">^org\.codehaus\.groovy:groovy-json:.*$</gav>
     <cpe>cpe:/a:apache:groovy</cpe>
   </suppress>
-  <suppress>
+  <suppress until="2030-01-01">
     <notes><![CDATA[
 	The offending library and class and not used in our code
 	https://tools.hmcts.net/jira/browse/RIA-951
@@ -22,7 +22,7 @@
     <gav regex="true">.*</gav>
     <cve>CVE-2018-8088</cve>
   </suppress>
-  <suppress>
+  <suppress until="2030-01-01">
     <notes><![CDATA[
          Shadowed dependency from AppInsights-Core. Unfortunately, not propagating and applying an override for transitive dependencies.
          Anyway, this is specific to deserialisation of AtomicDoubleArray and CompoundOrdering classes: https://github.com/google/guava/wiki/CVE-2018-10237
@@ -30,20 +30,20 @@
     <gav regex="true">^com\.google\.guava:guava:.*$</gav>
     <cve>CVE-2018-10237</cve>
   </suppress>
-  <suppress>
+  <suppress until="2030-01-01">
     <notes><![CDATA[
          CVE-2018-1115: Vulnerability applies to postgresql before versions 10.4, 9.6.9 is vulnerable. We use PostgreSQL 10.5 in Azure which does not have this issue.
        ]]></notes>
     <gav regex="true">^org\.postgresql:postgresql:.*$</gav>
     <cve>CVE-2018-1115</cve>
   </suppress>
-  <suppress>
+  <suppress until="2030-01-01">
     <notes><![CDATA[
          CVE-2016-7048: Vulnerability applies to PostgreSQL before 9.3.15, 9.4.x before 9.4.10, and 9.5.x before 9.5.5 only. We use PostgreSQL 10.5 in Azure which does not have this issue.
         ]]></notes>
     <cve>CVE-2016-7048</cve>
   </suppress>
-  <suppress>
+  <suppress until="2030-01-01">
     <notes><![CDATA[
          https://nvd.nist.gov/vuln/detail/CVE-2018-1258
          False positive -- we do not use Spring Framework 5.0.5.RELEASE (5.0.8.RELEASE at the time of writing)
@@ -51,13 +51,13 @@
         ]]></notes>
     <cve>CVE-2018-1258</cve>
   </suppress>
-  <suppress>
+  <suppress until="2030-01-01">
     <notes><![CDATA[
 	   Insecure randomness vulnerability when using SecureRandomFactoryBean#setSeed to configure a SecureRandom instance. However we do not use the offending Bean.
 	   ]]></notes>
     <cve>CVE-2019-3795</cve>
   </suppress>
-  <suppress>
+  <suppress until="2030-01-01">
     <notes><![CDATA[
          Improper validation of certificate with host mismatch in Apache Log4j SMTP appender. Only affects SMTPS which we do not use in this project.
          ]]></notes>

--- a/src/functionalTest/resources/scenarios/RIA-2829-PrepairTimeExtension.json
+++ b/src/functionalTest/resources/scenarios/RIA-2829-PrepairTimeExtension.json
@@ -25,7 +25,7 @@
           ],
           "timeExtensions": [
             {
-              "id": "123",
+              "id": "1",
               "value": {
                 "requestDate": "{$TODAY}",
                 "reason": "time extension reason",
@@ -48,7 +48,7 @@
       "replacements": {
         "timeExtensions": [
           {
-            "id": "123",
+            "id": "1",
             "value": {
               "requestDate": "{$TODAY}",
               "reason": "time extension reason",

--- a/src/functionalTest/resources/scenarios/RIA-2829-ReviewTimeExtension.json
+++ b/src/functionalTest/resources/scenarios/RIA-2829-ReviewTimeExtension.json
@@ -25,7 +25,7 @@
           ],
           "timeExtensions": [
             {
-              "id": "123",
+              "id": "1",
               "value": {
                 "requestDate": "{$TODAY}",
                 "reason": "time extension reason",
@@ -64,7 +64,7 @@
         ],
         "timeExtensions": [
           {
-            "id": "123",
+            "id": "1",
             "value": {
               "requestDate": "{$TODAY}",
               "reason": "time extension reason",

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -620,6 +620,12 @@ public enum AsylumCaseFieldDefinition {
     APPLICATION_CHANGE_DESIGNATED_HEARING_CENTRE(
         "applicationChangeDesignatedHearingCentre", new TypeReference<HearingCentre>(){}),
 
+    SUBMIT_TIME_EXTENSION_REASON(
+        "submitTimeExtensionReason", new TypeReference<String>(){}),
+
+    SUBMIT_TIME_EXTENSION_EVIDENCE(
+        "submitTimeExtensionEvidence", new TypeReference<List<IdValue<Document>>>(){}),
+
     REVIEW_TIME_EXTENSION_DATE(
         "reviewTimeExtensionDate", new TypeReference<String>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -73,7 +73,8 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
                    Event.CHANGE_HEARING_CENTRE,
                    Event.APPLY_FOR_FTPA_APPELLANT,
                    Event.APPLY_FOR_FTPA_RESPONDENT,
-                   Event.SUBMIT_TIME_EXTENSION
+                   Event.SUBMIT_TIME_EXTENSION,
+                   Event.REVIEW_TIME_EXTENSION
                ).contains(callback.getEvent());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TimeExtensionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TimeExtensionHandler.java
@@ -1,0 +1,96 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.TimeExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.TimeExtensionAppender;
+
+@Component
+public class TimeExtensionHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final TimeExtensionAppender timeExtensionAppender;
+
+    public TimeExtensionHandler(
+        TimeExtensionAppender timeExtensionAppender
+    ) {
+        this.timeExtensionAppender = timeExtensionAppender;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return
+            callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+            && Arrays.asList(
+                Event.SUBMIT_TIME_EXTENSION
+            ).contains(callback.getEvent());
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        String submitTimeExtensionReason =
+            asylumCase
+                .read(SUBMIT_TIME_EXTENSION_REASON, String.class)
+                .orElseThrow(() -> new IllegalStateException("timeExtensionReason is not present"));
+
+        Optional<List<IdValue<Document>>> submitTimeExtensionEvidence =
+            asylumCase
+                .read(SUBMIT_TIME_EXTENSION_EVIDENCE);
+
+        final State caseState =
+            callback
+                .getCaseDetails()
+                .getState();
+
+        Optional<List<IdValue<TimeExtension>>> maybeTimeExtensions =
+            asylumCase.read(TIME_EXTENSIONS);
+
+        final List<IdValue<TimeExtension>> existingTimeExtensions =
+            maybeTimeExtensions.orElse(emptyList());
+
+        List<IdValue<TimeExtension>> allTimeExtensions =
+            timeExtensionAppender.append(
+                existingTimeExtensions,
+                caseState,
+                submitTimeExtensionReason,
+                submitTimeExtensionEvidence.orElse(emptyList())
+            );
+
+        asylumCase.write(TIME_EXTENSIONS, allTimeExtensions);
+
+        asylumCase.clear(SUBMIT_TIME_EXTENSION_REASON);
+        asylumCase.clear(SUBMIT_TIME_EXTENSION_EVIDENCE);
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/TimeExtensionAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/TimeExtensionAppender.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.service;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.TimeExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.TimeExtensionStatus;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+
+@Service
+public class TimeExtensionAppender {
+
+    private final DateProvider dateProvider;
+
+    public TimeExtensionAppender(
+        DateProvider dateProvider
+    ) {
+        this.dateProvider = dateProvider;
+    }
+
+    public List<IdValue<TimeExtension>> append(
+        List<IdValue<TimeExtension>> existingTimeExtensions,
+        State state,
+        String reason,
+        List<IdValue<Document>> evidence
+    ) {
+        requireNonNull(existingTimeExtensions, "existingTimeExtension must not be null");
+        requireNonNull(state, "state must not be null");
+        requireNonNull(reason, "reason must not be null");
+
+        final TimeExtension newTimeExtension = new TimeExtension(
+            dateProvider.now().toString(),
+            reason,
+            state,
+            TimeExtensionStatus.SUBMITTED,
+            evidence
+        );
+
+        final List<IdValue<TimeExtension>> allTimeExtension = new ArrayList<>();
+
+        int index = existingTimeExtensions.size() + 1;
+
+        allTimeExtension.add(new IdValue<>(String.valueOf(index--), newTimeExtension));
+
+        for (IdValue<TimeExtension> existingTimeExtension : existingTimeExtensions) {
+            allTimeExtension.add(new IdValue<>(String.valueOf(index--), existingTimeExtension.getValue()));
+        }
+
+        return allTimeExtension;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
@@ -70,7 +70,8 @@ public class SendNotificationHandlerTest {
             Event.CHANGE_HEARING_CENTRE,
             Event.APPLY_FOR_FTPA_APPELLANT,
             Event.APPLY_FOR_FTPA_RESPONDENT,
-            Event.SUBMIT_TIME_EXTENSION
+            Event.SUBMIT_TIME_EXTENSION,
+            Event.REVIEW_TIME_EXTENSION
         ).forEach(event -> {
 
             AsylumCase expectedUpdatedCase = mock(AsylumCase.class);
@@ -178,7 +179,8 @@ public class SendNotificationHandlerTest {
                         Event.CHANGE_HEARING_CENTRE,
                         Event.APPLY_FOR_FTPA_APPELLANT,
                         Event.APPLY_FOR_FTPA_RESPONDENT,
-                        Event.SUBMIT_TIME_EXTENSION
+                        Event.SUBMIT_TIME_EXTENSION,
+                        Event.REVIEW_TIME_EXTENSION
                     ).contains(event)) {
 
                     assertTrue(canHandle);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TimeExtensionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TimeExtensionHandlerTest.java
@@ -1,0 +1,169 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.util.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.TimeExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.TimeExtensionAppender;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("unchecked")
+public class TimeExtensionHandlerTest {
+
+    @Mock private TimeExtensionAppender timeExtensionAppender;
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+
+    @Captor private ArgumentCaptor<List<IdValue<TimeExtension>>> existingTimeExtensionsCaptor;
+
+    private TimeExtensionHandler timeExtensionHandler;
+
+    @Before
+    public void setUp() {
+        timeExtensionHandler =
+            new TimeExtensionHandler(timeExtensionAppender);
+    }
+
+    @Test
+    public void should_append_new_timeExtension_to_existing_timeExtensions_for_the_case() {
+
+        final List<IdValue<TimeExtension>> existingTimeExtensions = new ArrayList<>();
+        final List<IdValue<TimeExtension>> allTimeExtensions = new ArrayList<>();
+
+        final String newTimeExtensionReason = "I requested more time because..";
+        List<IdValue<Document>> newTimeExtensionEvidence = Collections.emptyList();
+
+        final Event event = Event.SUBMIT_TIME_EXTENSION;
+        final State caseState = State.AWAITING_REASONS_FOR_APPEAL;
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetails().getState()).thenReturn(caseState);
+        when(callback.getEvent()).thenReturn(event);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(TIME_EXTENSIONS)).thenReturn(Optional.of(existingTimeExtensions));
+        when(asylumCase.read(SUBMIT_TIME_EXTENSION_REASON, String.class)).thenReturn(Optional.of(newTimeExtensionReason));
+        when(asylumCase.read(SUBMIT_TIME_EXTENSION_EVIDENCE)).thenReturn(Optional.of(newTimeExtensionEvidence));
+
+        when(timeExtensionAppender.append(
+            existingTimeExtensions,
+            caseState,
+            newTimeExtensionReason,
+            newTimeExtensionEvidence
+        )).thenReturn(allTimeExtensions);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            timeExtensionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).read(SUBMIT_TIME_EXTENSION_REASON, String.class);
+        verify(asylumCase, times(1)).read(SUBMIT_TIME_EXTENSION_EVIDENCE);
+
+        verify(timeExtensionAppender, times(1)).append(
+            existingTimeExtensions,
+            caseState,
+            newTimeExtensionReason,
+            newTimeExtensionEvidence
+        );
+
+        verify(asylumCase, times(1)).write(TIME_EXTENSIONS, allTimeExtensions);
+
+        verify(asylumCase, times(1)).clear(SUBMIT_TIME_EXTENSION_REASON);
+        verify(asylumCase, times(1)).clear(SUBMIT_TIME_EXTENSION_EVIDENCE);
+    }
+
+    @Test
+    public void should_throw_when_submit_timeExtension_reason_is_not_present() {
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_TIME_EXTENSION);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        when(asylumCase.read(SUBMIT_TIME_EXTENSION_REASON, String.class)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> timeExtensionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("timeExtensionReason is not present")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> timeExtensionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        assertThatThrownBy(() -> timeExtensionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = timeExtensionHandler.canHandle(callbackStage, callback);
+
+                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                    &&
+                    Arrays.asList(
+                        Event.SUBMIT_TIME_EXTENSION
+                    ).contains(event)) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> timeExtensionHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> timeExtensionHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> timeExtensionHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> timeExtensionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/TimeExtensionAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/TimeExtensionAppenderTest.java
@@ -1,0 +1,148 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.service;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.TimeExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.TimeExtensionStatus;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("unchecked")
+public class TimeExtensionAppenderTest {
+
+    @Mock private DateProvider dateProvider;
+    @Mock private IdValue<TimeExtension> existingTimeExtensionById1;
+    @Mock private IdValue<TimeExtension> existingTimeExtensionById2;
+    private String newTimeExtensionReason = "New direction";
+    private State caseState = State.AWAITING_REASONS_FOR_APPEAL;
+    private List<IdValue<Document>> newTimeExtensionEvidence = Collections.emptyList();
+    private String expectedDateRequested = LocalDate.MAX.toString();
+
+    private TimeExtensionAppender timeExtensionAppender;
+
+    @Before
+    public void setUp() {
+        timeExtensionAppender = new TimeExtensionAppender(dateProvider);
+    }
+
+    @Test
+    public void should_append_new_time_extension_in_first_position() {
+
+        when(dateProvider.now()).thenReturn(LocalDate.MAX);
+
+        TimeExtension existingTimeExtension1 = mock(TimeExtension.class);
+        when(existingTimeExtensionById1.getValue()).thenReturn(existingTimeExtension1);
+
+        TimeExtension existingTimeExtension2 = mock(TimeExtension.class);
+        when(existingTimeExtensionById2.getValue()).thenReturn(existingTimeExtension2);
+
+        List<IdValue<TimeExtension>> existingTimeExtensions =
+            asList(existingTimeExtensionById1, existingTimeExtensionById2);
+
+        List<IdValue<TimeExtension>> allTimeExtensions =
+            timeExtensionAppender.append(
+                existingTimeExtensions,
+                caseState,
+                newTimeExtensionReason,
+                newTimeExtensionEvidence
+            );
+
+        verify(existingTimeExtensionById1, never()).getId();
+        verify(existingTimeExtensionById2, never()).getId();
+
+        assertNotNull(allTimeExtensions);
+        assertEquals(3, allTimeExtensions.size());
+
+        assertEquals("3", allTimeExtensions.get(0).getId());
+        assertEquals(newTimeExtensionReason, allTimeExtensions.get(0).getValue().getReason());
+        assertEquals(newTimeExtensionEvidence, allTimeExtensions.get(0).getValue().getEvidence());
+        assertEquals(expectedDateRequested, allTimeExtensions.get(0).getValue().getRequestDate());
+        assertEquals(caseState, allTimeExtensions.get(0).getValue().getState());
+        assertEquals(TimeExtensionStatus.SUBMITTED, allTimeExtensions.get(0).getValue().getStatus());
+
+        assertEquals("2", allTimeExtensions.get(1).getId());
+        assertEquals(existingTimeExtension1, allTimeExtensions.get(1).getValue());
+
+        assertEquals("1", allTimeExtensions.get(2).getId());
+        assertEquals(existingTimeExtension2, allTimeExtensions.get(2).getValue());
+    }
+
+    @Test
+    public void should_return_new_documents_if_no_existing_documents_present() {
+
+        when(dateProvider.now()).thenReturn(LocalDate.MAX);
+
+        List<IdValue<TimeExtension>> existingTimeExtensions = Collections.emptyList();
+
+
+        List<IdValue<TimeExtension>> allTimeExtensions =
+            timeExtensionAppender.append(
+                existingTimeExtensions,
+                caseState,
+                newTimeExtensionReason,
+                newTimeExtensionEvidence
+            );
+
+        assertNotNull(allTimeExtensions);
+        assertEquals(1, allTimeExtensions.size());
+
+        assertEquals("1", allTimeExtensions.get(0).getId());
+        assertEquals(newTimeExtensionReason, allTimeExtensions.get(0).getValue().getReason());
+        assertEquals(newTimeExtensionEvidence, allTimeExtensions.get(0).getValue().getEvidence());
+        assertEquals(expectedDateRequested, allTimeExtensions.get(0).getValue().getRequestDate());
+        assertEquals(caseState, allTimeExtensions.get(0).getValue().getState());
+        assertEquals(TimeExtensionStatus.SUBMITTED, allTimeExtensions.get(0).getValue().getStatus());
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+
+        List<IdValue<TimeExtension>> existingTimeExtensions =
+            asList(existingTimeExtensionById1);
+
+        assertThatThrownBy(() ->
+            timeExtensionAppender.append(
+                null,
+                caseState,
+                newTimeExtensionReason,
+                newTimeExtensionEvidence
+            ))
+            .hasMessage("existingTimeExtension must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() ->
+            timeExtensionAppender.append(
+                existingTimeExtensions,
+                null,
+                newTimeExtensionReason,
+                newTimeExtensionEvidence
+            ))
+            .hasMessage("state must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() ->
+            timeExtensionAppender.append(
+                existingTimeExtensions,
+                caseState,
+                null,
+                newTimeExtensionEvidence
+            ))
+            .hasMessage("reason must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2873

### Change description ###

Enables `reviewTimeExtension` to be forwarded to the notifications service
Added time extension appender to handle time extensions on submission.
Added time extension handler

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
