### PR TITLE
RIA-3583 Updated the AppealReferenceNumberHandler dispatch priority to earliest

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealReferenceNumberHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealReferenceNumberHandler.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
@@ -24,6 +25,11 @@ public class AppealReferenceNumberHandler implements PreSubmitCallbackHandler<As
     private final DateProvider dateProvider;
 
     private final AppealReferenceNumberGenerator appealReferenceNumberGenerator;
+
+    @Override
+    public DispatchPriority getDispatchPriority() {
+        return DispatchPriority.EARLIEST;
+    }
 
     public AppealReferenceNumberHandler(
         DateProvider dateProvider,

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealReferenceNumberHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealReferenceNumberHandlerTest.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_REFERENCE_NUMBER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority.EARLIEST;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
@@ -48,6 +50,11 @@ public class AppealReferenceNumberHandlerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getId()).thenReturn(123L);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
+    }
+
+    @Test
+    public void set_to_earliest() {
+        assertThat(appealReferenceNumberHandler.getDispatchPriority()).isEqualTo(EARLIEST);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-3583](https://tools.hmcts.net/jira/browse/RIA-3583)


### Change description ###
Updated appealReferenceNumberHandler dispatch priority to earliest.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
