### PR TITLE
Ria 6109 create service request when submitting appeal

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ServiceRequestHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ServiceRequestHandler.java
@@ -1,0 +1,67 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
+
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.FeePayment;
+
+@Component
+public class ServiceRequestHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final FeePayment<AsylumCase> feePayment;
+    private final boolean isFeePaymentEnabled;
+
+    public ServiceRequestHandler(
+        @Value("${featureFlag.isfeePaymentEnabled}") boolean isFeePaymentEnabled,
+        FeePayment<AsylumCase> feePayment
+    ) {
+        this.feePayment = feePayment;
+        this.isFeePaymentEnabled = isFeePaymentEnabled;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT)
+               && Objects.equals(Event.SUBMIT_APPEAL, callback.getEvent())
+               && isFeePaymentEnabled;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        if (!isAipJourney(asylumCase)) {
+            asylumCase = feePayment.aboutToSubmit(callback);
+        }
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    private boolean isAipJourney(AsylumCase asylumCase) {
+        return asylumCase.read(JOURNEY_TYPE, JourneyType.class)
+            .map(journeyType -> journeyType == JourneyType.AIP)
+            .orElse(false);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ServiceRequestHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ServiceRequestHandlerTest.java
@@ -1,0 +1,139 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
+
+import java.util.Objects;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.FeePayment;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class ServiceRequestHandlerTest {
+
+    @Mock
+    private FeePayment<AsylumCase> feePayment;
+
+    @Mock
+    private Callback<AsylumCase> callback;
+
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+
+    @Mock
+    private AsylumCase asylumCase;
+
+    private ServiceRequestHandler serviceRequestHandler;
+
+    @BeforeEach
+    public void setUp() {
+        serviceRequestHandler = new ServiceRequestHandler(true, feePayment);
+    }
+
+    @Test
+    void lr_should_make_feePayment_submit_callback() {
+
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.empty()); // empty = not AIP
+
+        AsylumCase responseAsylumCase = mock(AsylumCase.class);
+        when(feePayment.aboutToSubmit(callback)).thenReturn(responseAsylumCase); // empty = not AIP
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            serviceRequestHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+
+        verify(feePayment, times(1)).aboutToSubmit(callback);
+    }
+
+    @Test
+    void aip_should_not_make_feePayment_submit_callback() {
+
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.of(JourneyType.AIP));
+        // JourneyType optional empty = not AIP
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            serviceRequestHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+
+        verify(feePayment, never()).aboutToSubmit(callback);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> serviceRequestHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        assertThatThrownBy(() -> serviceRequestHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = serviceRequestHandler.canHandle(callbackStage, callback);
+
+                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                    && Objects.equals(Event.SUBMIT_APPEAL, event)) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> serviceRequestHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> serviceRequestHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6109](https://tools.hmcts.net/jira/browse/RIA-6109)


### Change description ###
- ServiceRequestHandler added to trigger creation of Service Request in ia-case-payments-api when event is SUBMIT_APPEAL


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
