### PR TITLE
Ria-6223 ea hu end appeal automatically

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AutomaticEndAppealForNonPaymentEaHuTrigger.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AutomaticEndAppealForNonPaymentEaHuTrigger.java
@@ -1,0 +1,79 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REMISSION_TYPE;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.Scheduler;
+import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.model.TimedEvent;
+
+@Component
+public class AutomaticEndAppealForNonPaymentEaHuTrigger implements PostSubmitCallbackHandler<AsylumCase> {
+
+    private final DateProvider dateProvider;
+    private final Scheduler scheduler;
+
+    @Value("${paymentEaHuNoRemission.dueInMinutes}")
+    int schedule14DaysInMinutes;
+
+    public AutomaticEndAppealForNonPaymentEaHuTrigger(
+        DateProvider dateProvider,
+        Scheduler scheduler
+    ) {
+        this.dateProvider = dateProvider;
+        this.scheduler = scheduler;
+    }
+
+    public boolean canHandle(
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callback, "callback must not be null");
+
+        AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        Optional<RemissionType> remissionType = asylumCase.read(REMISSION_TYPE, RemissionType.class);
+        Optional<AppealType> appealType = asylumCase.read(APPEAL_TYPE, AppealType.class);
+
+        return callback.getEvent() == Event.SUBMIT_APPEAL
+               && (remissionType.isPresent() && remissionType.get() == RemissionType.NO_REMISSION)
+               && (appealType.isPresent() && (appealType.get() == AppealType.EA || appealType.get() == AppealType.HU));
+    }
+
+    public PostSubmitCallbackResponse handle(
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback for auto end appeal for remission rejection");
+        }
+
+        ZonedDateTime scheduledDate = ZonedDateTime.of(dateProvider.nowWithTime(), ZoneId.systemDefault()).plusMinutes(schedule14DaysInMinutes);
+
+        scheduler.schedule(
+            new TimedEvent(
+                "",
+                Event.END_APPEAL_AUTOMATICALLY,
+                scheduledDate,
+                "IA",
+                "Asylum",
+                callback.getCaseDetails().getId()
+            )
+        );
+        return new PostSubmitCallbackResponse();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -101,6 +101,7 @@ requestRespondentEvidence.dueInDays: 14
 requestRespondentReview.dueInDays: 14
 appellantReasonsForAppeal.dueInDays: 28
 paymentAfterRemissionRejection.dueInMinutes: 20160
+paymentEaHuNoRemission.dueInMinutes: 20160
 
 core_case_data_api_url_template: "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases"
 core_case_data_api_metatdata_url: "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/pagination_metadata"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AutomaticEndAppealForNonPaymentEaHuTriggerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AutomaticEndAppealForNonPaymentEaHuTriggerTest.java
@@ -1,0 +1,131 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REMISSION_TYPE;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.Scheduler;
+import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.AsylumCaseServiceResponseException;
+import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.model.TimedEvent;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class AutomaticEndAppealForNonPaymentEaHuTriggerTest {
+
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+    @Mock
+    private DateProvider dateProvider;
+    @Mock
+    private Scheduler scheduler;
+
+    @Captor
+    private ArgumentCaptor<TimedEvent> timedEventArgumentCaptor;
+    private final LocalDateTime now = LocalDateTime.now();
+    private final String id = "someId";
+    private final long caseId = 12345;
+
+    private final String jurisdiction = "IA";
+    private final String caseType = "Asylum";
+
+    private AutomaticEndAppealForNonPaymentEaHuTrigger automaticEndAppealForNonPaymentEaHuTrigger;
+
+    @BeforeEach
+    void setUp() {
+
+        automaticEndAppealForNonPaymentEaHuTrigger =
+            new AutomaticEndAppealForNonPaymentEaHuTrigger(
+                dateProvider,
+                scheduler
+            );
+    }
+
+    @Test
+    void should_schedule_automatic_end_appeal_14_days_from_now_ea_hu_after_submission() {
+
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(caseDetails.getId()).thenReturn(caseId);
+        when(asylumCase.read(REMISSION_TYPE, RemissionType.class))
+            .thenReturn(Optional.of(RemissionType.NO_REMISSION));
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class))
+            .thenReturn(Optional.of(AppealType.HU));
+        when(dateProvider.nowWithTime()).thenReturn(now);
+        TimedEvent timedEvent = new TimedEvent(
+            id,
+            Event.END_APPEAL_AUTOMATICALLY,
+            ZonedDateTime.of(dateProvider.nowWithTime(), ZoneId.systemDefault()).plusMinutes(20160),
+            jurisdiction,
+            caseType,
+            caseId
+        );
+        when(scheduler.schedule(any(TimedEvent.class))).thenReturn(timedEvent);
+
+        automaticEndAppealForNonPaymentEaHuTrigger.handle(callback);
+
+        verify(scheduler).schedule(timedEventArgumentCaptor.capture());
+
+        TimedEvent result = timedEventArgumentCaptor.getValue();
+
+        assertEquals(timedEvent.getCaseId(), result.getCaseId());
+        assertEquals(timedEvent.getJurisdiction(), result.getJurisdiction());
+        assertEquals(timedEvent.getCaseType(), result.getCaseType());
+        assertEquals(timedEvent.getEvent(), result.getEvent());
+        assertEquals("", result.getId());
+    }
+
+    @Test
+    void should_rethrow_exception_when_scheduler_failed() {
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(caseDetails.getId()).thenReturn(caseId);
+        when(dateProvider.nowWithTime()).thenReturn(now);
+        when(asylumCase.read(REMISSION_TYPE, RemissionType.class))
+            .thenReturn(Optional.of(RemissionType.NO_REMISSION));
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class))
+            .thenReturn(Optional.of(AppealType.EA));
+
+        when(scheduler.schedule(any(TimedEvent.class))).thenThrow(AsylumCaseServiceResponseException.class);
+
+        assertThatThrownBy(() -> automaticEndAppealForNonPaymentEaHuTrigger.handle(callback))
+            .isExactlyInstanceOf(AsylumCaseServiceResponseException.class);
+    }
+
+    @Test
+    void handling_should_throw_if_null_callback() {
+
+        assertThatThrownBy(() -> automaticEndAppealForNonPaymentEaHuTrigger.handle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> automaticEndAppealForNonPaymentEaHuTrigger.canHandle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6223

### Change description ###

- Trigger handler to schedule endAppealAutomatically event on the Submit Appeal event for EA and HU cases
- application.yaml value set to 14 days (20160 mins)
- Unit tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
