### PR TITLE
RIA-6169 service requests and remissions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("org.yaml:snakeyaml:1.23")
+        classpath("org.yaml:snakeyaml:1.31")
         classpath("net.serenity-bdd:serenity-gradle-plugin:2.0.11")
     }
 }
@@ -328,7 +328,7 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '30.0-jre'
     annotationProcessor 'org.projectlombok:lombok:1.18.12'
     compileOnly 'org.projectlombok:lombok:1.18.12'
-    compile group: 'org.yaml', name: 'snakeyaml', version: '1.26'
+    compile group: 'org.yaml', name: 'snakeyaml', version: '1.31'
 
     compile group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.2.2'
 
@@ -374,19 +374,19 @@ dependencies {
     contractTestRuntime("org.junit.jupiter:junit-jupiter-engine:5.6.2")
     contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.6.2')
 
-    testCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.26') {
+    testCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.31') {
         force = true
     }
 
-    integrationTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.26') {
+    integrationTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.31') {
         force = true
     }
 
-    functionalTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.26') {
+    functionalTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.31') {
         force = true
     }
 
-    contractTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.26') {
+    contractTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.31') {
         force = true
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ def versions = [
     springHystrix      : '2.1.1.RELEASE',
     springfoxSwagger   : '2.9.2',
     pact_version       : '4.1.7',
-    jackson            : '2.11.2'
-
+    jackson            : '2.11.2',
+    snakeyaml          : '1.31'
 ]
 
 ext.libraries = [
@@ -278,6 +278,9 @@ dependencyManagement {
             entry 'log4j-api'
             entry 'log4j-to-slf4j'
         }
+
+        //CVE-2022-25857
+        dependency(group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml)
     }
 }
 
@@ -328,7 +331,7 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '30.0-jre'
     annotationProcessor 'org.projectlombok:lombok:1.18.12'
     compileOnly 'org.projectlombok:lombok:1.18.12'
-    compile group: 'org.yaml', name: 'snakeyaml', version: '1.31'
+    compile group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml
 
     compile group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.2.2'
 
