### PR TITLE
Ria 6070 retain old events inflight cases

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1542,6 +1542,9 @@ public enum AsylumCaseFieldDefinition {
     HMCTS_CASE_CATEGORY(
         "hmctsCaseCategory", new TypeReference<String>(){}),
 
+    HAS_SERVICE_REQUEST_ALREADY(
+        "hasServiceRequestAlready", new TypeReference<YesOrNo>(){}),
+
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -116,6 +116,7 @@ public enum Event {
     MARK_ADDENDUM_EVIDENCE_AS_REVIEWED("markAddendumEvidenceAsReviewed"),
     MARK_PAYMENT_REQUEST_SENT("markPaymentRequestSent"),
     END_APPEAL_AUTOMATICALLY("endAppealAutomatically"),
+    GENERATE_SERVICE_REQUEST("generateServiceRequest"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealSubmitHandler.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
@@ -18,8 +19,8 @@ import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 @Component
 public class AppealSubmitHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
-    private final String PAY_OFFLINE = "payOffline";
-    private final String PAY_LATER = "payLater";
+    private static final String PAY_OFFLINE = "payOffline";
+    private static final String PAY_LATER = "payLater";
 
     public boolean canHandle(
         PreSubmitCallbackStage callbackStage,
@@ -47,9 +48,14 @@ public class AppealSubmitHandler implements PreSubmitCallbackHandler<AsylumCase>
                 .getCaseDetails()
                 .getCaseData();
 
+        boolean isAipJourney = callback.getCaseDetails().getCaseData()
+            .read(AsylumCaseFieldDefinition.JOURNEY_TYPE, JourneyType.class)
+            .map(journeyType -> journeyType == JourneyType.AIP)
+            .orElse(false);
+
         String paAppealTypePaymentOption = asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class).orElse("");
 
-        if (paAppealTypePaymentOption.equals(PAY_OFFLINE)) {
+        if (paAppealTypePaymentOption.equals(PAY_OFFLINE) && !isAipJourney) {
             asylumCase.write(PA_APPEAL_TYPE_PAYMENT_OPTION, PAY_LATER);
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ServiceRequestHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ServiceRequestHandler.java
@@ -1,11 +1,9 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HAS_SERVICE_REQUEST_ALREADY;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
 
 import java.util.List;
-import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
@@ -14,7 +12,6 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.FeePayment;
 
@@ -26,8 +23,7 @@ public class ServiceRequestHandler implements PreSubmitCallbackHandler<AsylumCas
 
     public ServiceRequestHandler(
         @Value("${featureFlag.isfeePaymentEnabled}") boolean isFeePaymentEnabled,
-        FeePayment<AsylumCase> feePayment
-        ) {
+        FeePayment<AsylumCase> feePayment) {
         this.feePayment = feePayment;
         this.isFeePaymentEnabled = isFeePaymentEnabled;
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ServiceRequestHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ServiceRequestHandler.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HAS_SERVICE_REQUEST_ALREADY;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
 
+import java.util.List;
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -12,6 +14,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.FeePayment;
 
@@ -24,7 +27,7 @@ public class ServiceRequestHandler implements PreSubmitCallbackHandler<AsylumCas
     public ServiceRequestHandler(
         @Value("${featureFlag.isfeePaymentEnabled}") boolean isFeePaymentEnabled,
         FeePayment<AsylumCase> feePayment
-    ) {
+        ) {
         this.feePayment = feePayment;
         this.isFeePaymentEnabled = isFeePaymentEnabled;
     }
@@ -37,7 +40,7 @@ public class ServiceRequestHandler implements PreSubmitCallbackHandler<AsylumCas
         requireNonNull(callback, "callback must not be null");
 
         return (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT)
-               && Objects.equals(Event.SUBMIT_APPEAL, callback.getEvent())
+               && List.of(Event.SUBMIT_APPEAL, Event.GENERATE_SERVICE_REQUEST).contains(callback.getEvent())
                && isFeePaymentEnabled;
     }
 
@@ -54,6 +57,7 @@ public class ServiceRequestHandler implements PreSubmitCallbackHandler<AsylumCas
 
         if (!isAipJourney(asylumCase)) {
             asylumCase = feePayment.aboutToSubmit(callback);
+
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SubmitAppealPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SubmitAppealPreparer.java
@@ -1,38 +1,52 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PA_APPEAL_TYPE_PAYMENT_OPTION;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.SUBMIT_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
-import lombok.extern.slf4j.Slf4j;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
-@Slf4j
 @Component
-public class AppealSubmitHandler implements PreSubmitCallbackHandler<AsylumCase> {
+public class SubmitAppealPreparer implements PreSubmitCallbackHandler<AsylumCase> {
 
+    private final boolean isfeePaymentEnabled;
     private final String PAY_OFFLINE = "payOffline";
     private final String PAY_LATER = "payLater";
+
+    public SubmitAppealPreparer(
+        @Value("${featureFlag.isfeePaymentEnabled}") boolean isfeePaymentEnabled
+    ) {
+        this.isfeePaymentEnabled = isfeePaymentEnabled;
+    }
 
     public boolean canHandle(
         PreSubmitCallbackStage callbackStage,
         Callback<AsylumCase> callback
     ) {
+
         requireNonNull(callbackStage, "callbackStage must not be null");
         requireNonNull(callback, "callback must not be null");
 
-        return
-            callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-            && (callback.getEvent() == SUBMIT_APPEAL);
-    }
+        boolean isAipJourney = callback.getCaseDetails().getCaseData()
+            .read(AsylumCaseFieldDefinition.JOURNEY_TYPE, JourneyType.class)
+            .map(journeyType -> journeyType == JourneyType.AIP)
+            .orElse(false);
 
+        return (callbackStage == PreSubmitCallbackStage.ABOUT_TO_START)
+               && Event.SUBMIT_APPEAL == callback.getEvent()
+               && isfeePaymentEnabled
+               && !isAipJourney;
+    }
 
     public PreSubmitCallbackResponse<AsylumCase> handle(
         PreSubmitCallbackStage callbackStage,
@@ -42,21 +56,13 @@ public class AppealSubmitHandler implements PreSubmitCallbackHandler<AsylumCase>
             throw new IllegalStateException("Cannot handle callback");
         }
 
-        AsylumCase asylumCase =
-            callback
-                .getCaseDetails()
-                .getCaseData();
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
         String paAppealTypePaymentOption = asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class).orElse("");
 
         if (paAppealTypePaymentOption.equals(PAY_OFFLINE)) {
             asylumCase.write(PA_APPEAL_TYPE_PAYMENT_OPTION, PAY_LATER);
         }
-
-        final long caseId = callback.getCaseDetails().getId();
-        YesOrNo appealOutOfCountry = asylumCase.read(AsylumCaseFieldDefinition.APPEAL_OUT_OF_COUNTRY, YesOrNo.class).orElse(YesOrNo.NO);
-
-        log.info("Appeal submitted for case ID {},  Out Of Country: {}", caseId, appealOutOfCountry);
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SubmitAppealPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SubmitAppealPreparer.java
@@ -3,10 +3,8 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
@@ -20,8 +18,8 @@ import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 public class SubmitAppealPreparer implements PreSubmitCallbackHandler<AsylumCase> {
 
     private final boolean isfeePaymentEnabled;
-    private final String PAY_OFFLINE = "payOffline";
-    private final String PAY_LATER = "payLater";
+    private static final String PAY_OFFLINE = "payOffline";
+    private static final String PAY_LATER = "payLater";
 
     public SubmitAppealPreparer(
         @Value("${featureFlag.isfeePaymentEnabled}") boolean isfeePaymentEnabled

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -198,7 +198,6 @@ security:
       - "generateServiceRequest"
     caseworker-ia-caseofficer:
       - "moveToPaymentPending"
-      - "moveToSubmitted"
       - "sendDirection"
       - "changeDirectionDueDate"
       - "requestCaseEdit"
@@ -290,6 +289,7 @@ security:
       - "generateUpperTribunalBundle"
       - "asyncStitchingComplete"
       - "markPaymentRequestSent"
+      - "moveToSubmitted"
     caseworker-ia-homeofficeapc:
       - "uploadHomeOfficeBundle"
       - "uploadAdditionalEvidenceHomeOffice"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -195,6 +195,7 @@ security:
       - "removeRepresentation"
       - "requestFeeRemission"
       - "nocRequest"
+      - "generateServiceRequest"
     caseworker-ia-caseofficer:
       - "moveToPaymentPending"
       - "moveToSubmitted"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -115,10 +115,11 @@ class EventTest {
         assertEquals("markAddendumEvidenceAsReviewed", Event.MARK_ADDENDUM_EVIDENCE_AS_REVIEWED.toString());
         assertEquals("markPaymentRequestSent", Event.MARK_PAYMENT_REQUEST_SENT.toString());
         assertEquals("endAppealAutomatically", Event.END_APPEAL_AUTOMATICALLY.toString());
+        assertEquals("generateServiceRequest", Event.GENERATE_SERVICE_REQUEST.toString());
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(112, Event.values().length);
+        assertEquals(113, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ServiceRequestHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ServiceRequestHandlerTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
 
-import java.util.Objects;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -112,7 +112,8 @@ public class ServiceRequestHandlerTest {
                 boolean canHandle = serviceRequestHandler.canHandle(callbackStage, callback);
 
                 if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-                    && Objects.equals(Event.SUBMIT_APPEAL, event)) {
+                    && List.of(Event.SUBMIT_APPEAL,
+                    Event.GENERATE_SERVICE_REQUEST).contains(event)) {
 
                     assertTrue(canHandle);
                 } else {

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SubmitAppealPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SubmitAppealPreparerTest.java
@@ -1,0 +1,128 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PA_APPEAL_TYPE_PAYMENT_OPTION;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class SubmitAppealPreparerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+
+    private SubmitAppealPreparer submitAppealPreparer;
+
+    @BeforeEach
+    void setup() {
+        submitAppealPreparer = new SubmitAppealPreparer(true);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        assertThatThrownBy(() -> submitAppealPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> submitAppealPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void lr_should_overwrite_payOffline_with_payLater() {
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class)).thenReturn(Optional.of("payOffline"));
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+
+        PreSubmitCallbackResponse<AsylumCase> response = submitAppealPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+        verify(asylumCase, times(1)).write(PA_APPEAL_TYPE_PAYMENT_OPTION, "payLater");
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.empty());
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+            when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = submitAppealPreparer.canHandle(callbackStage, callback);
+
+                if (event == Event.SUBMIT_APPEAL
+                    && callbackStage == PreSubmitCallbackStage.ABOUT_TO_START) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.of(JourneyType.AIP));
+
+        boolean canHandleAip = submitAppealPreparer.canHandle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+        assertFalse(canHandleAip);
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> submitAppealPreparer.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> submitAppealPreparer.canHandle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> submitAppealPreparer.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> submitAppealPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/MarkPaymentPaidPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/MarkPaymentPaidPreparerTest.java
@@ -145,24 +145,6 @@ class MarkPaymentPaidPreparerTest {
         assertThat(returnedCallbackResponse.getErrors()).contains("Payment is not required for this type of appeal.");
     }
 
-    @Test
-    void should_throw_error_for_pa_pay_later() {
-
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(callback.getEvent()).thenReturn(Event.MARK_APPEAL_PAID);
-        when(callback.getCaseDetails().getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(PA));
-        when(asylumCase.read(PAYMENT_STATUS, PaymentStatus.class)).thenReturn(Optional.empty());
-        when(asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class)).thenReturn(Optional.of("payLater"));
-        when(asylumCase.read(REMISSION_TYPE, RemissionType.class)).thenReturn(Optional.of(RemissionType.NO_REMISSION));
-
-        PreSubmitCallbackResponse<AsylumCase> returnedCallbackResponse =
-            markPaymentPaidPreparer.handle(ABOUT_TO_START, callback);
-
-        assertNotNull(returnedCallbackResponse);
-        assertThat(returnedCallbackResponse.getErrors()).contains("You cannot mark this appeal as paid");
-    }
-
     @ParameterizedTest
     @MethodSource("appealTypesWithRemissionTypes")
     void handling_should_error_for_remission_decision_not_present(AppealType type, RemissionType remissionType, AsylumCaseFieldDefinition field) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
- [RIA-6070](https://tools.hmcts.net/jira/browse/RIA-6070)


### Change description ###
- Allow creation of Service Request from "generateServiceRequest" event
- Retain some old events to allow for in-flight cases

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
