### PR TITLE
RIA-4369 initialize appealOutOfCountry case-field for the older appeals

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-3555-RIA-3763-RIA-3784-submit-new-hearing-requirements.json
+++ b/src/functionalTest/resources/scenarios/RIA-3555-RIA-3763-RIA-3784-submit-new-hearing-requirements.json
@@ -132,6 +132,7 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "appealOutOfCountry": "No",
         "isReheardAppealEnabled": "Yes",
         "caseFlagSetAsideReheardExists": "Yes",
         "currentHearingDetailsVisible": "No",

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
@@ -60,6 +60,10 @@ public class DraftHearingRequirementsHandler implements PreSubmitCallbackHandler
 
         final List<WitnessDetails> witnessDetails = mayBeWitnessDetails.orElse(Collections.emptyList()).stream().map(IdValue::getValue).collect(Collectors.toList());
 
+        if (!asylumCase.read(APPEAL_OUT_OF_COUNTRY, YesOrNo.class).isPresent()) {
+            asylumCase.write(APPEAL_OUT_OF_COUNTRY, YesOrNo.NO);
+        }
+
         asylumCase.write(WITNESS_COUNT, witnessDetails.size());
 
         asylumCase.write(SUBMIT_HEARING_REQUIREMENTS_AVAILABLE, YesOrNo.YES);


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-4369](https://tools.hmcts.net/jira/browse/RIA-4363)


### Change description ###
appealOfOutCountry case-field is being initialised for older appeals.
As appealOutOfCountry case-field is missing for the older appeals causing submit-hearing-requirements to fail as it is a mandatory field in the event.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```