### PR TITLE
Ria-5725 qa fix notifications

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HasServiceRequestAlreadyValueHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HasServiceRequestAlreadyValueHandler.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HAS_SERVICE_REQUEST_ALREADY;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class HasServiceRequestAlreadyValueHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    @Override
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
+               && Objects.equals(Event.START_APPEAL, callback.getEvent());
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback) {
+
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        Optional<YesOrNo> hasServiceRequestAlready = asylumCase.read(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.class);
+
+        if (hasServiceRequestAlready.isEmpty()) {
+
+            asylumCase.write(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.NO);
+
+        }
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HasServiceRequestAlreadyValueHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HasServiceRequestAlreadyValueHandler.java
@@ -3,9 +3,6 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HAS_SERVICE_REQUEST_ALREADY;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HasServiceRequestAlreadyValueHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HasServiceRequestAlreadyValueHandler.java
@@ -28,7 +28,7 @@ public class HasServiceRequestAlreadyValueHandler implements PreSubmitCallbackHa
         requireNonNull(callback, "callback must not be null");
 
         return callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
-               && Objects.equals(Event.START_APPEAL, callback.getEvent());
+               && callback.getEvent() == Event.START_APPEAL;
     }
 
     @Override

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HasServiceRequestAlreadyValueHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HasServiceRequestAlreadyValueHandlerTest.java
@@ -1,0 +1,79 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class HasServiceRequestAlreadyValueHandlerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+
+    private final HasServiceRequestAlreadyValueHandler hasServiceRequestAlreadyValueHandler = new HasServiceRequestAlreadyValueHandler();
+
+    @Test
+    void has_service_request_value_set_to_no() {
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        when(asylumCase.read(AsylumCaseFieldDefinition.HAS_SERVICE_REQUEST_ALREADY, YesOrNo.class)).thenReturn(Optional.empty());
+
+        hasServiceRequestAlreadyValueHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+
+        verify(asylumCase, times(1)).write(AsylumCaseFieldDefinition.HAS_SERVICE_REQUEST_ALREADY, YesOrNo.NO);
+
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        assertThatThrownBy(
+            () -> hasServiceRequestAlreadyValueHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = hasServiceRequestAlreadyValueHandler.canHandle(callbackStage, callback);
+                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
+                    && (callback.getEvent() == Event.START_APPEAL)) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-5725

### Change description ###

- added handler to set value for hasServiceRequestAlready in aboutToStart stage
- value is set to 'no' when appeal is saved when there is no value set yet

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
