### PR TITLE
RIA-3859 Remission details as collection

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/RemissionDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/RemissionDetails.java
@@ -1,0 +1,82 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public class RemissionDetails {
+
+    private String feeRemissionType;
+    private String asylumSupportReference;
+    private Document asylumSupportDocument;
+    private String legalAidAccountNumber;
+    private Document section17Document;
+    private Document section20Document;
+    private Document homeOfficeWaiverDocument;
+    private String helpWithFeesReferenceNumber;
+    private String exceptionalCircumstances;
+    private List<IdValue<Document>> remissionEcEvidenceDocuments;
+    private String remissionDecision;
+    private String feeAmount;
+    private String amountRemitted;
+    private String amountLeftToPay;
+    private String remissionDecisionReason;
+
+    private RemissionDetails() {
+
+    }
+
+    public RemissionDetails(String feeRemissionType, String asylumSupportReference, Document asylumSupportDocument) {
+        this.feeRemissionType = feeRemissionType;
+        this.asylumSupportReference = asylumSupportReference;
+        this.asylumSupportDocument = asylumSupportDocument;
+    }
+
+    public RemissionDetails(String feeRemissionType, String legalAidAccountNumber, String helpWithFeesReferenceNumber) {
+        this.feeRemissionType = feeRemissionType;
+        this.legalAidAccountNumber = legalAidAccountNumber;
+        this.helpWithFeesReferenceNumber = helpWithFeesReferenceNumber;
+    }
+
+    public RemissionDetails(
+        String feeRemissionType, Document section17Document,
+        Document section20Document, Document homeOfficeWaiverDocument) {
+        this.feeRemissionType = feeRemissionType;
+        this.section17Document = section17Document;
+        this.section20Document = section20Document;
+        this.homeOfficeWaiverDocument = homeOfficeWaiverDocument;
+    }
+
+    public RemissionDetails(String feeRemissionType,
+                            String exceptionalCircumstances, List<IdValue<Document>> remissionEcEvidenceDocuments) {
+        this.feeRemissionType = feeRemissionType;
+        this.exceptionalCircumstances = exceptionalCircumstances;
+        this.remissionEcEvidenceDocuments = remissionEcEvidenceDocuments;
+    }
+
+    public void setRemissionDecision(String remissionDecision) {
+        this.remissionDecision = remissionDecision;
+    }
+
+    public void setFeeAmount(String feeAmount) {
+        this.feeAmount = feeAmount;
+    }
+
+    public void setAmountRemitted(String amountRemitted) {
+        this.amountRemitted = amountRemitted;
+    }
+
+    public void setAmountLeftToPay(String amountLeftToPay) {
+        this.amountLeftToPay = amountLeftToPay;
+    }
+
+    public void setRemissionDecisionReason(String remissionDecisionReason) {
+        this.remissionDecisionReason = remissionDecisionReason;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/RemissionDetailsAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/RemissionDetailsAppender.java
@@ -1,0 +1,106 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+
+@Service
+public class RemissionDetailsAppender {
+
+    public List<IdValue<RemissionDetails>> appendAsylumSupportRemissionDetails(
+        List<IdValue<RemissionDetails>> existingRemissionDetails,
+        String feeRemissionType,
+        String asylumSupportReference,
+        Document asylumSupportDocument
+    ) {
+        final RemissionDetails newRemissionDetails = new RemissionDetails(feeRemissionType, asylumSupportReference, asylumSupportDocument);
+
+        return append(existingRemissionDetails, newRemissionDetails);
+    }
+
+    public List<IdValue<RemissionDetails>> appendLegalAidRemissionDetails(
+        List<IdValue<RemissionDetails>> existingRemissionDetails,
+        String feeRemissionType,
+        String legalAidAccountNumber
+    ) {
+        final RemissionDetails newRemissionDetails = new RemissionDetails(feeRemissionType, legalAidAccountNumber, "");
+
+        return append(existingRemissionDetails, newRemissionDetails);
+    }
+
+    public List<IdValue<RemissionDetails>> appendHelpWithFeeReferenceRemissionDetails(
+        List<IdValue<RemissionDetails>> existingRemissionDetails,
+        String feeRemissionType,
+        String helpWithFeesReferenceNumber
+    ) {
+        final RemissionDetails newRemissionDetails = new RemissionDetails(feeRemissionType, null, helpWithFeesReferenceNumber);
+
+        return append(existingRemissionDetails, newRemissionDetails);
+    }
+
+    public List<IdValue<RemissionDetails>> appendSection17RemissionDetails(
+        List<IdValue<RemissionDetails>> existingRemissionDetails,
+        String feeRemissionType,
+        Document section17Document
+    ) {
+        final RemissionDetails newRemissionDetails =
+            new RemissionDetails(feeRemissionType, section17Document, null, null);
+
+        return append(existingRemissionDetails, newRemissionDetails);
+    }
+
+    public List<IdValue<RemissionDetails>> appendSection20RemissionDetails(
+        List<IdValue<RemissionDetails>> existingRemissionDetails,
+        String feeRemissionType,
+        Document section20Document
+    ) {
+        final RemissionDetails newRemissionDetails =
+            new RemissionDetails(feeRemissionType, null, section20Document, null);
+
+        return append(existingRemissionDetails, newRemissionDetails);
+    }
+
+    public List<IdValue<RemissionDetails>> appendHomeOfficeWaiverRemissionDetails(
+        List<IdValue<RemissionDetails>> existingRemissionDetails,
+        String feeRemissionType,
+        Document homeOfficeWaiverDocument
+    ) {
+        final RemissionDetails newRemissionDetails =
+            new RemissionDetails(feeRemissionType, null, null, homeOfficeWaiverDocument);
+
+        return append(existingRemissionDetails, newRemissionDetails);
+    }
+
+    public List<IdValue<RemissionDetails>> appendExceptionalCircumstancesRemissionDetails(
+        List<IdValue<RemissionDetails>> existingRemissionDetails,
+        String feeRemissionType,
+        String exceptionalCircumstances,
+        List<IdValue<Document>> remissionEcEvidenceDocuments
+    ) {
+        final RemissionDetails newRemissionDetails =
+            new RemissionDetails(feeRemissionType, exceptionalCircumstances, remissionEcEvidenceDocuments);
+
+        return append(existingRemissionDetails, newRemissionDetails);
+    }
+
+    private List<IdValue<RemissionDetails>> append(
+        List<IdValue<RemissionDetails>> existingRemissionDetails,
+        RemissionDetails newRemissionDetails) {
+
+        final  List<IdValue<RemissionDetails>> allRemissionDetails = new ArrayList<>();
+
+        int index = existingRemissionDetails.size() + 1;
+
+        allRemissionDetails.add(new IdValue<>(String.valueOf(index--), newRemissionDetails));
+
+
+        for (IdValue<RemissionDetails> existingRemission : existingRemissionDetails) {
+            allRemissionDetails.add(new IdValue<>(String.valueOf(index--), existingRemission.getValue()));
+        }
+
+        return allRemissionDetails;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/RemissionDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/RemissionDetailsTest.java
@@ -98,4 +98,23 @@ class RemissionDetailsTest {
         assertEquals(exceptionalCircumstances, remissionDetails.getExceptionalCircumstances());
         assertEquals(remissionEcEvidenceDocuments, remissionDetails.getRemissionEcEvidenceDocuments());
     }
+
+    @Test
+    void should_set_correct_fields_in_remission_details() {
+
+        RemissionDetails remissionDetails =
+            new RemissionDetails("", "", "");
+
+        remissionDetails.setAmountLeftToPay(amountLeftToPay);
+        remissionDetails.setAmountRemitted(amountRemitted);
+        remissionDetails.setFeeAmount(feeAmount);
+        remissionDetails.setRemissionDecision(remissionDecision);
+        remissionDetails.setRemissionDecisionReason(remissionDecisionReason);
+
+        assertEquals(amountLeftToPay, remissionDetails.getAmountLeftToPay());
+        assertEquals(amountRemitted, remissionDetails.getAmountRemitted());
+        assertEquals(feeAmount, remissionDetails.getFeeAmount());
+        assertEquals(remissionDecision, remissionDetails.getRemissionDecision());
+        assertEquals(remissionDecisionReason, remissionDetails.getRemissionDecisionReason());
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/RemissionDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/RemissionDetailsTest.java
@@ -1,0 +1,101 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+
+class RemissionDetailsTest {
+
+    private String feeRemissionType = "A remission type";
+    private String asylumSupportReference = "Asylum support";
+    private Document asylumSupportDocument = mock(Document.class);
+    private String legalAidAccountNumber = "legalAidAccountNumber";
+    private Document section17Document = mock(Document.class);
+    private Document section20Document = mock(Document.class);
+    private Document homeOfficeWaiverDocument = mock(Document.class);
+    private String helpWithFeesReferenceNumber = "helpWithFeesReferenceNumber";
+    private String exceptionalCircumstances = "exceptionalCircumstances";
+    private List<IdValue<Document>> remissionEcEvidenceDocuments = Collections.emptyList();
+    private String remissionDecision = "remissionDecision";
+    private String feeAmount = "14000";
+    private String amountRemitted = "4000";
+    private String amountLeftToPay = "4000";
+    private String remissionDecisionReason = "remissionDecisionReason";
+
+    @Test
+    void should_hold_asylum_support_remission_details() {
+
+        RemissionDetails remissionDetails =
+            new RemissionDetails(feeRemissionType, asylumSupportReference, asylumSupportDocument);
+
+        assertEquals(feeRemissionType, remissionDetails.getFeeRemissionType());
+        assertEquals(asylumSupportReference, remissionDetails.getAsylumSupportReference());
+        assertEquals(asylumSupportDocument, remissionDetails.getAsylumSupportDocument());
+    }
+
+    @Test
+    void should_hold_legal_aid_remission_details() {
+
+        RemissionDetails remissionDetails =
+            new RemissionDetails(feeRemissionType, legalAidAccountNumber, "");
+
+        assertEquals(feeRemissionType, remissionDetails.getFeeRemissionType());
+        assertEquals(legalAidAccountNumber, remissionDetails.getLegalAidAccountNumber());
+    }
+
+    @Test
+    void should_hold_help_with_fees_remission_details() {
+
+        RemissionDetails remissionDetails =
+            new RemissionDetails(feeRemissionType, null, helpWithFeesReferenceNumber);
+
+        assertEquals(feeRemissionType, remissionDetails.getFeeRemissionType());
+        assertEquals(helpWithFeesReferenceNumber, remissionDetails.getHelpWithFeesReferenceNumber());
+    }
+
+    @Test
+    void should_hold_section_17_remission_details() {
+
+        RemissionDetails remissionDetails =
+            new RemissionDetails(feeRemissionType, section17Document, null, null);
+
+        assertEquals(feeRemissionType, remissionDetails.getFeeRemissionType());
+        assertEquals(section17Document, remissionDetails.getSection17Document());
+    }
+
+    @Test
+    void should_hold_section_20_remission_details() {
+
+        RemissionDetails remissionDetails =
+            new RemissionDetails(feeRemissionType, null, section20Document, null);
+
+        assertEquals(feeRemissionType, remissionDetails.getFeeRemissionType());
+        assertEquals(section20Document, remissionDetails.getSection20Document());
+    }
+
+    @Test
+    void should_hold_home_office_waiver_remission_details() {
+
+        RemissionDetails remissionDetails =
+            new RemissionDetails(feeRemissionType, null, null, homeOfficeWaiverDocument);
+
+        assertEquals(feeRemissionType, remissionDetails.getFeeRemissionType());
+        assertEquals(homeOfficeWaiverDocument, remissionDetails.getHomeOfficeWaiverDocument());
+    }
+
+    @Test
+    void should_hold_exceptional_circumstances_remission_details() {
+
+        RemissionDetails remissionDetails =
+            new RemissionDetails(feeRemissionType, exceptionalCircumstances, remissionEcEvidenceDocuments);
+
+        assertEquals(feeRemissionType, remissionDetails.getFeeRemissionType());
+        assertEquals(exceptionalCircumstances, remissionDetails.getExceptionalCircumstances());
+        assertEquals(remissionEcEvidenceDocuments, remissionDetails.getRemissionEcEvidenceDocuments());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/RemissionDetailsAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/RemissionDetailsAppenderTest.java
@@ -1,0 +1,154 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class RemissionDetailsAppenderTest {
+
+    @Mock private IdValue<RemissionDetails> remissionDetailsById1;
+    private RemissionDetailsAppender remissionDetailsAppender;
+
+    private String feeRemissionType = "feeRemissionType";
+
+    @BeforeEach
+    void setUp() {
+
+        remissionDetailsAppender = new RemissionDetailsAppender();
+    }
+
+    @Test
+    void append_asylum_support_remission_details() {
+
+        String asylumSupportReference = "asylumSupportReference";
+        Document asylumSupportDocument = mock(Document.class);
+
+        RemissionDetails remissionDetails1 = mock(RemissionDetails.class);
+        when(remissionDetailsById1.getValue()).thenReturn(remissionDetails1);
+
+        List<IdValue<RemissionDetails>> existingRemissionDetails = Arrays.asList(remissionDetailsById1);
+
+        List<IdValue<RemissionDetails>> remissionDetails =
+            remissionDetailsAppender
+                .appendAsylumSupportRemissionDetails(existingRemissionDetails, feeRemissionType, asylumSupportReference, asylumSupportDocument);
+
+        assertNotNull(remissionDetails);
+        assertEquals(2, remissionDetails.size());
+    }
+
+    void append_legal_aid_remission_details() {
+
+        String legalAidAccountNumber = "legalAidAccountNumber";
+
+        RemissionDetails remissionDetails1 = mock(RemissionDetails.class);
+        when(remissionDetailsById1.getValue()).thenReturn(remissionDetails1);
+
+        List<IdValue<RemissionDetails>> existingRemissionDetails = Arrays.asList(remissionDetailsById1);
+
+        List<IdValue<RemissionDetails>> remissionDetails =
+            remissionDetailsAppender.appendLegalAidRemissionDetails(existingRemissionDetails, feeRemissionType, legalAidAccountNumber);
+
+        assertNotNull(remissionDetails);
+        assertEquals(2, remissionDetails.size());
+    }
+
+    @Test
+    void append_help_with_fees_remission_details() {
+
+        String helpWithFeeReference = "helpWithFeeReference";
+
+        RemissionDetails remissionDetails1 = mock(RemissionDetails.class);
+        when(remissionDetailsById1.getValue()).thenReturn(remissionDetails1);
+
+        List<IdValue<RemissionDetails>> existingRemissionDetails = Arrays.asList(remissionDetailsById1);
+
+        List<IdValue<RemissionDetails>> remissionDetails =
+            remissionDetailsAppender.appendHelpWithFeeReferenceRemissionDetails(existingRemissionDetails, feeRemissionType, helpWithFeeReference);
+
+        assertNotNull(remissionDetails);
+        assertEquals(2, remissionDetails.size());
+    }
+
+    @Test
+    void append_section17_remission_details() {
+
+        Document section17Document = mock(Document.class);
+
+        RemissionDetails remissionDetails1 = mock(RemissionDetails.class);
+        when(remissionDetailsById1.getValue()).thenReturn(remissionDetails1);
+
+        List<IdValue<RemissionDetails>> existingRemissionDetails = Arrays.asList(remissionDetailsById1);
+
+        List<IdValue<RemissionDetails>> remissionDetails =
+            remissionDetailsAppender.appendSection17RemissionDetails(existingRemissionDetails, feeRemissionType, section17Document);
+
+        assertNotNull(remissionDetails);
+        assertEquals(2, remissionDetails.size());
+    }
+
+    @Test
+    void append_section20_remission_details() {
+
+        Document section20Document = mock(Document.class);
+
+        RemissionDetails remissionDetails1 = mock(RemissionDetails.class);
+        when(remissionDetailsById1.getValue()).thenReturn(remissionDetails1);
+
+        List<IdValue<RemissionDetails>> existingRemissionDetails = Arrays.asList(remissionDetailsById1);
+
+        List<IdValue<RemissionDetails>> remissionDetails =
+            remissionDetailsAppender.appendSection17RemissionDetails(existingRemissionDetails, feeRemissionType, section20Document);
+
+        assertNotNull(remissionDetails);
+        assertEquals(2, remissionDetails.size());
+    }
+
+    @Test
+    void append_home_office_waiver_remission_details() {
+
+        Document homeOfficeWaiver = mock(Document.class);
+
+        RemissionDetails remissionDetails1 = mock(RemissionDetails.class);
+        when(remissionDetailsById1.getValue()).thenReturn(remissionDetails1);
+
+        List<IdValue<RemissionDetails>> existingRemissionDetails = Arrays.asList(remissionDetailsById1);
+
+        List<IdValue<RemissionDetails>> remissionDetails =
+            remissionDetailsAppender.appendSection17RemissionDetails(existingRemissionDetails, feeRemissionType, homeOfficeWaiver);
+
+        assertNotNull(remissionDetails);
+        assertEquals(2, remissionDetails.size());
+    }
+
+    @Test
+    void append_exceptional_circumstances_remission_details() {
+
+        String exceptionalCircumstances = "exceptionalCircumstances";
+        List<IdValue<Document>> ecDocuments = Collections.emptyList();
+
+        RemissionDetails remissionDetails1 = mock(RemissionDetails.class);
+        when(remissionDetailsById1.getValue()).thenReturn(remissionDetails1);
+
+        List<IdValue<RemissionDetails>> existingRemissionDetails = Arrays.asList(remissionDetailsById1);
+
+        List<IdValue<RemissionDetails>> remissionDetails =
+            remissionDetailsAppender
+                .appendExceptionalCircumstancesRemissionDetails(existingRemissionDetails, feeRemissionType, exceptionalCircumstances, ecDocuments);
+
+        assertNotNull(remissionDetails);
+        assertEquals(2, remissionDetails.size());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/RemissionDetailsAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/RemissionDetailsAppenderTest.java
@@ -49,6 +49,7 @@ class RemissionDetailsAppenderTest {
         assertEquals(2, remissionDetails.size());
     }
 
+    @Test
     void append_legal_aid_remission_details() {
 
         String legalAidAccountNumber = "legalAidAccountNumber";


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-3850](https://github.com/hmcts/ia-case-api/compare/RIA-3859)


### Change description ###
Supporting classes for storing remission details as a collection


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
