### PR TITLE
RIA-6269 Conform paAppealTypePaymentOption "payOffline" to "payLater"

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordOutOfTimeDecisionPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordOutOfTimeDecisionPreparer.java
@@ -55,7 +55,9 @@ public class RecordOutOfTimeDecisionPreparer implements PreSubmitCallbackHandler
         // Migration to new F&P waysToPay requires "payOffline" not to be an option anymore.
         // "payOffline" values in old cases have to conform to "payLater".
         String paymentOption = asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class).orElse("");
-        if (paymentOption.equals("payOffline")) asylumCase.write(PA_APPEAL_TYPE_PAYMENT_OPTION, "payLater");
+        if (paymentOption.equals("payOffline")) {
+            asylumCase.write(PA_APPEAL_TYPE_PAYMENT_OPTION, "payLater");
+        }
 
         YesOrNo recordedOutOfTimeDecision = asylumCase.read(RECORDED_OUT_OF_TIME_DECISION, YesOrNo.class).orElse(NO);
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordOutOfTimeDecisionPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordOutOfTimeDecisionPreparer.java
@@ -52,6 +52,11 @@ public class RecordOutOfTimeDecisionPreparer implements PreSubmitCallbackHandler
 
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
+        // Migration to new F&P waysToPay requires "payOffline" not to be an option anymore.
+        // "payOffline" values in old cases have to conform to "payLater".
+        String paymentOption = asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class).orElse("");
+        if (paymentOption.equals("payOffline")) asylumCase.write(PA_APPEAL_TYPE_PAYMENT_OPTION, "payLater");
+
         YesOrNo recordedOutOfTimeDecision = asylumCase.read(RECORDED_OUT_OF_TIME_DECISION, YesOrNo.class).orElse(NO);
 
         if (recordedOutOfTimeDecision == YES) {

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordOutOfTimeDecisionPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordOutOfTimeDecisionPreparerTest.java
@@ -74,6 +74,7 @@ class RecordOutOfTimeDecisionPreparerTest {
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(callback.getEvent()).thenReturn(Event.RECORD_OUT_OF_TIME_DECISION);
 
+        when(asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(RECORDED_OUT_OF_TIME_DECISION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(asylumCase.read(PREVIOUS_OUT_OF_TIME_DECISION_DETAILS)).thenReturn(Optional.of(Collections.emptyList()));
 
@@ -90,6 +91,7 @@ class RecordOutOfTimeDecisionPreparerTest {
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(callback.getEvent()).thenReturn(Event.RECORD_OUT_OF_TIME_DECISION);
 
+        when(asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(RECORDED_OUT_OF_TIME_DECISION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(asylumCase.read(PREVIOUS_OUT_OF_TIME_DECISION_DETAILS)).thenReturn(Optional.of(Collections.emptyList()));
         when(asylumCase.read(OUT_OF_TIME_DECISION_TYPE, OutOfTimeDecisionType.class))
@@ -108,6 +110,7 @@ class RecordOutOfTimeDecisionPreparerTest {
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(callback.getEvent()).thenReturn(Event.RECORD_OUT_OF_TIME_DECISION);
 
+        when(asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(RECORDED_OUT_OF_TIME_DECISION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(asylumCase.read(OUT_OF_TIME_DECISION_TYPE, OutOfTimeDecisionType.class))
             .thenReturn(Optional.of(outOfTimeDecisionType));


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6269 (Scenario 4)](https://tools.hmcts.net/jira/browse/RIA-6269)


### Change description ###
- When starting event "recordOutOfTimeDecision", if the value of "paAppealTypePaymentOption" of an old case is `payOffline` it'll throw an error because that FixedRadioList now only allows "payNow" and "payLater" (no more ~`payOffline`~). Any `payOffline` value gets translated to `payLater` in the ABOUT_TO_START handler of the event, so it doesn't throw any error about case data validation.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
