### PR TITLE
RIA-4116: Added condition to ignore sending Home Office notifications for inflight cases and for cases where validation has failed

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-3302-ho-notifications-for-end-appeal-with-appeal-submitted-co.json
+++ b/src/functionalTest/resources/scenarios/RIA-3302-ho-notifications-for-end-appeal-with-appeal-submitted-co.json
@@ -10,7 +10,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "endAppealOutcome": "Struck out",
           "endAppealOutcomeReason": "fees not paid"
         }
@@ -21,6 +23,9 @@
       }
     }
   },
+  "homeOfficeSearchStatus": "SUCCESS",
+  "homeOfficeNotificationsEligible": "Yes",
+
   "expectation": {
     "status": 200,
     "errors": [],
@@ -28,7 +33,9 @@
       "template": "minimal-appeal-submitted.json",
       "replacements": {
         "stateBeforeEndAppeal": "appealSubmitted",
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "homeOfficeEndAppealInstructStatus": "OK"
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-3305-ho-notifications-for-async-stitching-complete.json
+++ b/src/functionalTest/resources/scenarios/RIA-3305-ho-notifications-for-async-stitching-complete.json
@@ -10,6 +10,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "listCaseHearingCentre": "taylorHouse",
           "ariaListingReference": "LP/12345/2019",
           "legalRepReferenceNumber": "REF54321",
@@ -58,6 +61,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "homeOfficeHearingBundleReadyInstructStatus": "OK"
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-3306-home-office-notifications-for-case-listing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3306-home-office-notifications-for-case-listing.json
@@ -10,7 +10,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "listCaseHearingCentre": "coventry",
           "listCaseHearingLength": "60",
           "listCaseHearingDate": "2018-12-31T12:34:56",
@@ -32,7 +34,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "listCaseHearingCentre": "coventry",
         "listCaseHearingLength": "60",
         "listCaseHearingDate": "2018-12-31T12:34:56",

--- a/src/functionalTest/resources/scenarios/RIA-3307-leadership-judge-record-appellant-ftpa-decision-ho-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-3307-leadership-judge-record-appellant-ftpa-decision-ho-notification.json
@@ -11,6 +11,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "ftpaApplicantType": "appellant",
           "ftpaAppellantSubmitted": "Yes",
           "ftpaAppellantDecisionOutcomeType": "partiallyGranted",
@@ -38,6 +41,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "ftpaAppellantDecisionDate": "{$TODAY}",
         "isFtpaAppellantDecided": "Yes",
         "allFtpaAppellantDecisionDocs": [

--- a/src/functionalTest/resources/scenarios/RIA-3307-leadership-judge-respondent-ftpa-decision-ho-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-3307-leadership-judge-respondent-ftpa-decision-ho-notification.json
@@ -11,6 +11,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "ftpaApplicantType": "respondent",
           "ftpaRespondentSubmitted": "Yes",
           "listCaseHearingCentre": "taylorHouse",
@@ -39,6 +42,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "ftpaRespondentDecisionDate": "{$TODAY}",
         "isFtpaRespondentDecided": "Yes",
         "listCaseHearingCentre": "taylorHouse",

--- a/src/functionalTest/resources/scenarios/RIA-3307-resident-judge-appellant-ftpa-decision-ho-notification-remade-allowed.json
+++ b/src/functionalTest/resources/scenarios/RIA-3307-resident-judge-appellant-ftpa-decision-ho-notification-remade-allowed.json
@@ -11,6 +11,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "ftpaApplicantType": "appellant",
           "ftpaAppellantSubmitted": "Yes",
           "ftpaAppellantRjDecisionOutcomeType": "remadeRule32",
@@ -54,6 +57,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "ftpaAppellantDecisionDate": "{$TODAY}",
         "isFtpaAppellantDecided": "Yes",
         "allFtpaAppellantDecisionDocs": [

--- a/src/functionalTest/resources/scenarios/RIA-3307-resident-judge-appellant-ftpa-decision-ho-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-3307-resident-judge-appellant-ftpa-decision-ho-notification.json
@@ -11,6 +11,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "ftpaApplicantType": "appellant",
           "ftpaAppellantSubmitted": "Yes",
           "ftpaAppellantRjDecisionOutcomeType": "granted",
@@ -53,6 +56,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "ftpaAppellantDecisionDate": "{$TODAY}",
         "isFtpaAppellantDecided": "Yes",
         "allFtpaAppellantDecisionDocs": [

--- a/src/functionalTest/resources/scenarios/RIA-3307-resident-judge-respondent-ftpa-decision-ho-notification-remade-dismissed.json
+++ b/src/functionalTest/resources/scenarios/RIA-3307-resident-judge-respondent-ftpa-decision-ho-notification-remade-dismissed.json
@@ -11,6 +11,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "ftpaApplicantType": "respondent",
           "ftpaRespondentSubmitted": "Yes",
           "ftpaRespondentRjDecisionOutcomeType": "remadeRule32",
@@ -54,6 +57,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "ftpaRespondentDecisionDate": "{$TODAY}",
         "isFtpaRespondentDecided": "Yes",
         "allFtpaRespondentDecisionDocs": [

--- a/src/functionalTest/resources/scenarios/RIA-3307-resident-judge-respondent-ftpa-decision-ho-notification.json
+++ b/src/functionalTest/resources/scenarios/RIA-3307-resident-judge-respondent-ftpa-decision-ho-notification.json
@@ -11,6 +11,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "ftpaApplicantType": "respondent",
           "ftpaRespondentSubmitted": "Yes",
           "ftpaRespondentRjDecisionOutcomeType": "reheardRule32",
@@ -53,6 +56,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "ftpaRespondentDecisionDate": "{$TODAY}",
         "isFtpaRespondentDecided": "Yes",
         "allFtpaRespondentDecisionDocs": [

--- a/src/functionalTest/resources/scenarios/RIA-3308-home-office-notifications-for-request_respondent_evidence-multiple-nationalities.json
+++ b/src/functionalTest/resources/scenarios/RIA-3308-home-office-notifications-for-request_respondent_evidence-multiple-nationalities.json
@@ -23,11 +23,13 @@
                 "code": "CA"
               }
             }],
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
           "appealSubmissionDate": "2020-09-22",
           "sendDirectionExplanation": "A notice of appeal has been lodged against this decision.\n\nYou must now upload all documents to the Tribunal. The Tribunal will make them accessible to the other party. You have 14 days to supply the documents.\n\nYou must include:\n- the notice of decision\n- any other document provided to the appellant giving reasons for that decision\n- any statements of evidence\n- the application form\n- any record of interview with the appellant in relation to the decision being appealed\n- any other unpublished documents on which you rely\n- the notice of any other appealable decision made in relation to the appellant",
           "sendDirectionParties": "respondent",
-          "sendDirectionDateDue": "{$TODAY+14}"
+          "sendDirectionDateDue": "{$TODAY+14}",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes"
         }
       }
     }
@@ -51,7 +53,9 @@
               "code": "CA"
             }
           }],
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "homeOfficeInstructStatus": "OK"
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-3308-home-office-notifications-for-request_respondent_evidence.json
+++ b/src/functionalTest/resources/scenarios/RIA-3308-home-office-notifications-for-request_respondent_evidence.json
@@ -10,11 +10,13 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
           "appealSubmissionDate": "2020-09-22",
           "sendDirectionExplanation": "A notice of appeal has been lodged against this decision.\n\nYou must now upload all documents to the Tribunal. The Tribunal will make them accessible to the other party. You have 14 days to supply the documents.\n\nYou must include:\n- the notice of decision\n- any other document provided to the appellant giving reasons for that decision\n- any statements of evidence\n- the application form\n- any record of interview with the appellant in relation to the decision being appealed\n- any other unpublished documents on which you rely\n- the notice of any other appealable decision made in relation to the appellant",
           "sendDirectionParties": "respondent",
