### PR TITLE
RIA-3711 payments aat issue fixes

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-2935-EA-appeal-fee-pay-later-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-2935-EA-appeal-fee-pay-later-hearing.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087535",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payLater",
+          "eaHuAppealTypePaymentOption": "payLater",
           "customerReference": "543232"
         }
       }

--- a/src/functionalTest/resources/scenarios/RIA-2935-EA-appeal-fee-pay-later-without-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-2935-EA-appeal-fee-pay-later-without-hearing.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087535",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payLater",
+          "eaHuAppealTypePaymentOption": "payLater",
           "customerReference": "543232"
         }
       }

--- a/src/functionalTest/resources/scenarios/RIA-2935-EA-appeal-fee-pay-now-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-2935-EA-appeal-fee-pay-now-hearing.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087535",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "customerReference": "543232"
         }
       }

--- a/src/functionalTest/resources/scenarios/RIA-2935-EA-appeal-fee-pay-now-without-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-2935-EA-appeal-fee-pay-now-without-hearing.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087535",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "customerReference": "543232"
         }
       }

--- a/src/functionalTest/resources/scenarios/RIA-3025-successful-payment-for-pa-appeal-type-at-case-building.json
+++ b/src/functionalTest/resources/scenarios/RIA-3025-successful-payment-for-pa-appeal-type-at-case-building.json
@@ -17,7 +17,7 @@
           "homeOfficeDecisionDate": "{$TODAY-14}",
           "paymentAccountList": "PBA0087535",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payLater",
+          "eaHuAppealTypePaymentOption": "payLater",
           "customerReference": "543232",
           "paymentStatus": "Payment due"
         }

--- a/src/functionalTest/resources/scenarios/RIA-3025-successful-payment-for-pa-appeal-type-at-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3025-successful-payment-for-pa-appeal-type-at-listing.json
@@ -17,7 +17,7 @@
           "homeOfficeDecisionDate": "{$TODAY-14}",
           "paymentAccountList": "PBA0087535",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payLater",
+          "eaHuAppealTypePaymentOption": "payLater",
           "customerReference": "543232",
           "paymentStatus": "Payment due"
         }

--- a/src/functionalTest/resources/scenarios/RIA-3082-EA-failed-payment-account-deleted-pay-now-with-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3082-EA-failed-payment-account-deleted-pay-now-with-hearing.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087240",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "customerReference": "543232",
           "paymentStatus": "Payment due"
         }

--- a/src/functionalTest/resources/scenarios/RIA-3082-EA-failed-payment-account-deleted-pay-now-without-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3082-EA-failed-payment-account-deleted-pay-now-without-hearing.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087240",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "customerReference": "543232",
           "paymentStatus": "Payment due"
         }

--- a/src/functionalTest/resources/scenarios/RIA-3082-EA-failed-payment-account-on-hold-pay-now-with-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3082-EA-failed-payment-account-on-hold-pay-now-with-hearing.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087240",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "customerReference": "543232",
           "paymentStatus": "Payment due"
         }

--- a/src/functionalTest/resources/scenarios/RIA-3082-EA-successful-payment-pay-now-with-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3082-EA-successful-payment-pay-now-with-hearing.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087535",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "customerReference": "543232",
           "paymentStatus": "Payment due"
         }

--- a/src/functionalTest/resources/scenarios/RIA-3082-EA-successful-payment-pay-now-without-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3082-EA-successful-payment-pay-now-without-hearing.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087535",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "customerReference": "543232",
           "paymentStatus": "Payment due"
         }

--- a/src/functionalTest/resources/scenarios/RIA-3082-HU-failed-payment-account-on-hold-pay-now-with-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3082-HU-failed-payment-account-on-hold-pay-now-with-hearing.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087240",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "customerReference": "543232",
           "paymentStatus": "Payment due"
         }

--- a/src/functionalTest/resources/scenarios/RIA-3082-PA-failed-payment-account-deleted-pay-now-without-hearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3082-PA-failed-payment-account-deleted-pay-now-without-hearing.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087240",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "customerReference": "543232",
           "paymentStatus": "Payment due"
         }

--- a/src/functionalTest/resources/scenarios/RIA-3163-PA-failed-payment-account-deleted-respondent-review-state.json
+++ b/src/functionalTest/resources/scenarios/RIA-3163-PA-failed-payment-account-deleted-respondent-review-state.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087240",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "customerReference": "543232",
           "paymentStatus": "Payment due"
         }

--- a/src/functionalTest/resources/scenarios/RIA-3163-PA-failed-payment-account-on-hold-listing-state.json
+++ b/src/functionalTest/resources/scenarios/RIA-3163-PA-failed-payment-account-on-hold-listing-state.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087240",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "customerReference": "543232",
           "paymentStatus": "Payment due"
         }

--- a/src/functionalTest/resources/scenarios/RIA-3163-PA-successful-payment-case-building-state.json.json
+++ b/src/functionalTest/resources/scenarios/RIA-3163-PA-successful-payment-case-building-state.json.json
@@ -16,7 +16,7 @@
           "paymentAccountList": "PBA0087535",
           "homeOfficeReferenceNumber": "A123456",
           "paymentDescription": "An IA pba test payment",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "customerReference": "543232",
           "paymentStatus": "Payment due"
         }