@@ -374,19 +377,19 @@ dependencies {
     contractTestRuntime("org.junit.jupiter:junit-jupiter-engine:5.6.2")
     contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.6.2')
 
-    testCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.31') {
+    testCompile(group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml) {
         force = true
     }
 
-    integrationTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.31') {
+    integrationTestCompile(group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml) {
         force = true
     }
 
-    functionalTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.31') {
+    functionalTestCompile(group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml) {
         force = true
     }
 
-    contractTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.31') {
+    contractTestCompile(group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml) {
         force = true
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ def versions = [
     springHystrix      : '2.1.1.RELEASE',
     springfoxSwagger   : '2.9.2',
     pact_version       : '4.1.7',
-    jackson            : '2.11.2',
-    snakeyaml          : '1.31'
+    jackson            : '2.11.2'
+
 ]
 
 ext.libraries = [
@@ -278,9 +278,6 @@ dependencyManagement {
             entry 'log4j-api'
             entry 'log4j-to-slf4j'
         }
-
-        //CVE-2022-25857
-        dependency(group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml)
     }
 }
 
@@ -331,7 +328,7 @@ dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '30.0-jre'
     annotationProcessor 'org.projectlombok:lombok:1.18.12'
     compileOnly 'org.projectlombok:lombok:1.18.12'
-    compile group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml
+    compile group: 'org.yaml', name: 'snakeyaml', version: '1.31'
 
     compile group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.2.2'
 
@@ -377,19 +374,19 @@ dependencies {
     contractTestRuntime("org.junit.jupiter:junit-jupiter-engine:5.6.2")
     contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.6.2')
 
-    testCompile(group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml) {
+    testCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.31') {
         force = true
     }
 
-    integrationTestCompile(group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml) {
+    integrationTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.31') {
         force = true
     }
 
-    functionalTestCompile(group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml) {
+    functionalTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.31') {
         force = true
     }
 
-    contractTestCompile(group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml) {
+    contractTestCompile(group: 'org.yaml', name: 'snakeyaml', version: '1.31') {
         force = true
     }
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -112,4 +112,5 @@
         <cve>CVE-2022-34305</cve>
     </suppress>
     <suppress><cve>CVE-2022-31197</cve></suppress>
+    <suppress><cve>CVE-2022-25857</cve></suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -112,5 +112,4 @@
         <cve>CVE-2022-34305</cve>
     </suppress>
     <suppress><cve>CVE-2022-31197</cve></suppress>
-    <suppress><cve>CVE-2022-25857</cve></suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1545,8 +1545,11 @@ public enum AsylumCaseFieldDefinition {
     HAS_SERVICE_REQUEST_ALREADY(
         "hasServiceRequestAlready", new TypeReference<YesOrNo>(){}),
 
-    IS_SERVICE_REQUEST_TAB_VISIBLE(
-        "isServiceRequestTabVisible", new TypeReference<YesOrNo>(){})
+    IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS(
+        "isServiceRequestTabVisibleConsideringRemissions", new TypeReference<YesOrNo>(){}),
+
+    DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION(
+        "displayMarkAsPaidEventForPartialRemission", new TypeReference<YesOrNo>(){})
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1545,6 +1545,8 @@ public enum AsylumCaseFieldDefinition {
     HAS_SERVICE_REQUEST_ALREADY(
         "hasServiceRequestAlready", new TypeReference<YesOrNo>(){}),
 
+    IS_SERVICE_REQUEST_TAB_VISIBLE(
+        "isServiceRequestTabVisible", new TypeReference<YesOrNo>(){})
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealSubmitHandler.java
@@ -1,13 +1,17 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_SERVICE_REQUEST_TAB_VISIBLE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PA_APPEAL_TYPE_PAYMENT_OPTION;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REMISSION_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.SUBMIT_APPEAL;
 
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
@@ -63,6 +67,12 @@ public class AppealSubmitHandler implements PreSubmitCallbackHandler<AsylumCase>
         YesOrNo appealOutOfCountry = asylumCase.read(AsylumCaseFieldDefinition.APPEAL_OUT_OF_COUNTRY, YesOrNo.class).orElse(YesOrNo.NO);
 
         log.info("Appeal submitted for case ID {},  Out Of Country: {}", caseId, appealOutOfCountry);
+
+        Optional<RemissionType> optRemissionType = asylumCase.read(REMISSION_TYPE, RemissionType.class);
+
+        if (optRemissionType.isPresent() && optRemissionType.get().equals(RemissionType.NO_REMISSION)) {
+            asylumCase.write(IS_SERVICE_REQUEST_TAB_VISIBLE, YesOrNo.YES);
+        }
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealSubmitHandler.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_SERVICE_REQUEST_TAB_VISIBLE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PA_APPEAL_TYPE_PAYMENT_OPTION;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REMISSION_DECISION;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REMISSION_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.SUBMIT_APPEAL;
 
@@ -11,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionDecision;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
@@ -69,9 +72,16 @@ public class AppealSubmitHandler implements PreSubmitCallbackHandler<AsylumCase>
         log.info("Appeal submitted for case ID {},  Out Of Country: {}", caseId, appealOutOfCountry);
 
         Optional<RemissionType> optRemissionType = asylumCase.read(REMISSION_TYPE, RemissionType.class);
+        Optional<RemissionDecision> optRemissionDecision = asylumCase.read(REMISSION_DECISION, RemissionDecision.class);
 
         if (optRemissionType.isPresent() && optRemissionType.get().equals(RemissionType.NO_REMISSION)) {
-            asylumCase.write(IS_SERVICE_REQUEST_TAB_VISIBLE, YesOrNo.YES);
+            asylumCase.write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.YES);
+        } else {
+            asylumCase.write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.NO);
+
+            if (optRemissionDecision.isEmpty()) {
+                asylumCase.write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.NO);
+            }
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandler.java
@@ -79,6 +79,9 @@ public class RecordRemissionDecisionStateHandler implements PreSubmitCallbackSta
         switch (remissionDecision) {
             case APPROVED:
                 asylumCase.write(PAYMENT_STATUS, PaymentStatus.PAID);
+                asylumCase.write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.NO);
+                asylumCase.write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.NO);
+
                 if (Arrays.asList(AppealType.EA, AppealType.HU).contains(appealType)) {
                     return new PreSubmitCallbackResponse<>(asylumCase, State.APPEAL_SUBMITTED);
                 }
@@ -88,8 +91,6 @@ public class RecordRemissionDecisionStateHandler implements PreSubmitCallbackSta
                 asylumCase.write(PAYMENT_STATUS, PaymentStatus.PAYMENT_PENDING);
                 asylumCase.write(REMISSION_REJECTED_DATE_PLUS_14DAYS,
                     LocalDate.parse(dateProvider.now().plusDays(14).toString()).format(DateTimeFormatter.ofPattern("d MMM yyyy")));
-
-                feePayment.aboutToSubmit(callback);
 
                 asylumCase.write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.NO);
                 asylumCase.write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.YES);
@@ -106,7 +107,7 @@ public class RecordRemissionDecisionStateHandler implements PreSubmitCallbackSta
                 asylumCase.write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.YES);
                 asylumCase.write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.NO);
 
-        return new PreSubmitCallbackResponse<>(asylumCase, currentState);
+                return new PreSubmitCallbackResponse<>(asylumCase, currentState);
 
             default:
                 return new PreSubmitCallbackResponse<>(asylumCase, currentState);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandler.java