-          "sendDirectionDateDue": "{$TODAY+14}"
+          "sendDirectionDateDue": "{$TODAY+14}",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes"
         }
       }
     }
@@ -25,7 +27,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "homeOfficeInstructStatus": "OK"
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-3309-ho-notifications-for-edit-case-listing-decision.json
+++ b/src/functionalTest/resources/scenarios/RIA-3309-ho-notifications-for-edit-case-listing-decision.json
@@ -10,7 +10,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
           "listCaseHearingCentre": "coventry",
           "listCaseHearingLength": "60",
           "listCaseHearingDate": "2018-12-31T12:34:56",
@@ -21,12 +21,15 @@
           "listCaseRequirementsOther": "something around Other",
           "uploadAdditionalEvidenceActionAvailable": "No",
           "decisionHearingFeeOption": "decisionWithHearing",
-          "ariaListingReference": "LP/12345/2019"
+          "ariaListingReference": "LP/12345/2019",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes"
         }
       },
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
           "listCaseHearingCentre": "manchester",
           "listCaseHearingLength": "60",
           "listCaseHearingDate": "2018-12-31T12:34:56",
@@ -37,6 +40,8 @@
           "listCaseRequirementsOther": "something around Other",
           "uploadAdditionalEvidenceActionAvailable": "No",
           "ariaListingReference": "LP/12345/2019",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "hearingDocuments": [
             {
               "id": "1",
@@ -62,7 +67,7 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
         "listCaseHearingCentre": "coventry",
         "listCaseHearingLength": "60",
         "listCaseHearingDate": "2018-12-31T12:34:56",
@@ -75,6 +80,8 @@
         "sendDirectionActionAvailable": "No",
         "ariaListingReference": "LP/12345/2019",
         "decisionHearingFeeOption": "decisionWithHearing",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "homeOfficeEditListingInstructStatus": "OK"
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-3309-ho-notifications-for-edit-case-listing-finalbundling.json
+++ b/src/functionalTest/resources/scenarios/RIA-3309-ho-notifications-for-edit-case-listing-finalbundling.json
@@ -10,7 +10,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
           "listCaseHearingCentre": "coventry",
           "listCaseHearingLength": "60",
           "listCaseHearingDate": "2018-12-31T12:34:56",
@@ -21,12 +21,15 @@
           "listCaseRequirementsOther": "something around Other",
           "uploadAdditionalEvidenceActionAvailable": "No",
           "decisionHearingFeeOption": "decisionWithHearing",
-          "ariaListingReference": "LP/12345/2019"
+          "ariaListingReference": "LP/12345/2019",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes"
         }
       },
       "caseDataBefore": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
           "listCaseHearingCentre": "manchester",
           "listCaseHearingLength": "60",
           "listCaseHearingDate": "2018-12-31T12:34:56",
