### PR TITLE
Fix for document_hash in lower envs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/field/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/field/Document.java
@@ -15,6 +15,7 @@ public class Document {
     private String documentUrl;
     private String documentBinaryUrl;
     private String documentFilename;
+    private String documentHash;
 
     private Document() {
         // noop -- for deserializer
@@ -23,7 +24,8 @@ public class Document {
     public Document(
         String documentUrl,
         String documentBinaryUrl,
-        String documentFilename
+        String documentFilename,
+        String documentHash
     ) {
         requireNonNull(documentUrl);
         requireNonNull(documentBinaryUrl);
@@ -32,6 +34,7 @@ public class Document {
         this.documentUrl = documentUrl;
         this.documentBinaryUrl = documentBinaryUrl;
         this.documentFilename = documentFilename;
+        this.documentHash = documentHash;
     }
 
     public String getDocumentUrl() {
@@ -44,5 +47,9 @@ public class Document {
 
     public String getDocumentFilename() {
         return documentFilename;
+    }
+
+    public String getDocumentHash() {
+        return documentHash;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/PreviousHearingTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/PreviousHearingTest.java
@@ -26,13 +26,15 @@ class PreviousHearingTest {
     private final Document doc = new Document(
         "documentUrl",
         "binaryUrl",
-        "documentFilename");
+        "documentFilename",
+        "documentHash");
 
     private final DocumentWithMetadata decisionAndReasonsDocument = new DocumentWithMetadata(
         new Document(
             "documentUrl",
             "binaryUrl",
-            "documentFilename"),
+            "documentFilename",
+            "documentHash"),
         "description",
         "dateUploaded",
         DocumentTag.FINAL_DECISION_AND_REASONS_PDF

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/field/DocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/field/DocumentTest.java
@@ -9,11 +9,13 @@ class DocumentTest {
     private final String documentUrl = "http://doc-store/A";
     private final String documentBinaryUrl = "http://doc-store/A/binary";
     private final String documentFilename = "evidence.pdf";
+    private final String documentHash = "someHash";
 
     private Document document = new Document(
         documentUrl,
         documentBinaryUrl,
-        documentFilename
+        documentFilename,
+        documentHash
     );
 
     @Test
@@ -22,6 +24,7 @@ class DocumentTest {
         assertEquals(documentUrl, document.getDocumentUrl());
         assertEquals(documentBinaryUrl, document.getDocumentBinaryUrl());
         assertEquals(documentFilename, document.getDocumentFilename());
+        assertEquals(documentHash, document.getDocumentHash());
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/DecideAnApplicationConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/DecideAnApplicationConfirmationTest.java
@@ -86,7 +86,8 @@ class DecideAnApplicationConfirmationTest {
             Arrays.asList(new IdValue<>("1",
                 new Document("http://localhost/documents/123456",
                     "http://localhost/documents/123456",
-                    "DocumentName.pdf")));
+                    "DocumentName.pdf",
+                    "documentHash")));
         MakeAnApplication makeAnApplication =
             new MakeAnApplication("Legal representative", type, "A reason to update appeal details",
                 evidence, dateProvider.now().toString(), "Pending",
@@ -227,7 +228,8 @@ class DecideAnApplicationConfirmationTest {
             Arrays.asList(new IdValue<>("1",
                 new Document("http://localhost/documents/123456",
                     "http://localhost/documents/123456",
-                    "DocumentName.pdf")));
+                    "DocumentName.pdf",
+                    "documentHash")));
         MakeAnApplication makeAnApplication =
             new MakeAnApplication("Legal representative", "Adjourn", "A reason to update appeal details",
                 evidence, dateProvider.now().toString(), "Pending",

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/editdocs/EditDocsAuditServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/editdocs/EditDocsAuditServiceTest.java
@@ -196,7 +196,8 @@ class EditDocsAuditServiceTest {
         Document doc = new Document(
             "http://dm-store:89/" + docId,
             "",
-            filename
+            filename,
+            "documentHash"
         );
         IdValue<HasDocument> idValue = new IdValue<>(id, buildValue(doc, description, hearingRecordingDocFlag));
         return Collections.singletonList(idValue);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AddAppellantDocumentsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AddAppellantDocumentsHandlerTest.java
@@ -122,7 +122,7 @@ class AddAppellantDocumentsHandlerTest {
                 .thenReturn(Optional.empty());
 
         DocumentWithMetadata reasonsForAppealEvidence = new DocumentWithMetadata(
-            new Document("documentUrl", "binaryUrl", "documentFielname"),
+            new Document("documentUrl", "binaryUrl", "documentFielname", "documentHash"),
             "description",
             "dateUploaded",
             DocumentTag.ADDITIONAL_EVIDENCE
@@ -158,7 +158,7 @@ class AddAppellantDocumentsHandlerTest {
                 .thenReturn(Optional.empty());
         when(asylumCase.read(AsylumCaseFieldDefinition.REASONS_FOR_APPEAL_DOCUMENTS))
             .thenReturn(Optional.empty());
-        Document clarifyingQuestionEvidence = new Document("documentUrl", "binaryUrl", "documentFielname");
+        Document clarifyingQuestionEvidence = new Document("documentUrl", "binaryUrl", "documentFielname", "documentHash");
         when(asylumCase.read(AsylumCaseFieldDefinition.CLARIFYING_QUESTIONS_ANSWERS))
             .thenReturn(Optional.of(asList(
                 new IdValue<>(

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DecideAnApplicationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DecideAnApplicationHandlerTest.java
@@ -78,7 +78,8 @@ class DecideAnApplicationHandlerTest {
             Arrays.asList(new IdValue<>("1",
                 new Document("http://localhost/documents/123456",
                     "http://localhost/documents/123456",
-                    "DocumentName.pdf")));
+                    "DocumentName.pdf",
+                    "documentHash")));
         MakeAnApplication makeAnApplication =
             new MakeAnApplication("Legal representative", "Update appeal details", "A reason to update appeal details",
                 evidence, dateProvider.now().toString(), "Pending",

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DecideAnApplicationMidEventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DecideAnApplicationMidEventTest.java
@@ -73,7 +73,8 @@ class DecideAnApplicationMidEventTest {
             Arrays.asList(new IdValue<>("1",
                 new Document("http://localhost/documents/123456",
                     "http://localhost/documents/123456",
-                    "DocumentName.pdf")));
+                    "DocumentName.pdf",
+                    "documentHash")));
         MakeAnApplication makeAnApplication =
             new MakeAnApplication("Legal representative", "Update appeal details", "A reason to update appeal details",
                 evidence, dateProvider.now().toString(), "Pending",

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DecideAnApplicationPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DecideAnApplicationPreparerTest.java
@@ -72,7 +72,7 @@ class DecideAnApplicationPreparerTest {
         when(dateProvider.now()).thenReturn(LocalDate.MAX);
 
         List<IdValue<Document>> evidence =
-            Arrays.asList(new IdValue<>("1", new Document("url", "url", "FileName")));
+            Arrays.asList(new IdValue<>("1", new Document("url", "url", "FileName", "documentHash")));
         MakeAnApplication makeAnApplication =
             new MakeAnApplication("Legal representative", "Update appeal details", "A reason to update appeal details",
                 evidence, dateProvider.now().toString(), "Pending",

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UploadDecisionLetterHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UploadDecisionLetterHandlerTest.java
@@ -38,7 +38,8 @@ class UploadDecisionLetterHandlerTest {
     private final Document someDoc = new Document(
         "some url",
         "some binary url",
-        "some filename");
+        "some filename",
+        "some documentHash");
 
     private final DocumentWithMetadata someLegalRepDocument = new DocumentWithMetadata(
         someDoc,

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UploadSensitiveDocsAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UploadSensitiveDocsAboutToSubmitHandlerTest.java
@@ -148,7 +148,8 @@ class UploadSensitiveDocsAboutToSubmitHandlerTest {
         doc = new Document(
             "http://someUrl",
             "http://someUrl/bin",
-            "some sensitive document uploaded");
+            "some sensitive document uploaded",
+            "some document hash");
         someSensitiveDocDesc = "some sensitive doc desc";
         uploadedSensitiveDoc = new DocumentWithDescription(doc, someSensitiveDocDesc);
         return new IdValue<>("1", uploadedSensitiveDoc);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/editdocs/EditDocsAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/editdocs/EditDocsAboutToSubmitHandlerTest.java
@@ -250,7 +250,8 @@ class EditDocsAboutToSubmitHandlerTest {
     private static DocumentWithMetadata buildValueWithNoTag(DocumentTag documentTag, String suppliedBy) {
         Document doc = new Document("http://dm-store:4506/documents/80e2af54-7a93-498f-af55-fe190f3224d2",
             "http://dm-store:4506/documents/80e2af54-7a93-498f-af55-fe190f3224d2/binary",
-            "Screenshot 2020-03-06 at 10.07.01.jpg");
+            "Screenshot 2020-03-06 at 10.07.01.jpg",
+            "documentHash");
         return new DocumentWithMetadata(doc, "some desc", "2020-01-01", documentTag, suppliedBy);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/editdocs/EditDocsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/editdocs/EditDocsServiceTest.java
@@ -119,7 +119,7 @@ class EditDocsServiceTest {
     }
 
     private static Document buildDocumentGivenDocId() {
-        return new Document("http://dm-store/" + DOC_ID, "", "");
+        return new Document("http://dm-store/" + DOC_ID, "", "", "");
     }
 
     private static DocumentWithMetadata buildDocWithMeta() {

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/PreviousRequirementsAndRequestsAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/PreviousRequirementsAndRequestsAppenderTest.java
@@ -108,7 +108,7 @@ class PreviousRequirementsAndRequestsAppenderTest {
             new IdValue<DocumentWithMetadata>(
                 "1",
                 new DocumentWithMetadata(
-                    new Document("documentUrl", "binaryUrl", "documentFilename"),
+                    new Document("documentUrl", "binaryUrl", "documentFilename", "documentHash"),
                     "description",
                     "dateUploaded",
                     DocumentTag.HEARING_REQUIREMENTS
@@ -117,7 +117,7 @@ class PreviousRequirementsAndRequestsAppenderTest {
             new IdValue<DocumentWithMetadata>(
                 "2",
                 new DocumentWithMetadata(
-                    new Document("documentUrl", "binaryUrl", "documentFilename"),
+                    new Document("documentUrl", "binaryUrl", "documentFilename", "documentHash"),
                     "description",
                     "dateUploaded",
                     DocumentTag.HEARING_REQUIREMENTS
@@ -129,7 +129,7 @@ class PreviousRequirementsAndRequestsAppenderTest {
             new IdValue<DocumentWithMetadata>(
                 "1",
                 new DocumentWithMetadata(
-                    new Document("documentUrl", "binaryUrl", "documentFilename"),
+                    new Document("documentUrl", "binaryUrl", "documentFilename", "documentHash"),
                     "description",
                     "dateUploaded",
                     DocumentTag.HEARING_REQUIREMENTS
@@ -138,7 +138,7 @@ class PreviousRequirementsAndRequestsAppenderTest {
             new IdValue<DocumentWithMetadata>(
                 "2",
                 new DocumentWithMetadata(
-                    new Document("documentUrl", "binaryUrl", "documentFilename"),
+                    new Document("documentUrl", "binaryUrl", "documentFilename", "documentHash"),
                     "description",
                     "dateUploaded",
                     DocumentTag.HEARING_REQUIREMENTS

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/controllers/AsylumCaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/controllers/AsylumCaseTest.java
@@ -281,7 +281,8 @@ class AsylumCaseTest {
                 new Document(
                     "some-doc-url",
                     "some-doc-binary-url",
-                    "some-doc-filename"),
+                    "some-doc-filename",
+                    "some-doc-hash"),
                 "some-description"));
 
         asylumCase.write(RESPONDENT_EVIDENCE, asList(idValue));


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a


### Change description ###

Fix for **document_hash** error seen in lower environments as a result of the CCD secure-doc-store changes. Required in order to test the **editDocuments** event associated with P1 incident INC5249521.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