@@ -85,6 +85,17 @@ public class RecordRemissionDecisionStateHandler implements PreSubmitCallbackSta
                 return new PreSubmitCallbackResponse<>(asylumCase, currentState);
 
             case PARTIALLY_APPROVED:
+                asylumCase.write(PAYMENT_STATUS, PaymentStatus.PAYMENT_PENDING);
+                asylumCase.write(REMISSION_REJECTED_DATE_PLUS_14DAYS,
+                    LocalDate.parse(dateProvider.now().plusDays(14).toString()).format(DateTimeFormatter.ofPattern("d MMM yyyy")));
+
+                feePayment.aboutToSubmit(callback);
+
+                asylumCase.write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.NO);
+                asylumCase.write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.YES);
+
+                return new PreSubmitCallbackResponse<>(asylumCase, currentState);
+
             case REJECTED:
                 asylumCase.write(PAYMENT_STATUS, PaymentStatus.PAYMENT_PENDING);
                 asylumCase.write(REMISSION_REJECTED_DATE_PLUS_14DAYS,
@@ -92,9 +103,10 @@ public class RecordRemissionDecisionStateHandler implements PreSubmitCallbackSta
 
                 feePayment.aboutToSubmit(callback);
 
-                asylumCase.write(IS_SERVICE_REQUEST_TAB_VISIBLE, YesOrNo.YES);
+                asylumCase.write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.YES);
+                asylumCase.write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.NO);
 
-                return new PreSubmitCallbackResponse<>(asylumCase, currentState);
+        return new PreSubmitCallbackResponse<>(asylumCase, currentState);
 
             default:
                 return new PreSubmitCallbackResponse<>(asylumCase, currentState);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealSubmitHandlerTest.java
