### PR TITLE
RIA-2976 & RIA-3153 & RIA-3157: Time Extensions for CMARequirements & Clarifying Questions

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-2829-ReviewTimeExtension-clarifying-questions.json
+++ b/src/functionalTest/resources/scenarios/RIA-2829-ReviewTimeExtension-clarifying-questions.json
@@ -1,0 +1,102 @@
+{
+  "description": "RIA-2829: [Clarifying questions] - Case officer can review a time extension request",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 1122,
+      "eventId": "reviewTimeExtension",
+      "state": "awaitingClarifyingQuestionsAnswers",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json",
+        "replacements": {
+          "directions": [
+            {
+              "id": "1",
+              "value": {
+                "explanation": "You need to answer some questions about your appeal.",
+                "parties": "appellant",
+                "dateDue": "{$TODAY+14}",
+                "dateSent": "{$TODAY}",
+                "tag": "requestClarifyingQuestions",
+                "previousDates": [],
+                "clarifyingQuestions": [
+                  {
+                    "id": "1",
+                    "value": {
+                      "question": "Question 1"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "timeExtensions": [
+            {
+              "id": "1",
+              "value": {
+                "requestDate": "{$TODAY}",
+                "reason": "time extension reason",
+                "state": "awaitingClarifyingQuestionsAnswers",
+                "status": "submitted",
+                "evidence": []
+              }
+            }
+          ],
+          "reviewTimeExtensionRequired": "Yes",
+          "reviewTimeExtensionDecision": "granted",
+          "reviewTimeExtensionDecisionReason": "decision reason",
+          "reviewTimeExtensionDueDate": "{$TODAY+14}"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json",
+      "replacements": {
+        "directions": [
+          {
+            "id": "1",
+            "value": {
+              "explanation": "You need to answer some questions about your appeal.",
+              "parties": "appellant",
+              "dateDue": "{$TODAY+14}",
+              "dateSent": "{$TODAY}",
+              "tag": "requestClarifyingQuestions",
+              "previousDates": [],
+              "clarifyingQuestions": [
+                {
+                  "id": "1",
+                  "value": {
+                    "question": "Question 1"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "timeExtensions": [
+          {
+            "id": "1",
+            "value": {
+              "requestDate": "{$TODAY}",
+              "reason": "time extension reason",
+              "state": "awaitingClarifyingQuestionsAnswers",
+              "status": "granted",
+              "decision": "granted",
+              "decisionReason": "decision reason",
+              "evidence": [],
+              "decisionOutcomeDate": "{$TODAY+14}"
+            }
+          }
+        ],
+        "reviewTimeExtensionRequired": "No",
+        "sendDirectionActionAvailable": "No"
+      }
+    }
+  }
+}
+

--- a/src/functionalTest/resources/scenarios/RIA-2829-ReviewTimeExtension-cma-requirements.json
+++ b/src/functionalTest/resources/scenarios/RIA-2829-ReviewTimeExtension-cma-requirements.json
@@ -1,0 +1,86 @@
+{
+  "description": "RIA-2829: [Cma Requirements] - Case officer can review a time extension request",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 1122,
+      "eventId": "reviewTimeExtension",
+      "state": "awaitingCmaRequirements",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json",
+        "replacements": {
+          "directions": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "requestCmaRequirements",
+                "parties": "appellant",
+                "dateDue": "{$TODAY}",
+                "dateSent": "{$TODAY}",
+                "explanation": "You must now tell us why you think the Home Office decision to refuse your claim is wrong.",
+                "previousDates": []
+              }
+            }
+          ],
+          "timeExtensions": [
+            {
+              "id": "1",
+              "value": {
+                "requestDate": "{$TODAY}",
+                "reason": "time extension reason",
+                "state": "awaitingCmaRequirements",
+                "status": "submitted",
+                "evidence": []
+              }
+            }
+          ],
+          "reviewTimeExtensionRequired": "Yes",
+          "reviewTimeExtensionDecision": "granted",
+          "reviewTimeExtensionDecisionReason": "decision reason",
+          "reviewTimeExtensionDueDate": "{$TODAY+14}"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json",
+      "replacements": {
+        "directions": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "requestCmaRequirements",
+              "parties": "appellant",
+              "dateDue": "{$TODAY+14}",
+              "dateSent": "{$TODAY}",
+              "explanation": "You must now tell us why you think the Home Office decision to refuse your claim is wrong.",
+              "previousDates": []
+            }
+          }
+        ],
+        "timeExtensions": [
+          {
+            "id": "1",
+            "value": {
+              "requestDate": "{$TODAY}",
+              "reason": "time extension reason",
+              "state": "awaitingCmaRequirements",
+              "status": "granted",
+              "decision": "granted",
+              "decisionReason": "decision reason",
+              "evidence": [],
+              "decisionOutcomeDate": "{$TODAY+14}"
+            }
+          }
+        ],
+        "reviewTimeExtensionRequired": "No",
+        "sendDirectionActionAvailable": "No"
+      }
+    }
+  }
+}
+

--- a/src/functionalTest/resources/scenarios/RIA-2829-ReviewTimeExtension-reasons-for-appeal.json
+++ b/src/functionalTest/resources/scenarios/RIA-2829-ReviewTimeExtension-reasons-for-appeal.json
@@ -1,0 +1,86 @@
+{
+  "description": "RIA-2829: [Reasons for appeal] - Case officer can review a time extension request",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 1122,
+      "eventId": "reviewTimeExtension",
+      "state": "awaitingReasonsForAppeal",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json",
+        "replacements": {
+          "directions": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "requestReasonsForAppeal",
+                "parties": "appellant",
+                "dateDue": "{$TODAY}",
+                "dateSent": "{$TODAY}",
+                "explanation": "You must now tell us why you think the Home Office decision to refuse your claim is wrong.",
+                "previousDates": []
+              }
+            }
+          ],
+          "timeExtensions": [
+            {
+              "id": "1",
+              "value": {
+                "requestDate": "{$TODAY}",
+                "reason": "time extension reason",
+                "state": "awaitingReasonsForAppeal",
+                "status": "submitted",
+                "evidence": []
+              }
+            }
+          ],
+          "reviewTimeExtensionRequired": "Yes",
+          "reviewTimeExtensionDecision": "granted",
+          "reviewTimeExtensionDecisionReason": "decision reason",
+          "reviewTimeExtensionDueDate": "{$TODAY+14}"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json",
+      "replacements": {
+        "directions": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "requestReasonsForAppeal",
+              "parties": "appellant",
+              "dateDue": "{$TODAY+14}",
+              "dateSent": "{$TODAY}",
+              "explanation": "You must now tell us why you think the Home Office decision to refuse your claim is wrong.",
+              "previousDates": []
+            }
+          }
+        ],
+        "timeExtensions": [
+          {
+            "id": "1",
+            "value": {
+              "requestDate": "{$TODAY}",
+              "reason": "time extension reason",
+              "state": "awaitingReasonsForAppeal",
+              "status": "granted",
+              "decision": "granted",
+              "decisionReason": "decision reason",
+              "evidence": [],
+              "decisionOutcomeDate": "{$TODAY+14}"
+            }
+          }
+        ],
+        "reviewTimeExtensionRequired": "No",
+        "sendDirectionActionAvailable": "No"
+      }
+    }
+  }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewTimeExtensionsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewTimeExtensionsHandler.java
@@ -53,8 +53,8 @@ public class ReviewTimeExtensionsHandler implements PreSubmitCallbackHandler<Asy
         State currentCaseState = callback.getCaseDetails().getState();
 
         DirectionTag directionTagToLookFor = stateToDirectionTag(currentCaseState);
