### PR TITLE
RIA-3144 Appellant documents on Documents tab

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -33,6 +33,8 @@ def secrets = [
         secret('test-judge-x-password', 'TEST_JUDGE_X_PASSWORD'),
         secret('test-law-firm-share-case-a-username', 'TEST_LAW_FIRM_SHARE_CASE_A_USERNAME'),
         secret('test-law-firm-share-case-a-password', 'TEST_LAW_FIRM_SHARE_CASE_A_PASSWORD'),
+        secret('test-citizen-username', 'TEST_CITIZEN_USERNAME'),
+        secret('test-citizen-password', 'TEST_CITIZEN_PASSWORD'),
 
         secret('idam-client-id', 'IA_IDAM_CLIENT_ID'),
         secret('idam-secret', 'IA_IDAM_SECRET'),

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -37,6 +37,8 @@ def secrets = [
         secret('test-homeoffice-generic-password', 'TEST_HOMEOFFICE_GENERIC_PASSWORD'),
         secret('test-judge-x-username', 'TEST_JUDGE_X_USERNAME'),
         secret('test-judge-x-password', 'TEST_JUDGE_X_PASSWORD'),
+        secret('test-citizen-username', 'TEST_CITIZEN_USERNAME'),
+        secret('test-citizen-password', 'TEST_CITIZEN_PASSWORD'),
 
         secret('test-law-firm-share-case-a-username', 'TEST_LAW_FIRM_SHARE_CASE_A_USERNAME'),
         secret('test-law-firm-share-case-a-password', 'TEST_LAW_FIRM_SHARE_CASE_A_PASSWORD'),

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -33,6 +33,8 @@ def secrets = [
         secret('test-homeoffice-generic-password', 'TEST_HOMEOFFICE_GENERIC_PASSWORD'),
         secret('test-judge-x-username', 'TEST_JUDGE_X_USERNAME'),
         secret('test-judge-x-password', 'TEST_JUDGE_X_PASSWORD'),
+        secret('test-citizen-username', 'TEST_CITIZEN_USERNAME'),
+        secret('test-citizen-password', 'TEST_CITIZEN_PASSWORD'),
 
         secret('test-law-firm-share-case-a-username', 'TEST_LAW_FIRM_SHARE_CASE_A_USERNAME'),
         secret('test-law-firm-share-case-a-password', 'TEST_LAW_FIRM_SHARE_CASE_A_PASSWORD'),
@@ -77,7 +79,7 @@ withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, params.E
     env.DM_URL = "http://dm-store-aat.service.core-compute-aat.internal"
     env.IDAM_URL = "https://idam-api.aat.platform.hmcts.net"
     env.S2S_URL = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-    
+
     loadVaultSecrets(secrets)
 
     after('functionalTest:preview') {

--- a/build.gradle
+++ b/build.gradle
@@ -256,17 +256,17 @@ dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: versions.springHystrix
     compile group: 'org.springframework.retry', name: 'spring-retry', version: '1.2.1.RELEASE'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-cache', version: versions.springBoot
-    
+
     compile('org.apache.logging.log4j:log4j-to-slf4j:2.13.2') {
         force = true
         because 'CVE-2020-9488, CVE-2020-9488'
     }
-    
+
     compile('org.apache.logging.log4j:log4j-api:2.13.2') {
         force = true
         because 'CVE-2020-9488, CVE-2020-9488'
     }
-    
+
     compile group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.5.6'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.0.pr3'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.0.pr3'
@@ -276,7 +276,7 @@ dependencies {
     compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
     compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
     compile group: 'org.flywaydb', name: 'flyway-core', version: '5.2.4'
-    compile group: 'org.postgresql', name: 'postgresql', version: '42.2.5'
+    compile group: 'org.postgresql', name: 'postgresql', version: '42.2.13'
 
     compile group: 'uk.gov.hmcts.reform', name: 'logging-spring', version: versions.reformLogging
     compile group: 'uk.gov.hmcts.reform', name: 'logging-httpcomponents', version: versions.reformLogging

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/CcdScenarioRunnerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/CcdScenarioRunnerTest.java
@@ -347,6 +347,11 @@ public class CcdScenarioRunnerTest {
                 .getJudgeAuthorization();
         }
 
+        if ("Citizen".equalsIgnoreCase(credentials)) {
+            return authorizationHeadersProvider
+                    .getCitizenAuthorization();
+        }
+
         return new Headers();
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/util/AuthorizationHeadersProvider.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/util/AuthorizationHeadersProvider.java
@@ -142,4 +142,16 @@ public class AuthorizationHeadersProvider {
         );
     }
 
+    public Headers getCitizenAuthorization() {
+        String serviceToken = serviceAuthTokenGenerator.generate();
+        String accessToken = idamAuthorizor.exchangeForAccessToken(
+                System.getenv("TEST_CITIZEN_USERNAME"),
+                System.getenv("TEST_CITIZEN_PASSWORD")
+        );
+
+        return new Headers(
+                new Header("ServiceAuthorization", serviceToken),
+                new Header("Authorization", accessToken)
+        );
+    }
 }

--- a/src/functionalTest/resources/scenarios/RIA-3144-SetupAppellantDocuments.json
+++ b/src/functionalTest/resources/scenarios/RIA-3144-SetupAppellantDocuments.json
@@ -1,0 +1,130 @@
+{
+  "description": "RIA-3017: Case officer can ask appellant to provide CMA requirements",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Citizen",
+    "input": {
+      "id": 1122,
+      "eventId": "submitClarifyingQuestionAnswers",
+      "state": "awaitingClarifyingQuestionsAnswers",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json",
+        "replacements": {
+          "reasonsForAppealDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "document": {
+                  "document_url": "http://document-store/BBB",
+                  "document_binary_url": "http://document-store/BBB/binary",
+                  "document_filename": "some-case-argument-evidence.pdf"
+                },
+                "dateUploaded": "2020-01-01",
+                "tag": "additionalEvidence",
+                "description": "Some case argument evidence"
+              }
+            }
+          ],
+          "clarifyingQuestionsAnswers": [
+            {
+              "id": "608e6eba-a8d6-4c3a-b95f-53e1cd7e7407",
+              "value": {
+                "answer": "answer1",
+                "dueDate": "2020-06-25",
+                "dateSent": "2020-05-28",
+                "question": "A question",
+                "dateResponded": "2020-05-28",
+                "supportingEvidence": [
+                  {
+                    "id": "8d6c15e0-37e1-4af9-ac4f-cbe9349c7c39",
+                    "value": {
+                      "document_url": "http://dm-store:4506/documents/0f8f7f89-311c-43f9-b7f2-c8c861a448ae",
+                      "document_filename": "Screenshot 2020-05-20 at 14.42.55.png",
+                      "document_binary_url": "http://dm-store:4506/documents/0f8f7f89-311c-43f9-b7f2-c8c861a448ae/binary"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json",
+      "replacements": {
+        "reasonsForAppealDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "http://document-store/BBB",
+                "document_binary_url": "http://document-store/BBB/binary",
+                "document_filename": "some-case-argument-evidence.pdf"
+              },
+              "dateUploaded": "2020-01-01",
+              "tag": "additionalEvidence",
+              "description": "Some case argument evidence"
+            }
+          }
+        ],
+        "clarifyingQuestionsAnswers": [
+          {
+            "id": "608e6eba-a8d6-4c3a-b95f-53e1cd7e7407",
+            "value": {
+              "answer": "answer1",
+              "dueDate": "2020-06-25",
+              "dateSent": "2020-05-28",
+              "question": "A question",
+              "dateResponded": "2020-05-28",
+              "supportingEvidence": [
+                {
+                  "id": "8d6c15e0-37e1-4af9-ac4f-cbe9349c7c39",
+                  "value": {
+                    "document_url": "http://dm-store:4506/documents/0f8f7f89-311c-43f9-b7f2-c8c861a448ae",
+                    "document_filename": "Screenshot 2020-05-20 at 14.42.55.png",
+                    "document_binary_url": "http://dm-store:4506/documents/0f8f7f89-311c-43f9-b7f2-c8c861a448ae/binary"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "appellantDocuments": [
+          {
+            "id": "2",
+            "value": {
+              "document": {
+                "document_url": "http://document-store/BBB",
+                "document_binary_url": "http://document-store/BBB/binary",
+                "document_filename": "some-case-argument-evidence.pdf"
+              },
+              "dateUploaded": "2020-01-01",
+              "tag": "additionalEvidence",
+              "description": "Some case argument evidence"
+            }
+          },
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "http://dm-store:4506/documents/0f8f7f89-311c-43f9-b7f2-c8c861a448ae",
+                "document_filename": "Screenshot 2020-05-20 at 14.42.55.png",
+                "document_binary_url": "http://dm-store:4506/documents/0f8f7f89-311c-43f9-b7f2-c8c861a448ae/binary"
+              },
+              "dateUploaded": "2020-05-28",
+              "tag": "additionalEvidence",
+              "description": "Clarifying question evidence"
+            }
+          }
+        ],
+        "sendDirectionActionAvailable": "No"
+      }
+    }
+  }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -718,7 +718,12 @@ public enum AsylumCaseFieldDefinition {
         "removeFlagTypeOfFlag", new TypeReference<DynamicList>() {}),
     REQUEST_CMA_REQUIREMENTS_REASONS(
             "requestCmaRequirementsReasons", new TypeReference<String>() {}),
-
+    APPELLANT_DOCUMENTS(
+            "appellantDocuments", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
+    REASONS_FOR_APPEAL_DOCUMENTS(
+            "reasonsForAppealDocuments", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
+    CLARIFYING_QUESTIONS_ANSWERS("clarifyingQuestionsAnswers",
+            new TypeReference<List<IdValue<ClarifyingQuestionAnswer>>>() {}),
     REASON_TO_FORCE_CASE_TO_CASE_UNDER_REVIEW(
         "reasonToForceCaseToCaseUnderReview", new TypeReference<String>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ClarifyingQuestionAnswer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ClarifyingQuestionAnswer.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+
+@EqualsAndHashCode
+@ToString
+public class ClarifyingQuestionAnswer {
+    private String dateSent;
+    private String dueDate;
+    private String dateResponded;
+    private String question;
+    private String answer;
+    private List<IdValue<Document>> supportingEvidence;
+
+    private ClarifyingQuestionAnswer() {
+    }
+
+    public ClarifyingQuestionAnswer(String dateSent, String dueDate, String dateResponded, String question, String answer, List<IdValue<Document>> supportingEvidence) {
+        this.dateSent = dateSent;
+        this.dueDate = dueDate;
+        this.dateResponded = dateResponded;
+        this.question = question;
+        this.answer = answer;
+        this.supportingEvidence = supportingEvidence;
+    }
+
+    public String getDateSent() {
+        return dateSent;
+    }
+
+    public String getDueDate() {
+        return dueDate;
+    }
+
+    public String getDateResponded() {
+        return dateResponded;
+    }
+
+    public String getQuestion() {
+        return question;
+    }
+
+    public String getAnswer() {
+        return answer;
+    }
+
+    public List<IdValue<Document>> getSupportingEvidence() {
+        return supportingEvidence;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AddAppellantDocumentsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AddAppellantDocumentsHandler.java
@@ -1,0 +1,107 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Stream.concat;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ClarifyingQuestionAnswer;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.DocumentsAppender;
+
+@Component
+public class AddAppellantDocumentsHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final DocumentsAppender documentsAppender;
+
+    public AddAppellantDocumentsHandler(DocumentsAppender documentsAppender) {
+        this.documentsAppender = documentsAppender;
+    }
+
+    @Override
+    public DispatchPriority getDispatchPriority() {
+        return DispatchPriority.LATEST;
+    }
+
+    public boolean canHandle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                && (callback.getEvent() == Event.SUBMIT_REASONS_FOR_APPEAL
+                || callback.getEvent() == Event.SUBMIT_CLARIFYING_QUESTION_ANSWERS);
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        List<DocumentWithMetadata> appellantDocuments = concat(
+                getReasonsForAppealEvidence(asylumCase),
+                getClarifyQuestionsEvidence(asylumCase)
+        ).collect(Collectors.toList());
+
+
+        if (!appellantDocuments.isEmpty()) {
+            asylumCase.write(APPELLANT_DOCUMENTS, documentsAppender.append(Collections.emptyList(), appellantDocuments));
+        }
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    private Stream<DocumentWithMetadata> getReasonsForAppealEvidence(AsylumCase asylumCase) {
+        return asylumCase.<List<IdValue<DocumentWithMetadata>>>read(REASONS_FOR_APPEAL_DOCUMENTS)
+                .map(documents -> documents.stream().map(IdValue::getValue))
+                .orElse(Stream.empty());
+    }
+
+    private Stream<DocumentWithMetadata> getClarifyQuestionsEvidence(AsylumCase asylumCase) {
+        return asylumCase.<List<IdValue<ClarifyingQuestionAnswer>>>read(CLARIFYING_QUESTIONS_ANSWERS)
+                .map(clarifyingQuestions -> clarifyingQuestions.stream().flatMap(evidenceOnEachQuestionToList()))
+                .orElse(Stream.empty());
+    }
+
+    private Function<IdValue<ClarifyingQuestionAnswer>, Stream<? extends DocumentWithMetadata>> evidenceOnEachQuestionToList() {
+        return clarifyingQuestion ->
+                Optional.ofNullable(clarifyingQuestion.getValue().getSupportingEvidence())
+                        .map(supportingEvidenceList -> supportingEvidenceList.stream()
+                                .map(supportingEvidenceToDocumentWithMetadata(clarifyingQuestion))
+                        )
+                        .orElse(Stream.empty());
+    }
+
+    private Function<IdValue<Document>, DocumentWithMetadata> supportingEvidenceToDocumentWithMetadata(IdValue<ClarifyingQuestionAnswer> clarifyingQuestion) {
+        return supportingEvidence ->
+                new DocumentWithMetadata(
+                        supportingEvidence.getValue(),
+                        "Clarifying question evidence",
+                        clarifyingQuestion.getValue().getDateResponded(),
+                        DocumentTag.ADDITIONAL_EVIDENCE
+                );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AddAppellantDocumentsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AddAppellantDocumentsHandlerTest.java
@@ -1,0 +1,229 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.DocumentsAppender;
+
+@RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("unchecked")
+public class AddAppellantDocumentsHandlerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private DocumentsAppender documentsAppender;
+
+    private AddAppellantDocumentsHandler addAppellantDocumentsHandler;
+
+    @Before
+    public void setupHandler() {
+        addAppellantDocumentsHandler = new AddAppellantDocumentsHandler(documentsAppender);
+    }
+
+    @Test
+    public void handling_should_throw_if_cannot_actually_handle() {
+        assertThatThrownBy(() -> addAppellantDocumentsHandler.handle(ABOUT_TO_START, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.SEND_DIRECTION);
+        assertThatThrownBy(() -> addAppellantDocumentsHandler.handle(ABOUT_TO_SUBMIT, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = addAppellantDocumentsHandler.canHandle(callbackStage, callback);
+
+                if ((event == Event.SUBMIT_REASONS_FOR_APPEAL || event == Event.SUBMIT_CLARIFYING_QUESTION_ANSWERS)
+                        && callbackStage == ABOUT_TO_SUBMIT) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> addAppellantDocumentsHandler.canHandle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> addAppellantDocumentsHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> addAppellantDocumentsHandler.handle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> addAppellantDocumentsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    public void addsReasonsForAppealEvidenceToAppellantEvidence() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_REASONS_FOR_APPEAL);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        DocumentWithMetadata reasonsForAppealEvidence = new DocumentWithMetadata(
+                new Document("documentUrl", "binaryUrl", "documentFielname"),
+                "description",
+                "dateUploaded",
+                DocumentTag.ADDITIONAL_EVIDENCE
+        );
+        List<IdValue<DocumentWithMetadata>> reasonsForAppealEvidenceList = asList(
+                new IdValue<DocumentWithMetadata>(
+                        "1",
+                        reasonsForAppealEvidence
+                )
+        );
+
+        when(asylumCase.read(AsylumCaseFieldDefinition.REASONS_FOR_APPEAL_DOCUMENTS))
+                .thenReturn(Optional.of(reasonsForAppealEvidenceList));
+        when(asylumCase.read(AsylumCaseFieldDefinition.CLARIFYING_QUESTIONS_ANSWERS))
+                .thenReturn(Optional.empty());
+        when(documentsAppender.append(Collections.emptyList(), asList(reasonsForAppealEvidence)))
+                .thenReturn(reasonsForAppealEvidenceList);
+
+        addAppellantDocumentsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        verify(asylumCase).write(AsylumCaseFieldDefinition.APPELLANT_DOCUMENTS, reasonsForAppealEvidenceList);
+    }
+
+    @Test
+    public void addsClarifyQuestionsEvidenceToAppellantEvidence() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_REASONS_FOR_APPEAL);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+
+        when(asylumCase.read(AsylumCaseFieldDefinition.REASONS_FOR_APPEAL_DOCUMENTS))
+                .thenReturn(Optional.empty());
+        Document clarifyingQuestionEvidence = new Document("documentUrl", "binaryUrl", "documentFielname");
+        when(asylumCase.read(AsylumCaseFieldDefinition.CLARIFYING_QUESTIONS_ANSWERS))
+                .thenReturn(Optional.of(asList(
+                        new IdValue<>(
+                                "1",
+                                new ClarifyingQuestionAnswer(
+                                        "dateSent",
+                                        "dateDue",
+                                        "dateResponded",
+                                        "question",
+                                        "answer",
+                                        asList(
+                                                new IdValue<Document>(
+                                                        "1",
+                                                        clarifyingQuestionEvidence
+                                                )
+                                        )
+                                )
+                        ),
+                        new IdValue<>(
+                                "2",
+                                new ClarifyingQuestionAnswer(
+                                        "dateSent2",
+                                        "dateDue2",
+                                        "dateResponded2",
+                                        "question2",
+                                        "answer2",
+                                        null
+                                )
+                        )
+
+                )));
+        List appellantEvidence = asList(new DocumentWithMetadata(
+                clarifyingQuestionEvidence,
+                "Clarifying question evidence",
+                "dateResponded",
+                DocumentTag.ADDITIONAL_EVIDENCE
+        ));
+        when(documentsAppender.append(Collections.emptyList(), appellantEvidence))
+                .thenReturn(appellantEvidence);
+
+        addAppellantDocumentsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        verify(asylumCase).write(AsylumCaseFieldDefinition.APPELLANT_DOCUMENTS, appellantEvidence);
+    }
+
+    @Test
+    public void donotAddAppellantDocumentsIfNoEvidenceHasBeenUploaded() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_REASONS_FOR_APPEAL);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+
+        when(asylumCase.read(AsylumCaseFieldDefinition.REASONS_FOR_APPEAL_DOCUMENTS))
+                .thenReturn(Optional.empty());
+        when(asylumCase.read(AsylumCaseFieldDefinition.CLARIFYING_QUESTIONS_ANSWERS))
+                .thenReturn(Optional.of(asList(
+                        new IdValue<>(
+                                "1",
+                                new ClarifyingQuestionAnswer(
+                                        "dateSent",
+                                        "dateDue",
+                                        "dateResponded",
+                                        "question",
+                                        "answer",
+                                        null
+                                )
+                        ),
+                        new IdValue<>(
+                                "2",
+                                new ClarifyingQuestionAnswer(
+                                        "dateSent2",
+                                        "dateDue2",
+                                        "dateResponded2",
+                                        "question2",
+                                        "answer2",
+                                        null
+                                )
+                        )
+
+                )));
+
+        addAppellantDocumentsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        verify(asylumCase, never()).write(any(), any());
+    }
+}


### PR DESCRIPTION
Create an appellantDocuments list to be displayed on the documents
tab. This will include any evidence the appellant has submitted about
their case. For the moment this includes the reasons for appeal evidence
and any clarify questions evidence.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-3144