### PR TITLE
RIA-3683-RIA-3784 fix - clear pre-populated fields

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-3683-list-case-start-flag-on.json
+++ b/src/functionalTest/resources/scenarios/RIA-3683-list-case-start-flag-on.json
@@ -1,0 +1,103 @@
+{
+  "description": "RIA-3683 Start list case (not a reheard case) - hold on to list case hearing centre, date and length fields (feature flag on)",
+  "launchDarklyKey": "reheard-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 3683,
+      "eventId": "listCase",
+      "state": "listing",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isReheardAppealEnabled": "Yes",
+          "currentHearingDetailsVisible": "No",
+          "ariaListingReference": "LP/12345/2019",
+          "hearingCentre": "manchester",
+          "listCaseHearingCentre": "manchester",
+          "listCaseHearingLength": "300",
+          "listCaseHearingDate": "2020-10-28T10:30:00.000",
+          "listCaseRequirementsVulnerabilities": "some vulnerabilities",
+          "listCaseRequirementsMultimedia": "some multimedia",
+          "listCaseRequirementsSingleSexCourt": "some single-sex court",
+          "listCaseRequirementsInCameraCourt": "some in-camera court",
+          "listCaseRequirementsOther": "some other requirements",
+          "reviewedUpdatedHearingRequirements": "Yes",
+          "doesTheCaseNeedToBeRelisted": "Yes",
+          "haveHearingAttendeesAndDurationBeenRecorded": "Yes",
+          "attendingTcw": "some TCW",
+          "attendingJudge": "some Judge",
+          "attendingAppellant": "some Appellant",
+          "attendingHomeOfficeLegalRepresentative": "some HO",
+          "attendingAppellantsLegalRepresentative": "some legal rep",
+          "actualCaseHearingLength": {
+            "hours": "2",
+            "minutes": "30"
+          },
+          "hearingConductionOptions": "allParticipants",
+          "hearingRecordingDocuments": [
+            {
+              "id": "cbe101ff-7f87-423e-93cd-f731adf7d979",
+              "value": {
+                "document": {
+                  "document_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6",
+                  "document_filename": "HearingRecording.mp3",
+                  "document_binary_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6/binary"
+                },
+                "description": "some description"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "isReheardAppealEnabled": "Yes",
+        "currentHearingDetailsVisible": "No",
+        "ariaListingReference": "LP/12345/2019",
+        "hearingCentre": "manchester",
+        "listCaseHearingCentre": "manchester",
+        "listCaseHearingLength": "300",
+        "listCaseHearingDate": "2020-10-28T10:30:00.000",
+        "listCaseRequirementsVulnerabilities": "some vulnerabilities",
+        "listCaseRequirementsMultimedia": "some multimedia",
+        "listCaseRequirementsSingleSexCourt": "some single-sex court",
+        "listCaseRequirementsInCameraCourt": "some in-camera court",
+        "listCaseRequirementsOther": "some other requirements",
+        "reviewedUpdatedHearingRequirements": "Yes",
+        "doesTheCaseNeedToBeRelisted": "Yes",
+        "haveHearingAttendeesAndDurationBeenRecorded": "Yes",
+        "attendingTcw": "some TCW",
+        "attendingJudge": "some Judge",
+        "attendingAppellant": "some Appellant",
+        "attendingHomeOfficeLegalRepresentative": "some HO",
+        "attendingAppellantsLegalRepresentative": "some legal rep",
+        "actualCaseHearingLength": {
+          "hours": "2",
+          "minutes": "30"
+        },
+        "hearingConductionOptions": "allParticipants",
+        "hearingRecordingDocuments": [
+          {
+            "id": "cbe101ff-7f87-423e-93cd-f731adf7d979",
+            "value": {
+              "document": {
+                "document_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6",
+                "document_filename": "HearingRecording.mp3",
+                "document_binary_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6/binary"
+              },
+              "description": "some description"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-3683-list-reheard-case-start-flag-off.json
+++ b/src/functionalTest/resources/scenarios/RIA-3683-list-reheard-case-start-flag-off.json
@@ -1,0 +1,101 @@
+{
+  "description": "RIA-3683 Start list reheard case - hold on to list case hearing centre, date and length fields (feature flag off)",
+  "launchDarklyKey": "reheard-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 3683,
+      "eventId": "listCase",
+      "state": "listing",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "currentHearingDetailsVisible": "No",
+          "ariaListingReference": "LP/12345/2019",
+          "hearingCentre": "manchester",
+          "listCaseHearingCentre": "manchester",
+          "listCaseHearingLength": "300",
+          "listCaseHearingDate": "2020-10-28T10:30:00.000",
+          "listCaseRequirementsVulnerabilities": "some vulnerabilities",
+          "listCaseRequirementsMultimedia": "some multimedia",
+          "listCaseRequirementsSingleSexCourt": "some single-sex court",
+          "listCaseRequirementsInCameraCourt": "some in-camera court",
+          "listCaseRequirementsOther": "some other requirements",
+          "reviewedUpdatedHearingRequirements": "Yes",
+          "doesTheCaseNeedToBeRelisted": "Yes",
+          "haveHearingAttendeesAndDurationBeenRecorded": "Yes",
+          "attendingTcw": "some TCW",
+          "attendingJudge": "some Judge",
+          "attendingAppellant": "some Appellant",
+          "attendingHomeOfficeLegalRepresentative": "some HO",
+          "attendingAppellantsLegalRepresentative": "some legal rep",
+          "actualCaseHearingLength": {
+            "hours": "2",
+            "minutes": "30"
+          },
+          "hearingConductionOptions": "allParticipants",
+          "hearingRecordingDocuments": [
+            {
+              "id": "cbe101ff-7f87-423e-93cd-f731adf7d979",
+              "value": {
+                "document": {
+                  "document_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6",
+                  "document_filename": "HearingRecording.mp3",
+                  "document_binary_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6/binary"
+                },
+                "description": "some description"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "currentHearingDetailsVisible": "No",
+        "ariaListingReference": "LP/12345/2019",
+        "hearingCentre": "manchester",
+        "listCaseHearingCentre": "manchester",
+        "listCaseHearingLength": "300",
+        "listCaseHearingDate": "2020-10-28T10:30:00.000",
+        "listCaseRequirementsVulnerabilities": "some vulnerabilities",
+        "listCaseRequirementsMultimedia": "some multimedia",
+        "listCaseRequirementsSingleSexCourt": "some single-sex court",
+        "listCaseRequirementsInCameraCourt": "some in-camera court",
+        "listCaseRequirementsOther": "some other requirements",
+        "reviewedUpdatedHearingRequirements": "Yes",
+        "doesTheCaseNeedToBeRelisted": "Yes",
+        "haveHearingAttendeesAndDurationBeenRecorded": "Yes",
+        "attendingTcw": "some TCW",
+        "attendingJudge": "some Judge",
+        "attendingAppellant": "some Appellant",
+        "attendingHomeOfficeLegalRepresentative": "some HO",
+        "attendingAppellantsLegalRepresentative": "some legal rep",
+        "actualCaseHearingLength": {
+          "hours": "2",
+          "minutes": "30"
+        },
+        "hearingConductionOptions": "allParticipants",
+        "hearingRecordingDocuments": [
+          {
+            "id": "cbe101ff-7f87-423e-93cd-f731adf7d979",
+            "value": {
+              "document": {
+                "document_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6",
+                "document_filename": "HearingRecording.mp3",
+                "document_binary_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6/binary"
+              },
+              "description": "some description"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-3683-list-reheard-case-start-flag-on.json
+++ b/src/functionalTest/resources/scenarios/RIA-3683-list-reheard-case-start-flag-on.json
@@ -1,0 +1,105 @@
+{
+  "description": "RIA-3683 Start list reheard case - clear list case hearing centre, date and length fields (feature flag on)",
+  "launchDarklyKey": "reheard-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 3683,
+      "eventId": "listCase",
+      "state": "listing",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isReheardAppealEnabled": "Yes",
+          "caseFlagSetAsideReheardExists": "Yes",
+          "currentHearingDetailsVisible": "No",
+          "ariaListingReference": "LP/12345/2019",
+          "hearingCentre": "manchester",
+          "listCaseHearingCentre": "manchester",
+          "listCaseHearingLength": "300",
+          "listCaseHearingDate": "2020-10-28T10:30:00.000",
+          "listCaseRequirementsVulnerabilities": "some vulnerabilities",
+          "listCaseRequirementsMultimedia": "some multimedia",
+          "listCaseRequirementsSingleSexCourt": "some single-sex court",
+          "listCaseRequirementsInCameraCourt": "some in-camera court",
+          "listCaseRequirementsOther": "some other requirements",
+          "reviewedUpdatedHearingRequirements": "Yes",
+          "doesTheCaseNeedToBeRelisted": "Yes",
+          "haveHearingAttendeesAndDurationBeenRecorded": "Yes",
+          "attendingTcw": "some TCW",
+          "attendingJudge": "some Judge",
+          "attendingAppellant": "some Appellant",
+          "attendingHomeOfficeLegalRepresentative": "some HO",
+          "attendingAppellantsLegalRepresentative": "some legal rep",
+          "actualCaseHearingLength": {
+            "hours": "2",
+            "minutes": "30"
+          },
+          "hearingConductionOptions": "allParticipants",
+          "hearingRecordingDocuments": [
+            {
+              "id": "cbe101ff-7f87-423e-93cd-f731adf7d979",
+              "value": {
+                "document": {
+                  "document_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6",
+                  "document_filename": "HearingRecording.mp3",
+                  "document_binary_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6/binary"
+                },
+                "description": "some description"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "isReheardAppealEnabled": "Yes",
+        "caseFlagSetAsideReheardExists": "Yes",
+        "currentHearingDetailsVisible": "No",
+        "ariaListingReference": "LP/12345/2019",
+        "hearingCentre": "manchester",
+        "listCaseHearingCentre": null,
+        "listCaseHearingLength": null,
+        "listCaseHearingDate": null,
+        "listCaseRequirementsVulnerabilities": "some vulnerabilities",
+        "listCaseRequirementsMultimedia": "some multimedia",
+        "listCaseRequirementsSingleSexCourt": "some single-sex court",
+        "listCaseRequirementsInCameraCourt": "some in-camera court",
+        "listCaseRequirementsOther": "some other requirements",
+        "reviewedUpdatedHearingRequirements": "Yes",
+        "doesTheCaseNeedToBeRelisted": "Yes",
+        "haveHearingAttendeesAndDurationBeenRecorded": "Yes",
+        "attendingTcw": "some TCW",
+        "attendingJudge": "some Judge",
+        "attendingAppellant": "some Appellant",
+        "attendingHomeOfficeLegalRepresentative": "some HO",
+        "attendingAppellantsLegalRepresentative": "some legal rep",
+        "actualCaseHearingLength": {
+          "hours": "2",
+          "minutes": "30"
+        },
+        "hearingConductionOptions": "allParticipants",
+        "hearingRecordingDocuments": [
+          {
+            "id": "cbe101ff-7f87-423e-93cd-f731adf7d979",
+            "value": {
+              "document": {
+                "document_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6",
+                "document_filename": "HearingRecording.mp3",
+                "document_binary_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6/binary"
+              },
+              "description": "some description"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1156,7 +1156,6 @@ public enum AsylumCaseFieldDefinition {
     PREVIOUS_HEARING_RECORDING_DOCUMENTS(
         "previousHearingRecordingDocuments", new TypeReference<List<IdValue<HearingRecordingDocument>>>(){}),
 
-
     CASE_INTRODUCTION_DESCRIPTION(
         "caseIntroductionDescription", new TypeReference<String>(){}),
 


### PR DESCRIPTION
Fix for issues discovered in AAT prior to release of reheard feature:

1. "Previous recordings" title no longer displays in the `Hearing and appointment` and `Documents` tab if none exist. 
2. "Hearing centre, hearing date and hearing length" fields are cleared at the start of the listing process for a reheard case.

### JIRA link (if applicable) ###

[RIA-3683](https://tools.hmcts.net/jira/browse/RIA-3683)
[RIA-3784](https://tools.hmcts.net/jira/browse/RIA-3784)

### Change description ###

See Jira


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