-        List<IdValue<Direction>> maybeDirections = getDirections(asylumCase);
-        Optional<IdValue<Direction>> directionBeingUpdated = maybeDirections
+        List<IdValue<Direction>> directions = getDirections(asylumCase);
+        Optional<IdValue<Direction>> directionBeingUpdated = directions
             .stream()
             .filter(directionIdVale -> directionIdVale.getValue().getTag().equals(directionTagToLookFor))
             .findFirst();
@@ -98,7 +98,7 @@ public class ReviewTimeExtensionsHandler implements PreSubmitCallbackHandler<Asy
         }).collect(Collectors.toList());
 
         List<IdValue<Direction>> changedDirections =
-            maybeDirections
+            directions
                 .stream()
                 .map(idValue -> {
                     if (directionBeingUpdated.isPresent() && directionBeingUpdated.get().getId().equals(idValue.getId())) {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewTimeExtensionsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewTimeExtensionsHandler.java
@@ -110,7 +110,8 @@ public class ReviewTimeExtensionsHandler implements PreSubmitCallbackHandler<Asy
                                 updatedDecisionDueDate,
                                 idValue.getValue().getDateSent(),
                                 idValue.getValue().getTag(),
-                                DateAppender.appendPreviousDates(idValue.getValue().getPreviousDates(), idValue.getValue().getDateDue(), idValue.getValue().getDateSent())
+                                DateAppender.appendPreviousDates(idValue.getValue().getPreviousDates(), idValue.getValue().getDateDue(), idValue.getValue().getDateSent()),
+                                idValue.getValue().getClarifyingQuestions()
                             )
                         );
                     } else {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewTimeExtensionsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewTimeExtensionsHandler.java
@@ -50,11 +50,14 @@ public class ReviewTimeExtensionsHandler implements PreSubmitCallbackHandler<Asy
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
         String decisionOutcomeDueDate = getTimeExtensionDueDate(asylumCase);
 
-        Optional<List<IdValue<Direction>>> maybeDirections = asylumCase.read(DIRECTIONS);
-        Optional<IdValue<Direction>> directionBeingUpdated = maybeDirections.orElse(emptyList())
-            .stream()
-            .filter(directionIdVale -> directionIdVale.getValue().getTag().equals(DirectionTag.REQUEST_REASONS_FOR_APPEAL)).findFirst();
+        State currentCaseState = callback.getCaseDetails().getState();
 
+        DirectionTag directionTagToLookFor = stateToDirectionTag(currentCaseState);
+        List<IdValue<Direction>> maybeDirections = getDirections(asylumCase);
+        Optional<IdValue<Direction>> directionBeingUpdated = maybeDirections
+            .stream()
+            .filter(directionIdVale -> directionIdVale.getValue().getTag().equals(directionTagToLookFor))
+            .findFirst();
 
         String currentDueDate = getDirectionDueDate(directionBeingUpdated);
 
@@ -95,7 +98,7 @@ public class ReviewTimeExtensionsHandler implements PreSubmitCallbackHandler<Asy
         }).collect(Collectors.toList());
 
         List<IdValue<Direction>> changedDirections =