--- a/src/functionalTest/resources/scenarios/RIA-3468-pa-appeal-type-pay-now.json
+++ b/src/functionalTest/resources/scenarios/RIA-3468-pa-appeal-type-pay-now.json
@@ -13,7 +13,7 @@
         "replacements": {
           "appealReferenceNumber": null,
           "appealType": "protection",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "paymentAccountList":{
             "value":{
               "code":"PBA0087535",

--- a/src/functionalTest/resources/scenarios/RIA-3471-ea-appeal-type-pay-now-ou-of-time.json
+++ b/src/functionalTest/resources/scenarios/RIA-3471-ea-appeal-type-pay-now-ou-of-time.json
@@ -13,7 +13,7 @@
         "replacements": {
           "appealType": "refusalOfEu",
           "homeOfficeDecisionDate": "{$TODAY-15}",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "paymentAccountList":{
             "value":{
               "code":"PBA0087535",

--- a/src/functionalTest/resources/scenarios/RIA-3471-hu-appeal-type-pay-now-ou-of-time.json
+++ b/src/functionalTest/resources/scenarios/RIA-3471-hu-appeal-type-pay-now-ou-of-time.json
@@ -13,7 +13,7 @@
         "replacements": {
           "appealType": "refusalOfHumanRights",
           "homeOfficeDecisionDate": "{$TODAY-15}",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "paymentAccountList":{
             "value":{
               "code":"PBA0087535",

--- a/src/functionalTest/resources/scenarios/RIA-3471-pa-appeal-type-pay-now-ou-of-time.json
+++ b/src/functionalTest/resources/scenarios/RIA-3471-pa-appeal-type-pay-now-ou-of-time.json
@@ -13,7 +13,7 @@
         "replacements": {
           "appealType": "protection",
           "homeOfficeDecisionDate": "{$TODAY-15}",
-          "payForTheAppealOption": "payNow",
+          "eaHuAppealTypePaymentOption": "payNow",
           "paymentAccountList":{
             "value":{
               "code":"PBA0087535",

--- a/src/functionalTest/resources/scenarios/RIA-3498-error-on-submit-when-option-is-payNow-for-HU.json
+++ b/src/functionalTest/resources/scenarios/RIA-3498-error-on-submit-when-option-is-payNow-for-HU.json
@@ -13,7 +13,7 @@
         "replacements": {
           "appealReferenceNumber": "PA/12345/2018",
           "appealType": "refusalOfHumanRights",
-          "payForTheAppealOption": "payNow"
+          "eaHuAppealTypePaymentOption": "payNow"
           }
         }
       }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -904,8 +904,7 @@ public enum AsylumCaseFieldDefinition {
         "hearingDecisionSelected", new TypeReference<String>(){}),
     IS_FEE_PAYMENT_ENABLED(
             "isFeePaymentEnabled", new TypeReference<YesOrNo>() {}),
-    PAY_FOR_THE_APPEAL_OPTION(
-            "payForTheAppealOption", new TypeReference<String>() {}),
+
     PA_APPEAL_TYPE_PAYMENT_OPTION(
         "paAppealTypePaymentOption", new TypeReference<String>() {}),
     EA_HU_APPEAL_TYPE_PAYMENT_OPTION(

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SubmitAppealPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SubmitAppealPreparer.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PAY_FOR_THE_APPEAL_OPTION;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PA_APPEAL_TYPE_PAYMENT_OPTION;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
@@ -75,7 +73,7 @@ public class SubmitAppealPreparer implements PreSubmitCallbackHandler<AsylumCase
         if (appealType.isPresent()) {
             if (appealType.get().equals(AppealType.EA)
                 || appealType.get().equals(AppealType.HU)) {
-                foundPaymentAppealTypePayNow = asylumCase.read(PAY_FOR_THE_APPEAL_OPTION, String.class).orElse("").equals(payNowOption);
+                foundPaymentAppealTypePayNow = asylumCase.read(EA_HU_APPEAL_TYPE_PAYMENT_OPTION, String.class).orElse("").equals(payNowOption);
             }
             if (appealType.get().equals(AppealType.PA)) {
                 foundPaymentAppealTypePayNow = asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class).orElse("").equals(payNowOption);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SubmitAppealPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SubmitAppealPreparerTest.java
@@ -70,7 +70,7 @@ public class SubmitAppealPreparerTest {
     public void should_return_true_for_HU_payNow() {
 
         when(asylumCase.read(APPEAL_TYPE)).thenReturn(Optional.of(AppealType.HU));
-        when(asylumCase.read(PAY_FOR_THE_APPEAL_OPTION, String.class)).thenReturn(Optional.of("payNow"));
+        when(asylumCase.read(EA_HU_APPEAL_TYPE_PAYMENT_OPTION, String.class)).thenReturn(Optional.of("payNow"));
 
         assertTrue(submitAppealPreparer.isPaymentAppealTypePayNow(asylumCase));
     }
@@ -79,7 +79,7 @@ public class SubmitAppealPreparerTest {
     public void should_return_false_for_HU_payLater() {
 
         when(asylumCase.read(APPEAL_TYPE)).thenReturn(Optional.of(AppealType.HU));
-        when(asylumCase.read(PAY_FOR_THE_APPEAL_OPTION, String.class)).thenReturn(Optional.of("payLater"));
+        when(asylumCase.read(EA_HU_APPEAL_TYPE_PAYMENT_OPTION, String.class)).thenReturn(Optional.of("payLater"));
 
         assertFalse(submitAppealPreparer.isPaymentAppealTypePayNow(asylumCase));
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-3711](https://tools.hmcts.net/jira/browse/RIA-3711)


### Change description ###
Issues fixed of the Payments AAT testing
1. Label name changed from 'Pending payment' to 'Payment pending'
2. Error on submitAppeal event if a saved draft appeal for EA/HU with PayNow option.
3. The overview tab text changed from 'Pay and submit your appeal' to 'Pay for and submit your appeal'


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```