### PR TITLE
RIA-6229 RecordRemissionDecision to populate paymentStatus if empty

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -74,6 +74,8 @@
         <cve>CVE-2021-22060</cve>
         <cve>CVE-2022-31569</cve>
         <cve>CVE-2022-38752</cve>
+        <cve>CVE-2022-42003</cve>
+        <cve>CVE-2022-42004</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandler.java
@@ -76,6 +76,8 @@ public class RecordRemissionDecisionStateHandler implements PreSubmitCallbackSta
         final RemissionDecision remissionDecision = asylumCase.read(REMISSION_DECISION, RemissionDecision.class)
             .orElseThrow(() -> new IllegalStateException("Remission decision is not present"));
 
+        final PaymentStatus paymentStatus = asylumCase.read(PAYMENT_STATUS, PaymentStatus.class).orElse(PaymentStatus.PAYMENT_PENDING);
+
         switch (remissionDecision) {
             case APPROVED:
                 asylumCase.write(PAYMENT_STATUS, PaymentStatus.PAID);
@@ -88,7 +90,7 @@ public class RecordRemissionDecisionStateHandler implements PreSubmitCallbackSta
                 return new PreSubmitCallbackResponse<>(asylumCase, currentState);
 
             case PARTIALLY_APPROVED:
-                asylumCase.write(PAYMENT_STATUS, PaymentStatus.PAYMENT_PENDING);
+                asylumCase.write(PAYMENT_STATUS, paymentStatus);
                 asylumCase.write(REMISSION_REJECTED_DATE_PLUS_14DAYS,
                     LocalDate.parse(dateProvider.now().plusDays(14).toString()).format(DateTimeFormatter.ofPattern("d MMM yyyy")));
 
@@ -98,7 +100,7 @@ public class RecordRemissionDecisionStateHandler implements PreSubmitCallbackSta
                 return new PreSubmitCallbackResponse<>(asylumCase, currentState);
 
             case REJECTED:
-                asylumCase.write(PAYMENT_STATUS, PaymentStatus.PAYMENT_PENDING);
+                asylumCase.write(PAYMENT_STATUS, paymentStatus);
                 asylumCase.write(REMISSION_REJECTED_DATE_PLUS_14DAYS,
                     LocalDate.parse(dateProvider.now().plusDays(14).toString()).format(DateTimeFormatter.ofPattern("d MMM yyyy")));
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandlerTest.java
@@ -30,6 +30,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.PaymentStatus;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.FeatureToggler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.FeePayment;
@@ -195,6 +196,39 @@ class RecordRemissionDecisionStateHandlerTest {
         assertThat(returnedCallbackResponse).isNotNull();
         assertThat(returnedCallbackResponse.getData()).isEqualTo(asylumCase);
         verify(asylumCase, times(1)).write(PAYMENT_STATUS, PAYMENT_PENDING);
+        verify(asylumCase,times(1)).write(REMISSION_REJECTED_DATE_PLUS_14DAYS,
+            LocalDate.parse(dateProvider.now().plusDays(14).toString()).format(DateTimeFormatter.ofPattern("d MMM yyyy")));
+
+        verify(feePayment, times(1)).aboutToSubmit(callback);
+        verify(asylumCase, times(1)).write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.YES);
+        verify(asylumCase, times(1)).write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.NO);
+        verify(asylumCase, times(1)).write(HAS_SERVICE_REQUEST_ALREADY, YesOrNo.YES);
+
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AppealType.class, names = { "EA", "HU", "PA" })
+    void handle_should_leave_payment_status_as_is_if_present_for_remission_rejected(AppealType type) {
+        // payment status gets left alone (e.g. when appeal gets paid for, THEN remissions are requested and decided)
+
+        when(featureToggler.getValue("remissions-feature", false)).thenReturn(true);
+
+        when(callback.getEvent()).thenReturn(Event.RECORD_REMISSION_DECISION);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getState()).thenReturn(State.APPEAL_SUBMITTED);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(dateProvider.now()).thenReturn(LocalDate.now());
+
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(type));
+        when(asylumCase.read(PAYMENT_STATUS, PaymentStatus.class)).thenReturn(Optional.of(PAID));
+        when(asylumCase.read(REMISSION_DECISION, RemissionDecision.class)).thenReturn(Optional.of(REJECTED));
+
+        PreSubmitCallbackResponse<AsylumCase> returnedCallbackResponse =
+            recordRemissionDecisionStateHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback, callbackResponse);
+
+        assertThat(returnedCallbackResponse).isNotNull();
+        assertThat(returnedCallbackResponse.getData()).isEqualTo(asylumCase);
+        verify(asylumCase, times(1)).write(PAYMENT_STATUS, PAID);
         verify(asylumCase,times(1)).write(REMISSION_REJECTED_DATE_PLUS_14DAYS,
             LocalDate.parse(dateProvider.now().plusDays(14).toString()).format(DateTimeFormatter.ofPattern("d MMM yyyy")));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[https://tools.hmcts.net/jira/browse/RIA-6229](https://tools.hmcts.net/jira/browse/RIA-6229)


### Change description ###
- Made the `recordRemissionDecision` event write `paymentStatus` with "Pending payment" when decision is "approved" or "partiallyApproved" only if not present (leave as is if there's a value already)

This is so that when a remission is requested after a payment has been taken, if the remission is rejected, `paymentStatus` doesn't go back to "Pending payment"


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
