### PR TITLE
RIA-4833 appealOutOfCountry field for old cases

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparer.java
@@ -88,11 +88,19 @@ public class ReviewDraftHearingRequirementsPreparer implements PreSubmitCallback
 
     static void decorateOutsideEvidenceDefaultsForOldCases(AsylumCase asylumCase) {
 
+        final Optional<YesOrNo> isAppealOutOfCountry =
+                asylumCase.read(APPEAL_OUT_OF_COUNTRY, YesOrNo.class);
+
         final Optional<YesOrNo> isEvidenceFromOutsideUkOoc =
             asylumCase.read(IS_EVIDENCE_FROM_OUTSIDE_UK_OOC, YesOrNo.class);
 
         final Optional<YesOrNo> isEvidenceFromOutsideUkInCountry =
             asylumCase.read(IS_EVIDENCE_FROM_OUTSIDE_UK_IN_COUNTRY, YesOrNo.class);
+
+
+        if (!isAppealOutOfCountry.isPresent()) {
+            asylumCase.write(APPEAL_OUT_OF_COUNTRY, YesOrNo.NO);
+        }
 
         if (!isEvidenceFromOutsideUkOoc.isPresent()) {
             asylumCase.write(IS_EVIDENCE_FROM_OUTSIDE_UK_OOC, YesOrNo.NO);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparerTest.java
@@ -104,6 +104,8 @@ class ReviewDraftHearingRequirementsPreparerTest {
         verify(asylumCase, times(1)).write(
             IS_EVIDENCE_FROM_OUTSIDE_UK_OOC,
             YesOrNo.NO);
+
+        verify(asylumCase, times(1)).write(APPEAL_OUT_OF_COUNTRY, YesOrNo.NO);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-4833](https://tools.hmcts.net/jira/browse/RIA-4833)


### Change description ###
Review hearing requirements event is broken for the older appeal before OOC, due to the incorrect permissions for the appealOutOfCountry casefield.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```