### PR TITLE
RIA-3370 Removed unused terraform_remote_state data resources

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -8,8 +8,6 @@ locals {
   non_preview_app_service_plan = "${var.product}-${var.env}"
   app_service_plan             = "${var.env == "preview" || var.env == "spreview" ? local.preview_app_service_plan : local.non_preview_app_service_plan}"
 
-  local_ase = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
-
   preview_vault_name     = "${var.raw_product}-aat"
   non_preview_vault_name = "${var.raw_product}-${var.env}"
   key_vault_name         = "${var.env == "preview" || var.env == "spreview" ? local.preview_vault_name : local.non_preview_vault_name}"

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -1,25 +1,3 @@
 terraform {
   backend "azurerm" {}
 }
-
-data "terraform_remote_state" "core_apps_infrastructure" {
-  backend = "azurerm"
-
-  config {
-    resource_group_name  = "mgmt-state-store-${var.subscription}"
-    storage_account_name = "mgmtstatestore${var.subscription}"
-    container_name       = "mgmtstatestorecontainer${var.env}"
-    key                  = "core-infra/${var.env}/terraform.tfstate"
-  }
-}
-
-data "terraform_remote_state" "core_apps_compute" {
-  backend = "azurerm"
-
-  config {
-    resource_group_name  = "mgmt-state-store-${var.subscription}"
-    storage_account_name = "mgmtstatestore${var.subscription}"
-    container_name       = "mgmtstatestorecontainer${var.env}"
-    key                  = "core-compute/${var.env}/terraform.tfstate"
-  }
-}

--- a/src/contractTest/java/uk/gov/hmcts/reform/iacaseapi/IdamConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/iacaseapi/IdamConsumerTest.java
@@ -124,7 +124,7 @@ public class IdamConsumerTest {
             SerenityRest
                 .given()
                 .headers(headers)
-                .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .get(mockServer.getUrl() + IDAM_DETAILS_URL)
                 .then()

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/CcdScenarioRunnerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/CcdScenarioRunnerTest.java
@@ -138,7 +138,7 @@ public class CcdScenarioRunnerTest {
                 SerenityRest
                     .given()
                     .headers(authorizationHeaders)
-                    .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .body(requestBody)
                     .when()
                     .post(requestUri)

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/DataFixingTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/DataFixingTest.java
@@ -67,7 +67,7 @@ public class DataFixingTest {
                 SerenityRest
                     .given()
                     .headers(getAuthorizationHeaders())
-                    .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .body(callbackBody)
                     .when()
                     .post(endpoint)

--- a/src/integrationTest/java/uk/gov/hmcts/reform/iacaseapi/component/testutils/IaCaseApiClient.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/iacaseapi/component/testutils/IaCaseApiClient.java
@@ -73,7 +73,7 @@ public class IaCaseApiClient {
     private HttpHeaders getHeaders() {
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON_UTF8);
+        headers.setContentType(MediaType.APPLICATION_JSON);
         headers.add("ServiceAuthorization", SERVICE_JWT_TOKEN);
         headers.add("Authorization", USER_JWT_TOKEN);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-3370](https://tools.hmcts.net/jira/browse/RIA-3370)

### Change description ###
Fix for the terraform build error
Error: Error refreshing state: 1 error(s) occurred:
09:34:28  
09:34:28  * data.terraform_remote_state.core_apps_infrastructure: 1 error(s) occurred:
09:34:28  
09:34:28  * data.terraform_remote_state.core_apps_infrastructure: data.terraform_remote_state.core_apps_infrastructure: Terraform 0.11.7 does not support state version 4, please update.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