-            maybeDirections.orElse(emptyList())
+            maybeDirections
                 .stream()
                 .map(idValue -> {
                     if (directionBeingUpdated.isPresent() && directionBeingUpdated.get().getId().equals(idValue.getId())) {
@@ -124,6 +127,20 @@ public class ReviewTimeExtensionsHandler implements PreSubmitCallbackHandler<Asy
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 
+    private DirectionTag stateToDirectionTag(State currentCaseState) {
+
+        switch (currentCaseState) {
+            case AWAITING_REASONS_FOR_APPEAL:
+                return DirectionTag.REQUEST_REASONS_FOR_APPEAL;
+            case AWAITING_CLARIFYING_QUESTIONS_ANSWERS:
+                return DirectionTag.REQUEST_CLARIFYING_QUESTIONS;
+            case AWAITING_CMA_REQUIREMENTS:
+                return DirectionTag.REQUEST_CMA_REQUIREMENTS;
+            default:
+                throw new IllegalArgumentException("Cannot map " + currentCaseState + " to a direction tag");
+        }
+    }
+
     private TimeExtensionDecision getTimeExtensionDecision(AsylumCase asylumCase) {
         Optional<TimeExtensionDecision> read = asylumCase.read(REVIEW_TIME_EXTENSION_DECISION);
         return read.orElseThrow(() -> new IllegalArgumentException("Cannot handle " + Event.REVIEW_TIME_EXTENSION + " without a decision"));
@@ -146,9 +163,13 @@ public class ReviewTimeExtensionsHandler implements PreSubmitCallbackHandler<Asy
         return read.orElse(null);
     }
 
-
     private Stream<IdValue<TimeExtension>> getTimeExtensions(AsylumCase asylumCase) {
         return asylumCase.<List<IdValue<TimeExtension>>>read(TIME_EXTENSIONS)
             .orElse(emptyList()).stream();
+    }
+
+    private List<IdValue<Direction>> getDirections(AsylumCase asylumCase) {
+        return asylumCase.<List<IdValue<Direction>>>read(DIRECTIONS)
+            .orElse(emptyList());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -74,7 +74,8 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
                    Event.APPLY_FOR_FTPA_APPELLANT,
                    Event.APPLY_FOR_FTPA_RESPONDENT,
                    Event.SUBMIT_TIME_EXTENSION,
-                   Event.SEND_DIRECTION_WITH_QUESTIONS
+                   Event.SEND_DIRECTION_WITH_QUESTIONS,
+                   Event.SUBMIT_CLARIFYING_QUESTION_ANSWERS
                ).contains(callback.getEvent());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -73,7 +73,8 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
                    Event.CHANGE_HEARING_CENTRE,
                    Event.APPLY_FOR_FTPA_APPELLANT,
                    Event.APPLY_FOR_FTPA_RESPONDENT,
-                   Event.SUBMIT_TIME_EXTENSION
+                   Event.SUBMIT_TIME_EXTENSION,
+                   Event.SEND_DIRECTION_WITH_QUESTIONS
                ).contains(callback.getEvent());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
@@ -70,7 +70,8 @@ public class SendNotificationHandlerTest {
             Event.CHANGE_HEARING_CENTRE,
             Event.APPLY_FOR_FTPA_APPELLANT,
             Event.APPLY_FOR_FTPA_RESPONDENT,
-            Event.SUBMIT_TIME_EXTENSION
+            Event.SUBMIT_TIME_EXTENSION,
+            Event.SEND_DIRECTION_WITH_QUESTIONS
         ).forEach(event -> {
 
             AsylumCase expectedUpdatedCase = mock(AsylumCase.class);
@@ -178,7 +179,8 @@ public class SendNotificationHandlerTest {
                         Event.CHANGE_HEARING_CENTRE,
                         Event.APPLY_FOR_FTPA_APPELLANT,
                         Event.APPLY_FOR_FTPA_RESPONDENT,
-                        Event.SUBMIT_TIME_EXTENSION
+                        Event.SUBMIT_TIME_EXTENSION,
+                        Event.SEND_DIRECTION_WITH_QUESTIONS
                     ).contains(event)) {
 
                     assertTrue(canHandle);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
@@ -71,7 +71,8 @@ public class SendNotificationHandlerTest {
             Event.APPLY_FOR_FTPA_APPELLANT,
             Event.APPLY_FOR_FTPA_RESPONDENT,
             Event.SUBMIT_TIME_EXTENSION,
-            Event.SEND_DIRECTION_WITH_QUESTIONS
+            Event.SEND_DIRECTION_WITH_QUESTIONS,
+            Event.SUBMIT_CLARIFYING_QUESTION_ANSWERS
         ).forEach(event -> {
 
             AsylumCase expectedUpdatedCase = mock(AsylumCase.class);
@@ -180,7 +181,8 @@ public class SendNotificationHandlerTest {
                         Event.APPLY_FOR_FTPA_APPELLANT,
                         Event.APPLY_FOR_FTPA_RESPONDENT,
                         Event.SUBMIT_TIME_EXTENSION,
-                        Event.SEND_DIRECTION_WITH_QUESTIONS
+                        Event.SEND_DIRECTION_WITH_QUESTIONS,
+                        Event.SUBMIT_CLARIFYING_QUESTION_ANSWERS
                     ).contains(event)) {
 
                     assertTrue(canHandle);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2976
https://tools.hmcts.net/jira/browse/RIA-3153
https://tools.hmcts.net/jira/browse/RIA-3157

### Change description ###
Extends the review time extension handler to work with any state defined on the stateToDirectionTag method.

Added functional tests and unit tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
