### PR TITLE
RIA-4546: Disabling and showing error message on edit appeal action for AIP appeals

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-4546-edit-appeal-aip-errors.json
+++ b/src/functionalTest/resources/scenarios/RIA-4546-edit-appeal-aip-errors.json
@@ -1,0 +1,22 @@
+{
+  "description": "RIA-4546 Edit Appeal for AIP journey  - return error message",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 1234,
+      "eventId": "editAppealAfterSubmit",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json"
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": ["This option is not available for 'Appellant in person' appeals."],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json"
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AipEditAppealPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AipEditAppealPreparer.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
+
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+
+@Component
+public class AipEditAppealPreparer implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
+                && (callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT);
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+                callback
+                        .getCaseDetails()
+                        .getCaseData();
+
+        PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
+        Optional<JourneyType> journeyType = asylumCase.read(JOURNEY_TYPE, JourneyType.class);
+
+        if (journeyType.isPresent() && journeyType.get() == JourneyType.AIP) {
+            response.addError("This option is not available for 'Appellant in person' appeals.");
+        }
+        return response;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AipEditAppealPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AipEditAppealPreparerTest.java
@@ -1,0 +1,116 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.EDIT_APPEAL_AFTER_SUBMIT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+
+
+@ExtendWith(MockitoExtension.class)
+class AipEditAppealPreparerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+
+    private AipEditAppealPreparer aipEditAppealPreparer;
+
+    @BeforeEach
+    public void setUp() {
+        aipEditAppealPreparer = new AipEditAppealPreparer();
+    }
+
+    @Test
+    void handler_checks_out_of_country_feature_flag_set_value() {
+
+        when(callback.getEvent()).thenReturn(EDIT_APPEAL_AFTER_SUBMIT);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.of(JourneyType.AIP));
+
+        PreSubmitCallbackResponse<AsylumCase> response =
+            aipEditAppealPreparer.handle(ABOUT_TO_START, callback);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getData()).isNotEmpty();
+        assertThat(response.getData()).isEqualTo(asylumCase);
+        assertThat(response.getErrors()).isNotEmpty();
+        assertThat(response.getErrors()).contains("This option is not available for 'Appellant in person' appeals.");
+
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = aipEditAppealPreparer.canHandle(callbackStage, callback);
+                if (callbackStage == ABOUT_TO_START
+                    && callback.getEvent() == EDIT_APPEAL_AFTER_SUBMIT) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> aipEditAppealPreparer.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> aipEditAppealPreparer.canHandle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> aipEditAppealPreparer.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> aipEditAppealPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+    }
+
+    @Test
+    void handler_throws_error_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> aipEditAppealPreparer.handle(ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(EDIT_APPEAL_AFTER_SUBMIT);
+        assertThatThrownBy(() -> aipEditAppealPreparer.handle(ABOUT_TO_START, callback))
+            .isExactlyInstanceOf(NullPointerException.class);
+
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-4546


### Change description ###
Disabling and showing error message on edit appeal action for AIP appeals


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