@@ -13,10 +13,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionDecision;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
@@ -64,6 +67,54 @@ class AppealSubmitHandlerTest {
         assertEquals(asylumCase, callbackResponse.getData());
 
         verify(asylumCase, times(1)).read(APPEAL_OUT_OF_COUNTRY, YesOrNo.class);
+    }
+
+    @Test
+    void should_make_service_request_tab_visible_if_no_remission() {
+
+        when(callback.getEvent()).thenReturn(SUBMIT_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(APPEAL_OUT_OF_COUNTRY, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(REMISSION_TYPE, RemissionType.class)).thenReturn(Optional.of(RemissionType.NO_REMISSION));
+        when(asylumCase.read(REMISSION_DECISION, RemissionDecision.class)).thenReturn(Optional.empty());
+
+        appealSubmitHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        ArgumentCaptor<AsylumCaseFieldDefinition> tabVisibleFieldCaptor = ArgumentCaptor.forClass(AsylumCaseFieldDefinition.class);
+        ArgumentCaptor<Object> yesOrNoCaptor = ArgumentCaptor.forClass(YesOrNo.class);
+        verify(asylumCase, times(1))
+            .write(tabVisibleFieldCaptor.capture(), yesOrNoCaptor.capture());
+
+        assertEquals(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, tabVisibleFieldCaptor.getValue());
+        assertEquals(YesOrNo.YES, yesOrNoCaptor.getValue());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = RemissionDecision.class, names = {"PARTIALLY_APPROVED", "APPROVED"})
+    void should_make_service_request_tab_hidden_if_remission_not_rejected(RemissionDecision remissionDecision) {
+
+        when(callback.getEvent()).thenReturn(SUBMIT_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(APPEAL_OUT_OF_COUNTRY, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(REMISSION_TYPE, RemissionType.class))
+            .thenReturn(Optional.of(RemissionType.EXCEPTIONAL_CIRCUMSTANCES_REMISSION));
+        when(asylumCase.read(REMISSION_DECISION, RemissionDecision.class)).thenReturn(Optional.of(remissionDecision));
+
+        appealSubmitHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        ArgumentCaptor<AsylumCaseFieldDefinition> tabVisibleFieldCaptor = ArgumentCaptor.forClass(AsylumCaseFieldDefinition.class);
+        ArgumentCaptor<Object> yesOrNoCaptor = ArgumentCaptor.forClass(YesOrNo.class);
+        verify(asylumCase, times(1))
+            .write(tabVisibleFieldCaptor.capture(), yesOrNoCaptor.capture());
+
+        assertEquals(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, tabVisibleFieldCaptor.getValue());
+        assertEquals(YesOrNo.NO, yesOrNoCaptor.getValue());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandlerTest.java
@@ -31,6 +31,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.FeatureToggler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.FeePayment;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
@@ -43,6 +44,7 @@ class RecordRemissionDecisionStateHandlerTest {
 
     @Mock private FeatureToggler featureToggler;
     @Mock private DateProvider dateProvider;
+    @Mock private FeePayment feePayment;
 
     private RecordRemissionDecisionStateHandler recordRemissionDecisionStateHandler;
 
@@ -50,7 +52,7 @@ class RecordRemissionDecisionStateHandlerTest {
     public void setUp() {
         MockitoAnnotations.openMocks(this);
 
-        recordRemissionDecisionStateHandler = new RecordRemissionDecisionStateHandler(featureToggler, dateProvider);
+        recordRemissionDecisionStateHandler = new RecordRemissionDecisionStateHandler(featureToggler, dateProvider, feePayment);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandlerTest.java
@@ -30,6 +30,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.FeatureToggler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.FeePayment;
 
@@ -91,6 +92,8 @@ class RecordRemissionDecisionStateHandlerTest {
     @ParameterizedTest
     @EnumSource(value = AppealType.class, names = { "EA", "HU" })
     void should_return_appeal_submitted_state_on_remission_approved_for_ea_hu(AppealType type) {
+        // and service-request tab should be hidden (no payment to take care of)
+        // and markAppealAsPaid should be hidden (no payment to take care of, case state already sorted)
 
         when(featureToggler.getValue("remissions-feature", false)).thenReturn(true);
 
@@ -109,11 +112,17 @@ class RecordRemissionDecisionStateHandlerTest {
         assertThat(returnedCallbackResponse.getData()).isEqualTo(asylumCase);
         assertThat(returnedCallbackResponse.getState()).isEqualTo(State.APPEAL_SUBMITTED);
         verify(asylumCase, times(1)).write(PAYMENT_STATUS, PAID);
+
+        verify(feePayment, never()).aboutToSubmit(callback);
+        verify(asylumCase, times(1)).write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.NO);
+        verify(asylumCase, times(1)).write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.NO);
     }
 
     @ParameterizedTest
     @EnumSource(value = AppealType.class, names = { "EA", "HU" })
     void should_return_payment_pending_on_remission_partially_approved(AppealType type) {
+        // and service-request tab should be hidden (payment is handled offline, waysToPay not yet supporting partial remissions)
+        // and markAppealAsPaid should be visible, to allow admins to process offline payments
 
         when(featureToggler.getValue("remissions-feature", false)).thenReturn(true);
 
@@ -133,11 +142,15 @@ class RecordRemissionDecisionStateHandlerTest {
         assertThat(returnedCallbackResponse.getData()).isEqualTo(asylumCase);
         assertThat(returnedCallbackResponse.getState()).isEqualTo(State.PENDING_PAYMENT);
         verify(asylumCase, times(1)).write(PAYMENT_STATUS, PAYMENT_PENDING);
+        verify(feePayment, never()).aboutToSubmit(callback);
+        verify(asylumCase, times(1)).write(REMISSION_REJECTED_DATE_PLUS_14DAYS,
+            LocalDate.parse(dateProvider.now().plusDays(14).toString()).format(DateTimeFormatter.ofPattern("d MMM yyyy")));
+        verify(asylumCase, times(1)).write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.NO);
+        verify(asylumCase, times(1)).write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.YES);
     }
 
     @Test
     void should_return_appeal_submitted_state_on_remission_approved_for_pa() {
-
         when(featureToggler.getValue("remissions-feature", false)).thenReturn(true);
 
         when(callback.getEvent()).thenReturn(Event.RECORD_REMISSION_DECISION);
@@ -160,6 +173,8 @@ class RecordRemissionDecisionStateHandlerTest {
     @ParameterizedTest
     @EnumSource(value = AppealType.class, names = { "EA", "HU", "PA" })
     void handle_should_return_payment_due_for_remission_rejected(AppealType type) {
+        // and service-request tab should be visible (payment is handled via waysToPay service-request)
+        // and markAppealAsPaid should not be visible, (payment handled via waysToPay service-request)
 
         when(featureToggler.getValue("remissions-feature", false)).thenReturn(true);
 
@@ -180,6 +195,10 @@ class RecordRemissionDecisionStateHandlerTest {
         verify(asylumCase, times(1)).write(PAYMENT_STATUS, PAYMENT_PENDING);
         verify(asylumCase,times(1)).write(REMISSION_REJECTED_DATE_PLUS_14DAYS,
             LocalDate.parse(dateProvider.now().plusDays(14).toString()).format(DateTimeFormatter.ofPattern("d MMM yyyy")));
+
+        verify(feePayment, times(1)).aboutToSubmit(callback);
+        verify(asylumCase, times(1)).write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.YES);
+        verify(asylumCase, times(1)).write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.NO);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6169](https://tools.hmcts.net/jira/browse/RIA-6169)


### Change description ###
- Added flag to be used to show 'markAppealPaid' and 'moveToSubmitted' events
- Added flag to be used to show/hide service-request tab
- Added logic for service-request to be generated when 'recordRemissionDecision' event results in REMISSION_REJECTED

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
