### PR TITLE
RIA-5586 Added New AppealType

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AppealType.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AppealType.java
@@ -11,7 +11,8 @@ public enum AppealType {
     PA("protection", "Refusal of protection claim"),
     EA("refusalOfEu", "Refusal of application under the EEA regulations"),
     HU("refusalOfHumanRights", "Refusal of a human rights claim"),
-    DC("deprivation", "Deprivation of citizenship");
+    DC("deprivation", "Deprivation of citizenship"),
+    EU("euSettlementScheme", "EU Settlement Scheme");
 
     @JsonValue
     private String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeAppealTypeChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeAppealTypeChecker.java
@@ -17,6 +17,7 @@ public class HomeOfficeAppealTypeChecker {
         switch (appealType) {
             case DC:
             case EA:
+            case EU:
             case HU:
                 return featureToggler.getValue(HO_UAN_DC_EA_HU_FEATURE, false) ? true : false;
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ManageFeeUpdatePreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ManageFeeUpdatePreparer.java
@@ -73,6 +73,7 @@ public class ManageFeeUpdatePreparer implements PreSubmitCallbackHandler<AsylumC
 
         switch (appealType) {
             case EA:
+            case EU:
             case HU:
             case PA:
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionPreparer.java
@@ -97,6 +97,7 @@ public class RecordRemissionDecisionPreparer implements PreSubmitCallbackHandler
                 break;
 
             case DC:
+            case EU:
             case RP:
                 callbackResponse.addError("Record remission decision is not valid for the appeal type.");
                 break;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestFeeRemissionPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestFeeRemissionPreparer.java
@@ -67,6 +67,7 @@ public class RequestFeeRemissionPreparer implements PreSubmitCallbackHandler<Asy
 
         switch (appealType) {
             case DC:
+            case EU:
             case RP:
 
                 callbackResponse.addError("You cannot request a fee remission for this appeal");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/EditPaymentMethodPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/EditPaymentMethodPreparer.java
@@ -114,6 +114,7 @@ public class EditPaymentMethodPreparer implements PreSubmitCallbackHandler<Asylu
                     break;
 
                 case DC:
+                case EU:
                 case RP:
                     callbackResponse.addError("You cannot change the payment method because there is no "
                             + "fee for this appeal.");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/FeesAndStatusCheckPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/FeesAndStatusCheckPreparer.java
@@ -175,6 +175,7 @@ public class FeesAndStatusCheckPreparer implements PreSubmitCallbackHandler<Asyl
                             });
                         break;
                     case RP:
+                    case EU:
                     case DC:
                         if (callback.getEvent() == Event.PAY_AND_SUBMIT_APPEAL) {
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/FeesHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/FeesHandler.java
@@ -113,6 +113,7 @@ public class FeesHandler implements PreSubmitCallbackHandler<AsylumCase> {
                 break;
 
             case DC:
+            case EU:
             case RP:
                 // by default (before remissions feature integration) we choose decisionWithHearing
                 // when the remissions are turned on it is a choice for the Legal Rep

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/MarkPaymentPaidPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/MarkPaymentPaidPreparer.java
@@ -106,6 +106,7 @@ public class MarkPaymentPaidPreparer implements PreSubmitCallbackHandler<AsylumC
                 break;
 
             case RP:
+            case EU:
             case DC:
                 callbackResponse.addError("Payment is not required for this type of appeal.");
                 break;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/AsylumFieldCaseCategoryFixer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/AsylumFieldCaseCategoryFixer.java
@@ -66,6 +66,10 @@ public class AsylumFieldCaseCategoryFixer implements DataFixer {
                 asylumCase.write(hmctsCaseCategory, ("DoC"));
                 break;
 
+            case EU:
+                asylumCase.write(hmctsCaseCategory, ("EU Settlement Scheme"));
+                break;
+
             default:
                 break;
         }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AppealTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AppealTypeTest.java
@@ -15,6 +15,7 @@ class AppealTypeTest {
         assertThat(AppealType.from("refusalOfEu").equals(Optional.of(AppealType.EA)));
         assertThat(AppealType.from("refusalOfHumanRights").equals(Optional.of(AppealType.HU)));
         assertThat(AppealType.from("deprivation").equals(Optional.of(AppealType.DC)));
+        assertThat(AppealType.from("euSettlementScheme").equals(Optional.of(AppealType.EU)));
     }
 
     @Test
@@ -24,6 +25,7 @@ class AppealTypeTest {
         assertEquals("Refusal of application under the EEA regulations", AppealType.EA.getDescription());
         assertEquals("Refusal of a human rights claim", AppealType.HU.getDescription());
         assertEquals("Deprivation of citizenship", AppealType.DC.getDescription());
+        assertEquals("EU Settlement Scheme", AppealType.EU.getDescription());
     }
 
     @Test
@@ -33,6 +35,6 @@ class AppealTypeTest {
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(5, AppealType.values().length);
+        assertEquals(6, AppealType.values().length);
     }
 }


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-5586

Change description
Remove "My client is not appealing an EU Settlement Scheme decision" from "Tell us about your client" page.
Add "EU Settlement Scheme" to appeal options in Type of appeals page.
Ensure that Type of appeal should appear as EU Settlement Scheme in the CYA page.

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[ x] No