@@ -37,6 +40,8 @@
           "listCaseRequirementsOther": "something around Other",
           "uploadAdditionalEvidenceActionAvailable": "No",
           "ariaListingReference": "LP/12345/2019",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "hearingDocuments": [
             {
               "id": "1",
@@ -62,7 +67,7 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
         "listCaseHearingCentre": "coventry",
         "listCaseHearingLength": "60",
         "listCaseHearingDate": "2018-12-31T12:34:56",
@@ -74,6 +79,8 @@
         "uploadAdditionalEvidenceActionAvailable": "No",
         "ariaListingReference": "LP/12345/2019",
         "decisionHearingFeeOption": "decisionWithHearing",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "homeOfficeEditListingInstructStatus": "OK"
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-3309-ho-notifications-for-edit-case-listing-prehearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3309-ho-notifications-for-edit-case-listing-prehearing.json
@@ -10,7 +10,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
           "listCaseHearingCentre": "coventry",
           "listCaseHearingLength": "60",
           "listCaseHearingDate": "2018-12-31T12:34:56",
@@ -21,7 +21,9 @@
           "listCaseRequirementsOther": "something around Other",
           "uploadAdditionalEvidenceActionAvailable": "No",
           "ariaListingReference": "LP/12345/2019",
-          "decisionHearingFeeOption": "decisionWithHearing"
+          "decisionHearingFeeOption": "decisionWithHearing",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes"
         }
       },
       "caseDataBefore": {
@@ -37,6 +39,8 @@
           "listCaseRequirementsOther": "something around Other",
           "uploadAdditionalEvidenceActionAvailable": "Yes",
           "ariaListingReference": "LP/12345/2019",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "hearingDocuments": [
             {
               "id": "1",
@@ -62,7 +66,7 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
         "listCaseHearingCentre": "coventry",
         "listCaseHearingLength": "60",
         "listCaseHearingDate": "2018-12-31T12:34:56",
@@ -74,6 +78,8 @@
         "uploadAdditionalEvidenceActionAvailable": "No",
         "ariaListingReference": "LP/12345/2019",
         "decisionHearingFeeOption": "decisionWithHearing",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "homeOfficeEditListingInstructStatus": "OK"
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-3309-ho-notifications-for-edit-case-listing-prepareforhearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3309-ho-notifications-for-edit-case-listing-prepareforhearing.json
@@ -10,7 +10,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
           "listCaseHearingCentre": "coventry",
           "listCaseHearingLength": "60",
           "listCaseHearingDate": "2018-12-31T12:34:56",
@@ -21,7 +21,9 @@
           "listCaseRequirementsOther": "something around Other",
           "uploadAdditionalEvidenceActionAvailable": "Yes",
           "ariaListingReference": "LP/12345/2019",
-          "decisionHearingFeeOption": "decisionWithHearing"
+          "decisionHearingFeeOption": "decisionWithHearing",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes"
         }
       },
       "caseDataBefore": {
@@ -37,6 +39,8 @@
           "listCaseRequirementsOther": "something around Other",
           "uploadAdditionalEvidenceActionAvailable": "Yes",
           "ariaListingReference": "LP/12345/2019",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "hearingDocuments": [
             {
               "id": "1",
@@ -62,7 +66,7 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
         "listCaseHearingCentre": "coventry",
         "listCaseHearingLength": "60",
         "listCaseHearingDate": "2018-12-31T12:34:56",
@@ -74,6 +78,8 @@
         "uploadAdditionalEvidenceActionAvailable": "Yes",
         "ariaListingReference": "LP/12345/2019",
         "decisionHearingFeeOption": "decisionWithHearing",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "homeOfficeEditListingInstructStatus": "OK"
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-3313-ftpa-appellant-notification-decided.json
+++ b/src/functionalTest/resources/scenarios/RIA-3313-ftpa-appellant-notification-decided.json
@@ -11,6 +11,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "listCaseHearingCentre": "taylorHouse",
           "ftpaAppellantDocuments": [],
           "ftpaAppellantOutOfTimeDocuments": [],
@@ -51,6 +54,10 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
+        "listCaseHearingCentre": "manchester",
         "ftpaAppellantSubmitted": "Yes",
         "ftpaAppellantSubmissionOutOfTime": "No",
         "ftpaAppellantApplicationDate": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-3313-ftpa-appellant-notification-ftpa-decided.json
+++ b/src/functionalTest/resources/scenarios/RIA-3313-ftpa-appellant-notification-ftpa-decided.json
@@ -11,6 +11,10 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
+          "listCaseHearingCentre": "manchester",
           "ftpaAppellantDocuments": [],
           "ftpaAppellantOutOfTimeDocuments": [],
           "ftpaAppellantGroundsDocuments": [
@@ -50,6 +54,10 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
+        "listCaseHearingCentre": "manchester",
         "ftpaAppellantSubmitted": "Yes",
         "ftpaAppellantSubmissionOutOfTime": "No",
         "ftpaAppellantApplicationDate": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-3313-ftpa-appellant-notification-ftpa-submitted.json
+++ b/src/functionalTest/resources/scenarios/RIA-3313-ftpa-appellant-notification-ftpa-submitted.json
@@ -11,6 +11,10 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
+          "listCaseHearingCentre": "manchester",
           "ftpaAppellantDocuments": [],
           "ftpaAppellantOutOfTimeDocuments": [],
           "ftpaAppellantGroundsDocuments": [
@@ -50,6 +54,10 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
+        "listCaseHearingCentre": "manchester",
         "ftpaAppellantSubmitted": "Yes",
         "ftpaAppellantSubmissionOutOfTime": "No",
         "ftpaAppellantApplicationDate": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-3313-ftpa-respondent-notification-homeoffice-generic-decided.json
+++ b/src/functionalTest/resources/scenarios/RIA-3313-ftpa-respondent-notification-homeoffice-generic-decided.json
@@ -11,6 +11,10 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
+          "listCaseHearingCentre": "manchester",
           "ftpaRespondentDocuments": [],
           "ftpaRespondentOutOfTimeDocuments": [],
           "ftpaRespondentGroundsDocuments": [
@@ -50,6 +54,10 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
+        "listCaseHearingCentre": "manchester",
         "ftpaRespondentSubmitted": "Yes",
         "ftpaRespondentSubmissionOutOfTime": "No",
         "ftpaRespondentApplicationDate": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-3313-ftpa-respondent-notification-homeoffice-generic-ftpa-decided.json
+++ b/src/functionalTest/resources/scenarios/RIA-3313-ftpa-respondent-notification-homeoffice-generic-ftpa-decided.json
@@ -11,6 +11,10 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
+          "listCaseHearingCentre": "manchester",
           "ftpaRespondentDocuments": [],
           "ftpaRespondentOutOfTimeDocuments": [],
           "ftpaRespondentGroundsDocuments": [
@@ -50,6 +54,10 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
+        "listCaseHearingCentre": "manchester",
         "ftpaRespondentSubmitted": "Yes",
         "ftpaRespondentSubmissionOutOfTime": "No",
         "ftpaRespondentApplicationDate": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-3313-ftpa-respondent-notification-homeoffice-generic-ftpa-submitted.json
+++ b/src/functionalTest/resources/scenarios/RIA-3313-ftpa-respondent-notification-homeoffice-generic-ftpa-submitted.json
@@ -11,6 +11,10 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
+          "listCaseHearingCentre": "manchester",
           "ftpaRespondentDocuments": [],
           "ftpaRespondentOutOfTimeDocuments": [],
           "ftpaRespondentGroundsDocuments": [
@@ -50,6 +54,10 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
+        "listCaseHearingCentre": "manchester",
         "ftpaRespondentSubmitted": "Yes",
         "ftpaRespondentSubmissionOutOfTime": "No",
         "ftpaRespondentApplicationDate": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-3313-ftpa-respondent-notification-homeoffice-pou-decided.json
+++ b/src/functionalTest/resources/scenarios/RIA-3313-ftpa-respondent-notification-homeoffice-pou-decided.json
@@ -11,6 +11,10 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
+          "listCaseHearingCentre": "manchester",
           "ftpaRespondentDocuments": [],
           "ftpaRespondentOutOfTimeDocuments": [],
           "ftpaRespondentGroundsDocuments": [
@@ -50,6 +54,10 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
+        "listCaseHearingCentre": "manchester",
         "ftpaRespondentSubmitted": "Yes",
         "ftpaRespondentSubmissionOutOfTime": "No",
         "ftpaRespondentApplicationDate": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-3313-ftpa-respondent-notification-homeoffice-pou-ftpa-decided.json
+++ b/src/functionalTest/resources/scenarios/RIA-3313-ftpa-respondent-notification-homeoffice-pou-ftpa-decided.json
@@ -11,6 +11,10 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
+          "listCaseHearingCentre": "manchester",
           "ftpaRespondentDocuments": [],
           "ftpaRespondentOutOfTimeDocuments": [],
           "ftpaRespondentGroundsDocuments": [
@@ -50,6 +54,10 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
+        "listCaseHearingCentre": "manchester",
         "ftpaRespondentSubmitted": "Yes",
         "ftpaRespondentSubmissionOutOfTime": "No",
         "ftpaRespondentApplicationDate": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-3313-ftpa-respondent-notification-homeoffice-pou-ftpa-submitted.json
+++ b/src/functionalTest/resources/scenarios/RIA-3313-ftpa-respondent-notification-homeoffice-pou-ftpa-submitted.json
@@ -11,6 +11,10 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
+          "listCaseHearingCentre": "manchester",
           "ftpaRespondentDocuments": [],
           "ftpaRespondentOutOfTimeDocuments": [],
           "ftpaRespondentGroundsDocuments": [
@@ -50,6 +54,10 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
+        "listCaseHearingCentre": "manchester",
         "ftpaRespondentSubmitted": "Yes",
         "ftpaRespondentSubmissionOutOfTime": "No",
         "ftpaRespondentApplicationDate": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-3316-ho-notifications-for-edit-adjourn-no-date-decision.json
+++ b/src/functionalTest/resources/scenarios/RIA-3316-ho-notifications-for-edit-adjourn-no-date-decision.json
@@ -10,7 +10,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "adjournHearingWithoutDateReasons": "Court closed now",
           "listCaseHearingCentre": "coventry",
           "listCaseHearingLength": "60",
@@ -39,7 +41,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "listCaseHearingCentre": "coventry",
         "listCaseRequirementsVulnerabilities": "something around Vulnerabilities",
         "listCaseRequirementsMultimedia": "something around Multimedia",

--- a/src/functionalTest/resources/scenarios/RIA-3316-ho-notifications-for-edit-adjourn-no-date-finalbundling.json
+++ b/src/functionalTest/resources/scenarios/RIA-3316-ho-notifications-for-edit-adjourn-no-date-finalbundling.json
@@ -10,7 +10,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "adjournHearingWithoutDateReasons": "Court closed now",
           "listCaseHearingCentre": "coventry",
           "listCaseHearingLength": "60",
@@ -39,7 +41,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "listCaseHearingCentre": "coventry",
         "listCaseHearingLength": "60",
         "listCaseHearingDate": "2018-12-31T12:34:56",

--- a/src/functionalTest/resources/scenarios/RIA-3316-ho-notifications-for-edit-adjourn-no-date-prehearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3316-ho-notifications-for-edit-adjourn-no-date-prehearing.json
@@ -10,7 +10,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "adjournHearingWithoutDateReasons": "Court closed now",
           "listCaseHearingCentre": "coventry",
           "listCaseHearingLength": "60",
@@ -39,7 +41,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "listCaseHearingCentre": "coventry",
         "listCaseHearingLength": "60",
         "listCaseHearingDate": "2018-12-31T12:34:56",

--- a/src/functionalTest/resources/scenarios/RIA-3316-ho-notifications-for-edit-adjourn-no-date-prepareforhearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3316-ho-notifications-for-edit-adjourn-no-date-prepareforhearing.json
@@ -10,7 +10,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "adjournHearingWithoutDateReasons": "Court closed now",
           "listCaseHearingCentre": "coventry",
           "listCaseHearingLength": "60",
@@ -39,7 +41,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "listCaseHearingCentre": "coventry",
         "listCaseHearingLength": "60",
         "listCaseHearingDate": "2018-12-31T12:34:56",

--- a/src/functionalTest/resources/scenarios/RIA-3600-home-office-notifications-for-request_respondent_review.json
+++ b/src/functionalTest/resources/scenarios/RIA-3600-home-office-notifications-for-request_respondent_review.json
@@ -10,7 +10,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "sendDirectionExplanation": "You have 14 days to review the appellant's argument and evidence. You must explain whether the appellant makes a valid case for overturning the original decision.\\n\\nYou must respond to the Tribunal and tell them:\\n\\n- whether you oppose all or parts of the appellant's case\\n- what your grounds are for opposing the case\\n- which of the issues are agreed or not agreed\\n- whether there are any further issues you wish to raise\\n- whether you are prepared to withdraw to grant\\n- whether the appeal can be resolved without a hearing\\n\\nNext steps\\n\\nIf you do not respond in time the Tribunal will decide how the case should proceed.",
           "sendDirectionParties": "respondent",
           "sendDirectionDateDue": "{$TODAY+14}"
@@ -24,7 +26,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "directions": [
           {
             "id": "1",

--- a/src/functionalTest/resources/scenarios/RIA-3691-home-office-notifications-for-amend-bundle-send_direction.json
+++ b/src/functionalTest/resources/scenarios/RIA-3691-home-office-notifications-for-amend-bundle-send_direction.json
@@ -10,7 +10,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "sendDirectionExplanation": "You must now tell us why you think the Home Office decision to refuse your claim is wrong.",
           "sendDirectionDateDue": "{$TODAY+28}",
           "sendDirectionParties": "respondent",
@@ -49,7 +51,7 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
         "homeOfficeAmendBundleInstructStatus": "OK"
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-3692-home-office-notification-amend-response-for-respondent-review.json
+++ b/src/functionalTest/resources/scenarios/RIA-3692-home-office-notification-amend-response-for-respondent-review.json
@@ -11,7 +11,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "sendDirectionExplanation": "Review the case",
           "sendDirectionDateDue": "{$TODAY+28}",
           "uploadAdditionalEvidenceActionAvailable": "Yes",
@@ -38,7 +40,9 @@
       "template": "minimal-appeal-submitted.json",
       "replacements": {
         "uploadAdditionalEvidenceActionAvailable": "Yes",
-        "homeOfficeReferenceNumber": "1111-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "homeOfficeAmendResponseInstructStatus": "OK"
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-3693-ho-notifications-for-change-direction-due-date-awaitingRespondentEvidence.json
+++ b/src/functionalTest/resources/scenarios/RIA-3693-ho-notifications-for-change-direction-due-date-awaitingRespondentEvidence.json
@@ -11,7 +11,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "9999-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "listCaseHearingCentre": "coventry",
           "sendDirectionExplanation": "A notice of appeal has been lodged against this decision.",
           "sendDirectionDateDue": "{$TODAY+28}",
@@ -41,7 +43,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "9999-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "homeOfficeEvidenceChangeDirectionDueDateInstructStatus": "OK"
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-3693-ho-notifications-for-change-direction-due-date-requestRespondentReview.json
+++ b/src/functionalTest/resources/scenarios/RIA-3693-ho-notifications-for-change-direction-due-date-requestRespondentReview.json
@@ -11,7 +11,9 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "homeOfficeReferenceNumber": "9999-2222-3333-4444",
+          "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "homeOfficeNotificationsEligible": "Yes",
           "sendDirectionExplanation": "A notice of appeal has been lodged against this decision.",
           "sendDirectionDateDue": "{$TODAY+28}",
           "sendDirectionParties": "respondent",
@@ -40,7 +42,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "homeOfficeReferenceNumber": "9999-2222-3333-4444",
+        "homeOfficeReferenceNumber": "1212-0099-0062-8083",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes",
         "sendDirectionActionAvailable": "Yes",
         "uploadAdditionalEvidenceActionAvailable": "Yes",
         "homeOfficeReviewChangeDirectionDueDateInstructStatus": "OK"

--- a/src/functionalTest/resources/scenarios/RIA-4116-ho-notification-eligible-flag-appeal-submitted.json
+++ b/src/functionalTest/resources/scenarios/RIA-4116-ho-notification-eligible-flag-appeal-submitted.json
@@ -1,8 +1,8 @@
 {
-  "description": "RIA-3271 Set Home Office integration enabled flag value",
-  "disabled": "{$featureFlag.isHomeOfficeIntegrationEnabled}",
+  "description": "RIA-4116 Gets Home Office data for the IA appeal reference and sets the eligible field value",
+  "enabled": "{$featureFlag.isHomeOfficeIntegrationEnabled}",
   "request": {
-    "uri": "/asylum/ccdAboutToStart",
+    "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "LegalRepresentative",
     "input": {
       "eventId": "submitAppeal",
@@ -22,7 +22,12 @@
       "template": "minimal-appeal-submitted.json",
       "replacements": {
         "homeOfficeReferenceNumber": "1212-0099-0062-8083",
-        "isHomeOfficeIntegrationEnabled": "No"
+        "isHomeOfficeIntegrationEnabled": "Yes",
+        "contactPreferenceDescription": "Text message",
+        "appealTypeDescription": "Refusal of protection claim",
+        "appellantNationalitiesDescription": "Iceland",
+        "homeOfficeSearchStatus": "SUCCESS",
+        "homeOfficeNotificationsEligible": "Yes"
       }
     }
   }

--- a/src/functionalTest/resources/scenarios/RIA-4116-ho-notifications-existing-cases-response.json
+++ b/src/functionalTest/resources/scenarios/RIA-4116-ho-notifications-existing-cases-response.json
@@ -1,5 +1,5 @@
 {
-  "description": "RIA-3308 sends home office notifications for request respondent evidence - stateless",
+  "description": "RIA-4116 does not trigger home office notifications when a case is already in progress",
   "launchDarklyKey": "home-office-notification-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -10,20 +10,13 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "appellantNationalities": [
-            {
-              "id": "1",
-              "value": {
-                "code": "ZZ"
-              }
-            }],
           "homeOfficeReferenceNumber": "1212-0099-0062-8083",
           "appealSubmissionDate": "2020-09-22",
           "sendDirectionExplanation": "A notice of appeal has been lodged against this decision.\n\nYou must now upload all documents to the Tribunal. The Tribunal will make them accessible to the other party. You have 14 days to supply the documents.\n\nYou must include:\n- the notice of decision\n- any other document provided to the appellant giving reasons for that decision\n- any statements of evidence\n- the application form\n- any record of interview with the appellant in relation to the decision being appealed\n- any other unpublished documents on which you rely\n- the notice of any other appealable decision made in relation to the appellant",
           "sendDirectionParties": "respondent",
           "sendDirectionDateDue": "{$TODAY+14}",
           "homeOfficeSearchStatus": "SUCCESS",
-          "homeOfficeNotificationsEligible": "Yes"
+          "homeOfficeNotificationsEligible": "No"
         }
       }
     }
@@ -34,17 +27,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "appellantNationalities": [
-          {
-            "id": "1",
-            "value": {
-              "code": "ZZ"
-            }
-          }],
         "homeOfficeReferenceNumber": "1212-0099-0062-8083",
         "homeOfficeSearchStatus": "SUCCESS",
-        "homeOfficeNotificationsEligible": "Yes",
-        "homeOfficeInstructStatus": "OK"
+        "homeOfficeNotificationsEligible": "No"
       }
     }
   }

--- a/src/functionalTest/resources/scenarios/RIA-4116-ho-notifications-validation-fail-response.json
+++ b/src/functionalTest/resources/scenarios/RIA-4116-ho-notifications-validation-fail-response.json
@@ -1,5 +1,5 @@
 {
-  "description": "RIA-3308 sends home office notifications for request respondent evidence - stateless",
+  "description": "RIA-4116 does not trigger home office notifications when validation is not success",
   "launchDarklyKey": "home-office-notification-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -10,20 +10,13 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "appellantNationalities": [
-            {
-              "id": "1",
-              "value": {
-                "code": "ZZ"
-              }
-            }],
           "homeOfficeReferenceNumber": "1212-0099-0062-8083",
           "appealSubmissionDate": "2020-09-22",
           "sendDirectionExplanation": "A notice of appeal has been lodged against this decision.\n\nYou must now upload all documents to the Tribunal. The Tribunal will make them accessible to the other party. You have 14 days to supply the documents.\n\nYou must include:\n- the notice of decision\n- any other document provided to the appellant giving reasons for that decision\n- any statements of evidence\n- the application form\n- any record of interview with the appellant in relation to the decision being appealed\n- any other unpublished documents on which you rely\n- the notice of any other appealable decision made in relation to the appellant",
           "sendDirectionParties": "respondent",
           "sendDirectionDateDue": "{$TODAY+14}",
-          "homeOfficeSearchStatus": "SUCCESS",
-          "homeOfficeNotificationsEligible": "Yes"
+          "homeOfficeSearchStatus": "FAIL",
+          "homeOfficeNotificationsEligible": "No"
         }
       }
     }
@@ -34,17 +27,9 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
-        "appellantNationalities": [
-          {
-            "id": "1",
-            "value": {
-              "code": "ZZ"
-            }
-          }],
         "homeOfficeReferenceNumber": "1212-0099-0062-8083",
-        "homeOfficeSearchStatus": "SUCCESS",
-        "homeOfficeNotificationsEligible": "Yes",
-        "homeOfficeInstructStatus": "OK"
+        "homeOfficeSearchStatus": "FAIL",
+        "homeOfficeNotificationsEligible": "No"
       }
     }
   }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1010,6 +1010,9 @@ public enum AsylumCaseFieldDefinition {
     HOME_OFFICE_SEARCH_STATUS(
         "homeOfficeSearchStatus", new TypeReference<String>() {}),
 
+    HOME_OFFICE_NOTIFICATIONS_ELIGIBLE(
+        "homeOfficeNotificationsEligible", new TypeReference<YesOrNo>() {}),
+
     HOME_OFFICE_SEARCH_STATUS_MESSAGE(
         "homeOfficeSearchStatusMessage", new TypeReference<String>() {}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdvancedFinalBundlingStitchingCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdvancedFinalBundlingStitchingCallbackHandler.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
@@ -30,6 +31,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.service.NotificationSender;
 
 
 @Component
+@Slf4j
 public class AdvancedFinalBundlingStitchingCallbackHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
     private final NotificationSender<AsylumCase> notificationSender;
@@ -98,7 +100,7 @@ public class AdvancedFinalBundlingStitchingCallbackHandler implements PreSubmitC
         Optional<YesOrNo> maybeCaseFlagSetAsideReheardExists = asylumCase.read(CASE_FLAG_SET_ASIDE_REHEARD_EXISTS,YesOrNo.class);
 
         boolean isReheardCase = maybeCaseFlagSetAsideReheardExists.isPresent()
-                && maybeCaseFlagSetAsideReheardExists.get() == YesOrNo.YES;
+                                && maybeCaseFlagSetAsideReheardExists.get() == YesOrNo.YES;
 
         if (stitchedDocument.isPresent()) {
             saveHearingBundleDocument(asylumCase, stitchedDocument,isReheardCase ? REHEARD_HEARING_DOCUMENTS : HEARING_DOCUMENTS);
@@ -111,19 +113,43 @@ public class AdvancedFinalBundlingStitchingCallbackHandler implements PreSubmitC
         if (asylumCase.read(APPELLANT_IN_UK, YesOrNo.class).map(
             value -> value.equals(YesOrNo.YES)).orElse(true)) {
 
-            if (featureToggler.getValue(HO_NOTIFICATION_FEATURE, false)) {
-
-                AsylumCase asylumCaseWithHomeOfficeData = homeOfficeApi.call(callback);
-
-                asylumCaseWithHomeOfficeData.write(HOME_OFFICE_HEARING_BUNDLE_READY_INSTRUCT_STATUS,
-                    asylumCaseWithHomeOfficeData.read(HOME_OFFICE_HEARING_BUNDLE_READY_INSTRUCT_STATUS, String.class).orElse(""));
-            }
+            handleHomeOfficeNotification(callback, asylumCase);
         }
 
         AsylumCase asylumCaseWithNotificationMarker = notificationSender.send(callback);
 
         return new PreSubmitCallbackResponse<>(asylumCaseWithNotificationMarker);
+    }
 
+    private void handleHomeOfficeNotification(Callback<AsylumCase> callback, AsylumCase asylumCase) {
+
+        if (featureToggler.getValue(HO_NOTIFICATION_FEATURE, false)) {
+
+            final String homeOfficeSearchStatus = asylumCase.read(HOME_OFFICE_SEARCH_STATUS, String.class)
+                .orElse("");
+
+            final YesOrNo homeOfficeNotificationsEligible = asylumCase.read(HOME_OFFICE_NOTIFICATIONS_ELIGIBLE, YesOrNo.class)
+                .orElse(YesOrNo.NO);
+
+            if ("SUCCESS".equalsIgnoreCase(homeOfficeSearchStatus)
+                && homeOfficeNotificationsEligible == YesOrNo.YES) {
+
+                AsylumCase asylumCaseWithHomeOfficeData = homeOfficeApi.call(callback);
+
+                asylumCaseWithHomeOfficeData.write(HOME_OFFICE_HEARING_BUNDLE_READY_INSTRUCT_STATUS,
+                    asylumCaseWithHomeOfficeData.read(HOME_OFFICE_HEARING_BUNDLE_READY_INSTRUCT_STATUS, String.class).orElse(""));
+            } else {
+                final long caseId = callback.getCaseDetails().getId();
+                final String homeOfficeReferenceNumber = asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse("");
+
+                log.warn("Home Office notification was not invoked due to unsuccessful validation search - "
+                         + "caseId: {}, "
+                         + "homeOfficeReferenceNumber: {}, "
+                         + "homeOfficeSearchStatus: {}, "
+                         + "homeOfficeNotificationsEligible: {} ",
+                    caseId, homeOfficeReferenceNumber, homeOfficeSearchStatus, homeOfficeNotificationsEligible);
+            }
+        }
     }
 
     private void saveHearingBundleDocument(AsylumCase asylumCase, Optional<Document> stitchedDocument, AsylumCaseFieldDefinition field) {

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdvancedFinalBundlingStitchingCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdvancedFinalBundlingStitchingCallbackHandlerTest.java
@@ -115,6 +115,11 @@ class AdvancedFinalBundlingStitchingCallbackHandlerTest {
     @Test
     void should_successfully_handle_the_callback_in_reheard_case() {
 
+        when(featureToggler.getValue("home-office-notification-feature", false)).thenReturn(true);
+        when(homeOfficeApi.call(callback)).thenReturn(asylumCase);
+        when(asylumCase.read(HOME_OFFICE_HEARING_BUNDLE_READY_INSTRUCT_STATUS, String.class)).thenReturn(Optional.of("OK"));
+        when(asylumCase.read(HOME_OFFICE_SEARCH_STATUS, String.class)).thenReturn(Optional.of("SUCCESS"));
+        when(asylumCase.read(HOME_OFFICE_NOTIFICATIONS_ELIGIBLE, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(asylumCase.read(CASE_FLAG_SET_ASIDE_REHEARD_EXISTS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         assertEquals(asylumCase.read(CASE_FLAG_SET_ASIDE_REHEARD_EXISTS, YesOrNo.class), Optional.of(YesOrNo.YES));
 
@@ -143,15 +148,19 @@ class AdvancedFinalBundlingStitchingCallbackHandlerTest {
         verify(asylumCase, times(1)).read(REHEARD_HEARING_DOCUMENTS);
         verify(documentReceiver).receive(stitchedDocument, "", DocumentTag.HEARING_BUNDLE);
         verify(documentsAppender).append(anyList(), anyList(), eq(DocumentTag.HEARING_BUNDLE));
+        verify(homeOfficeApi, times(1)).call(callback);
+        verify(notificationSender, times(1)).send(callback);
 
     }
 
     @Test
-    public void should_write_instruct_status_when_ho_notification_feature_on() {
+    void should_write_instruct_status_when_ho_notification_feature_on() {
 
         when(featureToggler.getValue("home-office-notification-feature", false)).thenReturn(true);
         when(homeOfficeApi.call(callback)).thenReturn(asylumCase);
         when(asylumCase.read(HOME_OFFICE_HEARING_BUNDLE_READY_INSTRUCT_STATUS, String.class)).thenReturn(Optional.of("OK"));
+        when(asylumCase.read(HOME_OFFICE_SEARCH_STATUS, String.class)).thenReturn(Optional.of("SUCCESS"));
+        when(asylumCase.read(HOME_OFFICE_NOTIFICATIONS_ELIGIBLE, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             advancedFinalBundlingStitchingCallbackHandler.handle(ABOUT_TO_SUBMIT, callback);
@@ -160,10 +169,50 @@ class AdvancedFinalBundlingStitchingCallbackHandlerTest {
         assertEquals(asylumCase, callbackResponse.getData());
 
         verify(asylumCase, times(1)).write(HOME_OFFICE_HEARING_BUNDLE_READY_INSTRUCT_STATUS, "OK");
+        verify(homeOfficeApi, times(1)).call(callback);
+        verify(notificationSender, times(1)).send(callback);
     }
 
     @Test
-    public void should_not_write_instruct_status_when_ho_notification_feature_off() {
+    void should_not_call_home_office_notification_when_ho_validation_has_failed() {
+
+        when(featureToggler.getValue("home-office-notification-feature", false)).thenReturn(true);
+        when(homeOfficeApi.call(callback)).thenReturn(asylumCase);
+        when(asylumCase.read(HOME_OFFICE_HEARING_BUNDLE_READY_INSTRUCT_STATUS, String.class)).thenReturn(Optional.of("OK"));
+        when(asylumCase.read(HOME_OFFICE_SEARCH_STATUS, String.class)).thenReturn(Optional.of("FAIL"));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            advancedFinalBundlingStitchingCallbackHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        //verify(asylumCase, times(1)).write(HOME_OFFICE_HEARING_BUNDLE_READY_INSTRUCT_STATUS, "OK");
+        verify(homeOfficeApi, times(0)).call(callback);
+        verify(notificationSender, times(1)).send(callback);
+    }
+
+    @Test
+    void should_not_call_home_office_notification_when_ho_validation_success_but_for_in_progress_case() {
+
+        when(featureToggler.getValue("home-office-notification-feature", false)).thenReturn(true);
+        when(homeOfficeApi.call(callback)).thenReturn(asylumCase);
+        when(asylumCase.read(HOME_OFFICE_HEARING_BUNDLE_READY_INSTRUCT_STATUS, String.class)).thenReturn(Optional.of("OK"));
+        when(asylumCase.read(HOME_OFFICE_SEARCH_STATUS, String.class)).thenReturn(Optional.of("SUCCESS"));
+        when(asylumCase.read(HOME_OFFICE_NOTIFICATIONS_ELIGIBLE, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            advancedFinalBundlingStitchingCallbackHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(homeOfficeApi, times(0)).call(callback);
+        verify(notificationSender, times(1)).send(callback);
+    }
+
+    @Test
+    void should_not_write_instruct_status_when_ho_notification_feature_off() {
 
         when(featureToggler.getValue("home-office-notification-feature", false)).thenReturn(false);
 
@@ -177,7 +226,7 @@ class AdvancedFinalBundlingStitchingCallbackHandlerTest {
     }
 
     @Test
-    public void should_not_write_instruct_status_when_ho_notification_feature_missing() {
+    void should_not_write_instruct_status_when_ho_notification_feature_missing() {
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             advancedFinalBundlingStitchingCallbackHandler.handle(ABOUT_TO_SUBMIT, callback);
@@ -189,7 +238,7 @@ class AdvancedFinalBundlingStitchingCallbackHandlerTest {
     }
 
     @Test
-    public void should_not_call_ho_api_when_ooc_appeal() {
+    void should_not_call_ho_api_when_ooc_appeal() {
 
         when(featureToggler.getValue("home-office-notification-feature", false)).thenReturn(true);
         when(homeOfficeApi.call(callback)).thenReturn(asylumCase);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeCaseNotificationsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeCaseNotificationsHandlerTest.java
@@ -102,6 +102,9 @@ class HomeOfficeCaseNotificationsHandlerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getCaseDetails().getCaseData()).thenReturn(asylumCase);
         when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(HOME_OFFICE_SEARCH_STATUS, String.class)).thenReturn(Optional.of("SUCCESS"));
+        when(asylumCase.read(HOME_OFFICE_NOTIFICATIONS_ELIGIBLE, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             homeOfficeCaseNotificationsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
@@ -110,6 +113,72 @@ class HomeOfficeCaseNotificationsHandlerTest {
         assertEquals(asylumCase, callbackResponse.getData());
 
         verify(homeOfficeApi, times(1)).call(callback);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Event.class, names = {
+        "REQUEST_RESPONDENT_EVIDENCE",
+        "REQUEST_RESPONDENT_REVIEW",
+        "LIST_CASE",
+        "EDIT_CASE_LISTING",
+        "ADJOURN_HEARING_WITHOUT_DATE",
+        "SEND_DECISION_AND_REASONS",
+        "APPLY_FOR_FTPA_APPELLANT",
+        "APPLY_FOR_FTPA_RESPONDENT",
+        "LEADERSHIP_JUDGE_FTPA_DECISION",
+        "RESIDENT_JUDGE_FTPA_DECISION",
+        "END_APPEAL"
+    })
+    void should_not_call_home_office_api_when_validation_unsuccessful(Event event) {
+
+        when(callback.getEvent()).thenReturn(event);
+        when(homeOfficeApi.call(callback)).thenReturn(asylumCase);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetails().getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(HOME_OFFICE_SEARCH_STATUS, String.class)).thenReturn(Optional.of("FAIL"));
+        when(asylumCase.read(HOME_OFFICE_NOTIFICATIONS_ELIGIBLE, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            homeOfficeCaseNotificationsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(homeOfficeApi, times(0)).call(callback);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Event.class, names = {
+        "REQUEST_RESPONDENT_EVIDENCE",
+        "REQUEST_RESPONDENT_REVIEW",
+        "LIST_CASE",
+        "EDIT_CASE_LISTING",
+        "ADJOURN_HEARING_WITHOUT_DATE",
+        "SEND_DECISION_AND_REASONS",
+        "APPLY_FOR_FTPA_APPELLANT",
+        "APPLY_FOR_FTPA_RESPONDENT",
+        "LEADERSHIP_JUDGE_FTPA_DECISION",
+        "RESIDENT_JUDGE_FTPA_DECISION",
+        "END_APPEAL"
+    })
+    void should_not_call_home_office_api_for_in_progress_case(Event event) {
+
+        when(callback.getEvent()).thenReturn(event);
+        when(homeOfficeApi.call(callback)).thenReturn(asylumCase);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetails().getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(HOME_OFFICE_SEARCH_STATUS, String.class)).thenReturn(Optional.of("SUCCESS"));
+        when(asylumCase.read(HOME_OFFICE_NOTIFICATIONS_ELIGIBLE, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            homeOfficeCaseNotificationsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(homeOfficeApi, times(0)).call(callback);
     }
 
     @Test
@@ -146,6 +215,8 @@ class HomeOfficeCaseNotificationsHandlerTest {
         when(callback.getCaseDetails().getState()).thenReturn(state);
         when(asylumCase.read(DIRECTION_EDIT_PARTIES, Parties.class)).thenReturn(Optional.of(Parties.RESPONDENT));
         when(asylumCase.read(APPELLANT_IN_UK,YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(HOME_OFFICE_SEARCH_STATUS, String.class)).thenReturn(Optional.of("SUCCESS"));
+        when(asylumCase.read(HOME_OFFICE_NOTIFICATIONS_ELIGIBLE, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             homeOfficeCaseNotificationsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-4116


### Change description ###
RIA-4116: Added condition to ignore sending Home Office notifications for inflight cases and for cases where validation has failed


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
