### PR TITLE
RIA-3793 Manage fee update for the type appeal not valid

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1326,6 +1326,12 @@ public enum AsylumCaseFieldDefinition {
     FEE_UPDATE_COMPLETED_STAGES(
         "feeUpdateCompletedStages", new TypeReference<List<String>>(){}),
 
+    FEE_UPDATE_REASON(
+        "feeUpdateReason", new TypeReference<FeeUpdateReason>(){}),
+
+    NEW_FEE_AMOUNT(
+        "newFeeAmount", new TypeReference<String>(){}),
+
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeUpdateReason.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeUpdateReason.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum FeeUpdateReason {
+
+    DECISION_TYPE_CHANGED("decisionTypeChanged"),
+    APPEAL_NOT_VALID("appealNotValid"),
+    FEE_REMISSION_CHANGED("feeRemissionChanged");
+
+    @JsonValue
+    private final String value;
+
+    FeeUpdateReason(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ManageFeeUpdateMidEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ManageFeeUpdateMidEvent.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.FEE_UPDATE_REASON;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.NEW_FEE_AMOUNT;
+
+import java.math.BigDecimal;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.FeeUpdateReason;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.FeatureToggler;
+
+@Component
+public class ManageFeeUpdateMidEvent implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final FeatureToggler featureToggler;
+
+    public ManageFeeUpdateMidEvent(FeatureToggler featureToggler) {
+        this.featureToggler = featureToggler;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.MID_EVENT
+               && callback.getEvent() == Event.MANAGE_FEE_UPDATE
+               && featureToggler.getValue("manage-fee-update-feature", false);
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse = new PreSubmitCallbackResponse<>(asylumCase);
+
+        FeeUpdateReason feeUpdateReason = asylumCase.read(FEE_UPDATE_REASON, FeeUpdateReason.class)
+            .orElseThrow(() -> new IllegalStateException("Fee update reason is not present"));
+        String newFeeAmount = asylumCase.read(NEW_FEE_AMOUNT, String.class)
+            .orElseThrow(() -> new IllegalStateException("New fee amount is not present"));
+
+        if (feeUpdateReason == FeeUpdateReason.APPEAL_NOT_VALID && new BigDecimal(newFeeAmount).signum() > 0) {
+
+            callbackResponse.addError("Appeal not valid is selected, the new fee amount must be 0");
+            return callbackResponse;
+        }
+
+        return callbackResponse;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeUpdateReasonTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeUpdateReasonTest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import static junit.framework.TestCase.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class FeeUpdateReasonTest {
+
+    @Test
+    void has_correct_values() {
+        assertEquals("decisionTypeChanged", FeeUpdateReason.DECISION_TYPE_CHANGED.toString());
+        assertEquals("appealNotValid", FeeUpdateReason.APPEAL_NOT_VALID.toString());
+        assertEquals("feeRemissionChanged", FeeUpdateReason.FEE_REMISSION_CHANGED.toString());
+    }
+
+    @Test
+    void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
+        assertEquals(3, FeeUpdateReason.values().length);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ManageFeeUpdateMidEventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ManageFeeUpdateMidEventTest.java
@@ -1,0 +1,136 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.FeeUpdateReason;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.FeatureToggler;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class ManageFeeUpdateMidEventTest {
+
+    @Mock private AsylumCase asylumCase;
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private FeatureToggler featureToggler;
+
+    private ManageFeeUpdateMidEvent manageFeeUpdateMidEvent;
+
+    @BeforeEach
+    void setUp() {
+
+        manageFeeUpdateMidEvent = new ManageFeeUpdateMidEvent(featureToggler);
+    }
+
+    @Test
+    void handling_should_error_for_amount_greater_than_zero_for_appeal_not_valid() {
+
+        when(featureToggler.getValue("manage-fee-update-feature", false)).thenReturn(true);
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.MANAGE_FEE_UPDATE);
+        when(asylumCase.read(FEE_UPDATE_REASON, FeeUpdateReason.class)).thenReturn(Optional.of(FeeUpdateReason.APPEAL_NOT_VALID));
+        when(asylumCase.read(NEW_FEE_AMOUNT, String.class)).thenReturn(Optional.of("1000"));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            manageFeeUpdateMidEvent.handle(MID_EVENT, callback);
+
+        assertNotNull(callbackResponse);
+        assertThat(callbackResponse.getErrors()).isNotEmpty();
+        assertThat(callbackResponse.getErrors()).contains("Appeal not valid is selected, the new fee amount must be 0");
+    }
+
+    @Test
+    void handling_should_error_if_fee_update_reason_is_not_present() {
+
+        when(featureToggler.getValue("manage-fee-update-feature", false)).thenReturn(true);
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.MANAGE_FEE_UPDATE);
+        when(asylumCase.read(FEE_UPDATE_REASON, FeeUpdateReason.class)).thenReturn(Optional.of(FeeUpdateReason.APPEAL_NOT_VALID));
+
+        assertThatThrownBy(() -> manageFeeUpdateMidEvent.handle(MID_EVENT, callback))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessage("New fee amount is not present");
+    }
+
+    @Test
+    void handling_should_error_if_new_fee_amount_is_not_present() {
+
+        when(featureToggler.getValue("manage-fee-update-feature", false)).thenReturn(true);
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.MANAGE_FEE_UPDATE);
+
+        assertThatThrownBy(() -> manageFeeUpdateMidEvent.handle(MID_EVENT, callback))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessage("Fee update reason is not present");
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> manageFeeUpdateMidEvent
+            .handle(MID_EVENT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        when(featureToggler.getValue("manage-fee-update-feature", false)).thenReturn(true);
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = manageFeeUpdateMidEvent.canHandle(callbackStage, callback);
+
+                if ((event == Event.MANAGE_FEE_UPDATE)
+                    && callbackStage == MID_EVENT) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> manageFeeUpdateMidEvent.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> manageFeeUpdateMidEvent.handle(MID_EVENT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-3793](https://tools.hmcts.net/jira/browse/RIA-3793)


### Change description ###
Case-officer and Admin-officer manageFeeUpdate for the type Appeal not valid


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```