### PR TITLE
RIA-6290 New flag as condition for service request generation

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -74,6 +74,8 @@
         <cve>CVE-2021-22060</cve>
         <cve>CVE-2022-31569</cve>
         <cve>CVE-2022-38752</cve>
+        <cve>CVE-2022-42003</cve>
+        <cve>CVE-2022-42004</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1549,7 +1549,11 @@ public enum AsylumCaseFieldDefinition {
         "isServiceRequestTabVisibleConsideringRemissions", new TypeReference<YesOrNo>(){}),
 
     DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION(
-        "displayMarkAsPaidEventForPartialRemission", new TypeReference<YesOrNo>(){})
+        "displayMarkAsPaidEventForPartialRemission", new TypeReference<YesOrNo>(){}),
+
+    REQUEST_FEE_REMISSION_FLAG_FOR_SERVICE_REQUEST(
+
+        "requestFeeRemissionFlagForServiceRequest", new TypeReference<YesOrNo>(){}),
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/PostSubmitCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/PostSubmitCallbackHandler.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers;
 
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseData;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
 
 public interface PostSubmitCallbackHandler<T extends CaseData> {
@@ -9,6 +10,10 @@ public interface PostSubmitCallbackHandler<T extends CaseData> {
     boolean canHandle(
         Callback<T> callback
     );
+
+    default DispatchPriority getDispatchPriority() {
+        return DispatchPriority.LATE;
+    }
 
     PostSubmitCallbackResponse handle(
         Callback<T> callback

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestFeeRemissionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestFeeRemissionHandler.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.FeatureToggler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.RemissionDetailsAppender;
@@ -61,6 +62,8 @@ public class RequestFeeRemissionHandler implements PreSubmitCallbackHandler<Asyl
 
         asylumCase.write(PREVIOUS_REMISSION_DETAILS, getPreviousRemissions());
         clearPreviousRemissionCaseFields(asylumCase);
+
+        asylumCase.write(REQUEST_FEE_REMISSION_FLAG_FOR_SERVICE_REQUEST, YesOrNo.YES);
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestFeeRemissionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestFeeRemissionHandlerTest.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.FeatureToggler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.RemissionDetailsAppender;
 
@@ -78,6 +79,8 @@ class RequestFeeRemissionHandlerTest {
         assertEquals(asylumCase, callbackResponse.getData());
 
         verify(asylumCase, times(1)).write(PREVIOUS_REMISSION_DETAILS, remissionDetailsAppender.getRemissions());
+        verify(asylumCase, times(1)).write(REQUEST_FEE_REMISSION_FLAG_FOR_SERVICE_REQUEST, YesOrNo.YES);
+
 
         if (remissionType == HO_WAIVER_REMISSION) {
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6290

### Change description ###

- New flag 'requestFeeRemissionFlagForServiceRequest' which is only set to 'Yes' when a LR triggers the 'requestFeeRemission' event after submitting the case, which allows us to stop anymore service requests being generated for all case types.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
