### PR TITLE
RIA-6232 Suspend TTL clock

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -174,6 +174,7 @@
     <module name="AbbreviationAsWordInName">
       <property name="ignoreFinal" value="false"/>
       <property name="allowedAbbreviationLength" value="1"/>
+      <property name="allowedAbbreviations" value="systemTTL,overrideTTL,TTL"/>
     </module>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="VariableDeclarationUsageDistance"/>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -62,4 +62,12 @@
         <cve>CVE-2022-34305</cve>
         <cve>CVE-2022-25857</cve>
     </suppress>
+    <suppress>
+        <cve>CVE-2022-42003</cve>
+        <cve>CVE-2022-42004</cve>
+        <cve>CVE-2022-38752</cve>
+        <cve>CVE-2022-38751</cve>
+        <cve>CVE-2022-38750</cve>
+        <cve>CVE-2022-38749</cve>
+    </suppress>
 </suppressions>

--- a/src/functionalTest/resources/scenarios/RIA-6232-stop-the-ttl-clock-when-leadership-judge-ftpa-decision.json
+++ b/src/functionalTest/resources/scenarios/RIA-6232-stop-the-ttl-clock-when-leadership-judge-ftpa-decision.json
@@ -1,0 +1,34 @@
+{
+  "description": "RIA-6232 Suspend the Time To Live clock when triggering leadershipJudgeFtpaDecision",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "leadershipJudgeFtpaDecision",
+      "state": "ftpaDecided",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "ftpaDecisionOutcomeType": "granted",
+          "TTL": {
+            "systemTTL": "${TODAY+730}",
+            "suspended": "No"
+          }
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "TTL": {
+          "systemTTL": "${TODAY+730}",
+          "suspended": "Yes"
+        }
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6232-stop-the-ttl-clock-when-reistating-case.json
+++ b/src/functionalTest/resources/scenarios/RIA-6232-stop-the-ttl-clock-when-reistating-case.json
@@ -1,0 +1,33 @@
+{
+  "description": "RIA-6232 Suspend the Time To Live clock when reinstating a case",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "reinstateAppeal",
+      "state": "appealEnded",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "TTL": {
+            "systemTTL": "${TODAY+730}",
+            "suspended": "No"
+          }
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "TTL": {
+          "systemTTL": "${TODAY+730}",
+          "suspended": "Yes"
+        }
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6232-stop-the-ttl-clock-when-resident-judge-ftpa-decision.json
+++ b/src/functionalTest/resources/scenarios/RIA-6232-stop-the-ttl-clock-when-resident-judge-ftpa-decision.json
@@ -1,0 +1,34 @@
+{
+  "description": "RIA-6232 Suspend the Time To Live clock when triggering residentJudgeFtpaDecision",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "residentJudgeFtpaDecision",
+      "state": "ftpaDecided",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "ftpaResidentJudgeDecisionOutcomeType": "granted",
+          "TTL": {
+            "systemTTL": "${TODAY+730}",
+            "suspended": "No"
+          }
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "TTL": {
+          "systemTTL": "${TODAY+730}",
+          "suspended": "Yes"
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -493,6 +493,9 @@ public enum AsylumCaseFieldDefinition {
     CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER(
         "currentCaseStateVisibleToAdminOfficer", new TypeReference<State>(){}),
 
+    CURRENT_CASE_STATE_VISIBLE_TO_SYSTEM(
+        "currentCaseStateVisibleToSystem", new TypeReference<State>(){}),
+
     CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE_APC(
         "currentCaseStateVisibleToHomeOfficeApc", new TypeReference<State>(){}),
 
@@ -1542,7 +1545,8 @@ public enum AsylumCaseFieldDefinition {
     HMCTS_CASE_CATEGORY(
         "hmctsCaseCategory", new TypeReference<String>(){}),
 
-    ;
+    TTL(
+        "TTL", new TypeReference<TTL>(){});
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/CaseDataContent.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/CaseDataContent.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CaseDataContent {
+
+    private String caseReference;
+    private Map<String, Object> data;
+    private Map<String, Object> event;
+    private String eventToken;
+    private boolean ignoreWarning;
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -118,6 +118,7 @@ public enum Event {
     UPDATE_PAYMENT_STATUS("updatePaymentStatus"),
     MARK_ADDENDUM_EVIDENCE_AS_REVIEWED("markAddendumEvidenceAsReviewed"),
     MARK_PAYMENT_REQUEST_SENT("markPaymentRequestSent"),
+    MANAGE_CASE_TTL("manageCaseTTL"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/StartEventDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/StartEventDetails.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class StartEventDetails {
+
+    private Event eventId;
+    private String token;
+    private CaseDetails<AsylumCase> caseDetails;
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/SubmitEventDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/SubmitEventDetails.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SubmitEventDetails {
+
+    private long id;
+    private String jurisdiction;
+    private State state;
+    private Map<String, Object> data;
+    private int callbackResponseStatusCode;
+    private String callbackResponseStatus;
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/field/TTL.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/field/TTL.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Data;
+
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
+@Builder
+@Data
+public class TTL {
+
+    private String systemTTL;
+    private String overrideTTL;
+    private YesOrNo suspended;
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/EndAppealConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/EndAppealConfirmation.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/EndAppealConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/EndAppealConfirmation.java
@@ -2,16 +2,28 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.TTL;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 @Component
 public class EndAppealConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    private final TimeToLiveDataService timeToLiveDataService;
+
+    public EndAppealConfirmation(TimeToLiveDataService timeToLiveDataService) {
+        this.timeToLiveDataService = timeToLiveDataService;
+    }
 
     @Override
     public boolean canHandle(
@@ -53,6 +65,25 @@ public class EndAppealConfirmation implements PostSubmitCallbackHandler<AsylumCa
             );
         }
 
+        // CCD doesn't set the "ttl.suspended" to NO (clock is active) unless it's null.
+        // When the clock has been stopped "ttl.suspended" gets populated with "YES" and isn't null anymore
+        // So it requires manual intervention to set "ttl.suspended = NO" when starting the clock again
+        if (wasSuccessful(callback) && !isClockActive(asylumCase)) {
+            // stop the clock
+            timeToLiveDataService.updateTheClock(callback, false);
+        }
+
         return postSubmitResponse;
+    }
+
+    private boolean wasSuccessful(Callback<AsylumCase> callback) {
+        CaseDetails<AsylumCase> caseDetails = callback.getCaseDetails();
+        return caseDetails.getState().equals(State.ENDED);
+    }
+
+    private boolean isClockActive(AsylumCase asylumCase) {
+        return asylumCase.read(AsylumCaseFieldDefinition.TTL, TTL.class)
+            .map(ttl -> ttl.getSuspended().equals(YesOrNo.NO))
+            .orElse(false);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/ReinstateAppealConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/ReinstateAppealConfirmation.java
@@ -4,14 +4,23 @@ import static java.util.Objects.requireNonNull;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 
 @Component
 public class ReinstateAppealConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    private final TimeToLiveDataService timeToLiveDataService;
+
+    public ReinstateAppealConfirmation(TimeToLiveDataService timeToLiveDataService) {
+        this.timeToLiveDataService = timeToLiveDataService;
+    }
 
     public boolean canHandle(
         Callback<AsylumCase> callback
@@ -37,6 +46,16 @@ public class ReinstateAppealConfirmation implements PostSubmitCallbackHandler<As
             + "The legal representative and the Home Office will be notified that the case has been reinstated.<br>"
         );
 
+        if (wasSuccessful(callback)) {
+            // stop the clock
+            timeToLiveDataService.updateTheClock(callback, true);
+        }
+
         return postSubmitResponse;
+    }
+
+    private boolean wasSuccessful(Callback<AsylumCase> callback) {
+        CaseDetails<AsylumCase> caseDetails = callback.getCaseDetails();
+        return !caseDetails.getState().equals(State.ENDED);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/RemoveAppealFromOnlineConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/RemoveAppealFromOnlineConfirmation.java
@@ -4,13 +4,25 @@ import static java.util.Objects.*;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.TTL;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 @Component
 public class RemoveAppealFromOnlineConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    private final TimeToLiveDataService timeToLiveDataService;
+
+    public RemoveAppealFromOnlineConfirmation(TimeToLiveDataService timeToLiveDataService) {
+        this.timeToLiveDataService = timeToLiveDataService;
+    }
 
     @Override
     public boolean canHandle(Callback<AsylumCase> callback) {
@@ -38,6 +50,25 @@ public class RemoveAppealFromOnlineConfirmation implements PostSubmitCallbackHan
             + "3.Email a link to the saved files with the appeal reference number to: BAUArnhemHouse@justice.gov.uk"
         );
 
+        // CCD doesn't set the "ttl.suspended" to NO (clock is active) unless it's null.
+        // When the clock has been stopped "ttl.suspended" gets populated with "YES" and isn't null anymore
+        // So it requires manual intervention to set "ttl.suspended = NO" when starting the clock again
+        if (wasSuccessful(callback) && !isClockActive(callback.getCaseDetails().getCaseData())) {
+            // stop the clock
+            timeToLiveDataService.updateTheClock(callback, false);
+        }
+
         return postSubmitResponse;
+    }
+
+    private boolean wasSuccessful(Callback<AsylumCase> callback) {
+        CaseDetails<AsylumCase> caseDetails = callback.getCaseDetails();
+        return caseDetails.getState().equals(State.ENDED);
+    }
+
+    private boolean isClockActive(AsylumCase asylumCase) {
+        return asylumCase.read(AsylumCaseFieldDefinition.TTL, TTL.class)
+            .map(ttl -> ttl.getSuspended().equals(YesOrNo.NO))
+            .orElse(false);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/ResidentJudgeFtpaDecisionConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/ResidentJudgeFtpaDecisionConfirmation.java
@@ -3,15 +3,32 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
+import java.util.List;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 @Component
 public class ResidentJudgeFtpaDecisionConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    private static final String GRANTED = "granted";
+    private static final String PARTIALLY_GRANTED = "partiallyGranted";
+    private static final String REFUSED = "refused";
+    private static final String REHEARD_RULE_32 = "reheardRule32";
+    private static final String REHEARD_RULE_35 = "reheardRule35";
+    private static final String REMADE_RULE_32 = "remadeRule32";
+
+    private final TimeToLiveDataService timeToLiveDataService;
+
+    public ResidentJudgeFtpaDecisionConfirmation(TimeToLiveDataService timeToLiveDataService) {
+        this.timeToLiveDataService = timeToLiveDataService;
+    }
 
     public boolean canHandle(
         Callback<AsylumCase> callback
@@ -49,30 +66,30 @@ public class ResidentJudgeFtpaDecisionConfirmation implements PostSubmitCallback
 
         switch (ftpaOutcomeType) {
 
-            case "granted":
-            case "partiallyGranted":
+            case GRANTED:
+            case PARTIALLY_GRANTED:
                 postSubmitResponse.setConfirmationBody(
                     "#### What happens next\n\n"
                     + "Both parties have been notified of the decision. The Upper Tribunal has also been notified, and will now proceed with the case.<br>"
                 );
                 break;
 
-            case "refused":
+            case REFUSED:
                 postSubmitResponse.setConfirmationBody(
                     "#### What happens next\n\n"
                     + "Both parties have been notified that permission was refused. They'll also be able to access this information in the FTPA tab.<br>"
                 );
                 break;
 
-            case "reheardRule32":
-            case "reheardRule35":
+            case REHEARD_RULE_32:
+            case REHEARD_RULE_35:
                 postSubmitResponse.setConfirmationBody(
                     "#### What happens next\n\n"
                     + "Both parties will be notified of the decision. A Caseworker will review any Tribunal instructions and then relist the case.<br>"
                 );
                 break;
 
-            case "remadeRule32":
+            case REMADE_RULE_32:
                 postSubmitResponse.setConfirmationBody(
                     "#### What happens next\n\n"
                     + "Both parties have been notified of the decision.<br>"
@@ -83,7 +100,19 @@ public class ResidentJudgeFtpaDecisionConfirmation implements PostSubmitCallback
                 throw new IllegalStateException("FtpaDecisionOutcome is not present");
         }
 
+        if (wasSuccessful(callback)
+            && List.of(GRANTED, PARTIALLY_GRANTED, REHEARD_RULE_32, REHEARD_RULE_35).contains(ftpaOutcomeType)) {
+
+            // stop the clock
+            timeToLiveDataService.updateTheClock(callback, true);
+        }
+
         return postSubmitResponse;
+    }
+
+    private boolean wasSuccessful(Callback<AsylumCase> callback) {
+        CaseDetails<AsylumCase> caseDetails = callback.getCaseDetails();
+        return caseDetails.getState().equals(State.FTPA_DECIDED);
     }
 }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/SendDecisionAndReasonsConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/SendDecisionAndReasonsConfirmation.java
@@ -4,13 +4,25 @@ import static java.util.Objects.requireNonNull;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.TTL;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 @Component
 public class SendDecisionAndReasonsConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    private final TimeToLiveDataService timeToLiveDataService;
+
+    public SendDecisionAndReasonsConfirmation(TimeToLiveDataService timeToLiveDataService) {
+        this.timeToLiveDataService = timeToLiveDataService;
+    }
 
     public boolean canHandle(
         Callback<AsylumCase> callback
@@ -36,6 +48,25 @@ public class SendDecisionAndReasonsConfirmation implements PostSubmitCallbackHan
             + "Both parties have been notified of the decision. They'll also be able to access the Decision and Reasons document from the Documents tab."
         );
 
+        // CCD doesn't set the "ttl.suspended" to NO (clock is active) unless it's null.
+        // When the clock has been stopped "ttl.suspended" gets populated with "YES" and isn't null anymore
+        // So it requires manual intervention to set "ttl.suspended = NO" when starting the clock again
+        if (wasSuccessful(callback) && !isClockActive(callback.getCaseDetails().getCaseData())) {
+            // stop the clock
+            timeToLiveDataService.updateTheClock(callback, false);
+        }
+
         return postSubmitResponse;
+    }
+
+    private boolean wasSuccessful(Callback<AsylumCase> callback) {
+        CaseDetails<AsylumCase> caseDetails = callback.getCaseDetails();
+        return caseDetails.getState().equals(State.DECIDED);
+    }
+
+    private boolean isClockActive(AsylumCase asylumCase) {
+        return asylumCase.read(AsylumCaseFieldDefinition.TTL, TTL.class)
+            .map(ttl -> ttl.getSuspended().equals(YesOrNo.NO))
+            .orElse(false);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CurrentCaseStateUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CurrentCaseStateUpdater.java
@@ -53,6 +53,7 @@ public class CurrentCaseStateUpdater implements PreSubmitCallbackHandler<AsylumC
 
         asylumCase.write(CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE, currentCaseState);
         asylumCase.write(CURRENT_CASE_STATE_VISIBLE_TO_ADMIN_OFFICER, currentCaseState);
+        asylumCase.write(CURRENT_CASE_STATE_VISIBLE_TO_SYSTEM, currentCaseState);
         asylumCase.write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE_APC, currentCaseState);
         asylumCase.write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE_LART, currentCaseState);
         asylumCase.write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE_POU, currentCaseState);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/IdamService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/IdamService.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.service;
 
+import feign.FeignException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.IdamApi;
+import uk.gov.hmcts.reform.iacaseapi.infrastructure.security.idam.IdentityManagerResponseException;
 
 @Component
 public class IdamService {
@@ -47,6 +49,14 @@ public class IdamService {
         idamAuthDetails.put("scope", systemUserScope);
 
         return "Bearer " + idamApi.token(idamAuthDetails).getAccessToken();
+    }
+
+    public String getSystemUserId(String userToken) {
+        try {
+            return idamApi.userInfo(userToken).getUid();
+        } catch (FeignException ex) {
+            throw new IdentityManagerResponseException("Could not get system user id from IDAM", ex);
+        }
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ccddataservice/CcdDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ccddataservice/CcdDataService.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.service.ccddataservice;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDataContent;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.StartEventDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.SubmitEventDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.IdamService;
+import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.CcdDataApi;
+import uk.gov.hmcts.reform.iacaseapi.infrastructure.security.idam.IdentityManagerResponseException;
+
+@Service
+@Slf4j
+public class CcdDataService {
+
+    protected final CcdDataApi ccdDataApi;
+    protected final IdamService idamService;
+    protected final AuthTokenGenerator serviceAuthorization;
+    protected final static String JURISDICTION = "IA";
+    protected final static String CASE_TYPE= "Asylum";
+    protected String userToken;
+    protected String s2sToken;
+    protected String uid;
+
+    public CcdDataService(CcdDataApi ccdDataApi,
+                          IdamService idamService,
+                          AuthTokenGenerator serviceAuthorization) {
+
+        this.ccdDataApi = ccdDataApi;
+        this.idamService = idamService;
+        this.serviceAuthorization = serviceAuthorization;
+    }
+
+    protected void authorize(Event eventToAuthorize, String caseId) {
+        String event = eventToAuthorize.toString();
+
+        try {
+            userToken = idamService.getUserToken();
+            log.info("System user token has been generated for event: {}, caseId: {}.", event, caseId);
+
+            s2sToken = serviceAuthorization.generate();
+            log.info("S2S token has been generated for event: {}, caseId: {}.", event, caseId);
+
+            uid = idamService.getSystemUserId(userToken);
+            log.info("System user id has been fetched for event: {}, caseId: {}.", event, caseId);
+
+        } catch (IdentityManagerResponseException ex) {
+
+            log.error("CcdDataService failed to be authorized: {}", ex.getMessage());
+            throw new IdentityManagerResponseException(ex.getMessage(), ex);
+        }
+    }
+
+    protected SubmitEventDetails submitEvent(
+        String userToken,
+        String s2sToken,
+        String caseId,
+        Map<String, Object> data,
+        Map<String, Object> eventData,
+        String eventToken,
+        boolean ignoreWarning) {
+
+        CaseDataContent request =
+            new CaseDataContent(caseId, data, eventData, eventToken, ignoreWarning);
+
+        return ccdDataApi.submitEvent(userToken, s2sToken, caseId, request);
+    }
+
+    protected StartEventDetails startEvent(
+        String userToken,
+        String s2sToken,
+        String uid,
+        String jurisdiction,
+        String caseType,
+        String caseId,
+        Event event) {
+        return ccdDataApi.startEvent(userToken, s2sToken, uid, jurisdiction, caseType,
+            caseId, event.toString());
+    }
+
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ccddataservice/CcdDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ccddataservice/CcdDataService.java
@@ -19,8 +19,8 @@ public class CcdDataService {
     protected final CcdDataApi ccdDataApi;
     protected final IdamService idamService;
     protected final AuthTokenGenerator serviceAuthorization;
-    protected final static String JURISDICTION = "IA";
-    protected final static String CASE_TYPE= "Asylum";
+    protected static final String JURISDICTION = "IA";
+    protected static final String CASE_TYPE = "Asylum";
     protected String userToken;
     protected String s2sToken;
     protected String uid;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ccddataservice/TimeToLiveDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ccddataservice/TimeToLiveDataService.java
@@ -1,0 +1,75 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.service.ccddataservice;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.StartEventDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.SubmitEventDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.TTL;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.IdamService;
+import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.CcdDataApi;
+
+@Service
+@Slf4j
+public class TimeToLiveDataService extends CcdDataService {
+
+    public TimeToLiveDataService(CcdDataApi ccdDataApi, IdamService idamService, AuthTokenGenerator serviceAuthorization) {
+        super(ccdDataApi, idamService, serviceAuthorization);
+    }
+
+    public SubmitEventDetails updateTheClock(Callback<AsylumCase> callback, boolean isToBeSuspended) {
+
+        String caseId = String.valueOf(callback.getCaseDetails().getId());
+        authorize(Event.MANAGE_CASE_TTL, caseId);
+
+        StartEventDetails startEventDetails = startEvent(
+            userToken,
+            s2sToken,
+            uid,
+            JURISDICTION,
+            CASE_TYPE,
+            caseId,
+            Event.MANAGE_CASE_TTL);
+
+        // Update TTL
+        TTL ttlToBeUpdated = updateTTL(startEventDetails, isToBeSuspended);
+
+        Map<String, Object> caseData = new HashMap<>();
+        caseData.put(AsylumCaseFieldDefinition.TTL.value(), ttlToBeUpdated);
+
+        Map<String, Object> eventData = new HashMap<>();
+        eventData.put("id", Event.MANAGE_CASE_TTL.toString());
+
+        SubmitEventDetails submitEventDetails = submitEvent(userToken, s2sToken, caseId, caseData, eventData,
+            startEventDetails.getToken(), true);
+
+        log.info("TTL updated with systemTTL: {}, overrideTTL: {}, suspended: {}",
+            ttlToBeUpdated.getSystemTTL(),
+            ttlToBeUpdated.getOverrideTTL(),
+            ttlToBeUpdated.getSuspended());
+
+        return submitEventDetails;
+    }
+
+    private TTL updateTTL(StartEventDetails startEventDetails, boolean isToBeSuspended) {
+
+        TTL ttl = startEventDetails.getCaseDetails().getCaseData()
+            .read(AsylumCaseFieldDefinition.TTL, TTL.class)
+            .orElseThrow(() -> new IllegalStateException("TTL not present"));
+
+        if (isToBeSuspended) {
+            ttl.setSuspended(YesOrNo.YES);
+        } else {
+            ttl.setSuspended(YesOrNo.NO);
+        }
+
+        return ttl;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/clients/CcdDataApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/clients/CcdDataApi.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.reform.iacaseapi.infrastructure.clients;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static uk.gov.hmcts.reform.iacaseapi.infrastructure.config.ServiceTokenGeneratorConfiguration.SERVICE_AUTHORIZATION;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDataContent;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.StartEventDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.SubmitEventDetails;
+import uk.gov.hmcts.reform.iacaseapi.infrastructure.config.FeignConfiguration;
+
+@FeignClient(
+    name = "core-case-data-api",
+    url = "${core_case_data_api_url}",
+    configuration = FeignConfiguration.class
+)
+public interface CcdDataApi {
+    String EXPERIMENTAL = "experimental=true";
+    String CONTENT_TYPE = "content-type=application/json";
+
+    @GetMapping(
+        value = "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/{cid}/event-triggers/{etid}"
+                + "/token?ignore-warning=true",
+        headers = CONTENT_TYPE
+    )
+    StartEventDetails startEvent(
+        @RequestHeader(AUTHORIZATION) String userToken,
+        @RequestHeader(SERVICE_AUTHORIZATION) String s2sToken,
+        @PathVariable("uid") String userId,
+        @PathVariable("jid") String jurisdiction,
+        @PathVariable("ctid") String caseType,
+        @PathVariable("cid") String id,
+        @PathVariable("etid") String eventId
+    );
+
+    @PostMapping(
+        value = "/cases/{cid}/events",
+        headers = { CONTENT_TYPE, EXPERIMENTAL })
+    SubmitEventDetails submitEvent(
+        @RequestHeader(AUTHORIZATION) String userToken,
+        @RequestHeader(SERVICE_AUTHORIZATION) String s2sToken,
+        @PathVariable("cid") String id,
+        @RequestBody CaseDataContent requestBody
+    );
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -359,6 +359,7 @@ security:
       - "rollbackPaymentTimeout"
       - "rollbackPaymentTimeoutToPaymentPending"
       - "updatePaymentStatus"
+      - "manageCaseTTL"
 
 ### dependency configuration
 ccdGatewayUrl: ${CCD_GW_URL:http://localhost:3453}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinitionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinitionTest.java
@@ -4,7 +4,9 @@ import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ATTENDING_TCW;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.TTL;
 
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +16,7 @@ class AsylumCaseFieldDefinitionTest {
     void mapped_to_equivalent_field_name() {
         Stream.of(AsylumCaseFieldDefinition.values())
             // filter out below variable because of CCD defs constrains to edit existing fields
-            .filter(val -> val != ATTENDING_TCW)
+            .filter(val -> !List.of(ATTENDING_TCW, TTL).contains(val))
             .forEach(v -> assertThat(UPPER_UNDERSCORE.to(LOWER_CAMEL, v.name()))
                 .isEqualTo(v.value()));
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/CaseDataContentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/CaseDataContentTest.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class CaseDataContentTest {
+
+    private final String caseReference = "caseReference";
+    private final Map<String, Object> data = Map.of("data", "data");
+    private final Map<String, Object> event = Map.of("data", "data");
+    private final String eventToken = "eventToken";
+    private final boolean ignoreWarning = true;
+
+    private CaseDataContent caseDataContent = new CaseDataContent(
+        caseReference,
+        data,
+        event,
+        eventToken,
+        ignoreWarning);
+
+    @Test
+    void should_hold_onto_values() {
+        assertEquals(caseReference, caseDataContent.getCaseReference());
+        assertEquals(data, caseDataContent.getData());
+        assertEquals(event, caseDataContent.getEvent());
+        assertEquals(eventToken, caseDataContent.getEventToken());
+        assertEquals(ignoreWarning, caseDataContent.isIgnoreWarning());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -117,10 +117,12 @@ class EventTest {
         assertEquals("updatePaymentStatus", Event.UPDATE_PAYMENT_STATUS.toString());
         assertEquals("markAddendumEvidenceAsReviewed", Event.MARK_ADDENDUM_EVIDENCE_AS_REVIEWED.toString());
         assertEquals("markPaymentRequestSent", Event.MARK_PAYMENT_REQUEST_SENT.toString());
+        assertEquals("manageCaseTTL", Event.MANAGE_CASE_TTL.toString());
+
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(114, Event.values().length);
+        assertEquals(115, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/StartEventDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/StartEventDetailsTest.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+
+@SuppressWarnings("unchecked")
+public class StartEventDetailsTest {
+
+    private Event eventId = Event.SUBMIT_APPEAL;
+    private String token = "token";
+    private CaseDetails<AsylumCase> caseDetails = mock(CaseDetails.class);
+
+    private StartEventDetails startEventDetails = new StartEventDetails(eventId, token, caseDetails);
+
+    @Test
+    void should_hold_onto_values() {
+        assertEquals(eventId, startEventDetails.getEventId());
+        assertEquals(token, startEventDetails.getToken());
+        assertEquals(caseDetails, startEventDetails.getCaseDetails());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/SubmitEventDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/SubmitEventDetailsTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class SubmitEventDetailsTest {
+
+    private long id = 1000L;
+    private String jurisdiction = "Jurisdiction";
+    private State state = State.ENDED;
+    private Map<String, Object> data = Map.of("data", "data");
+    private int callbackResponseStatusCode = 200;
+    private String callbackResponseStatus = "callbackResponseStatus";
+
+    private SubmitEventDetails submitEventDetails = new SubmitEventDetails(
+        id,
+        jurisdiction,
+        state,
+        data,
+        callbackResponseStatusCode,
+        callbackResponseStatus);
+
+    @Test
+    void should_hold_onto_values() {
+        assertEquals(id, submitEventDetails.getId());
+        assertEquals(jurisdiction, submitEventDetails.getJurisdiction());
+        assertEquals(state, submitEventDetails.getState());
+        assertEquals(data, submitEventDetails.getData());
+        assertEquals(callbackResponseStatusCode, submitEventDetails.getCallbackResponseStatusCode());
+        assertEquals(callbackResponseStatus, submitEventDetails.getCallbackResponseStatus());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/field/TtlTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/field/TtlTest.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TtlTest {
+
+    private final String systemTTL = "2022-10-21";
+    private final String overrideTTL = "2023-10-21";
+    private final YesOrNo suspended = YesOrNo.YES;
+
+    private TTL ttl = TTL.builder()
+        .suspended(suspended)
+        .overrideTTL(overrideTTL)
+        .systemTTL(systemTTL)
+        .build();
+
+    @Test
+    void should_hold_onto_values() {
+
+        assertEquals(suspended, ttl.getSuspended());
+        assertEquals(overrideTTL, ttl.getOverrideTTL());
+        assertEquals(systemTTL, ttl.getSystemTTL());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/SendDecisionAndReasonsConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/SendDecisionAndReasonsConfirmationTest.java
@@ -1,22 +1,33 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
 
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.TTL;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
@@ -25,14 +36,25 @@ class SendDecisionAndReasonsConfirmationTest {
     @Mock private Callback<AsylumCase> callback;
     @Mock private CaseDetails<AsylumCase> caseDetails;
     @Mock private AsylumCase asylumCase;
+    @Mock private TTL ttl;
+    @Mock private TimeToLiveDataService timeToLiveDataService;
 
-    private SendDecisionAndReasonsConfirmation sendDecisionAndReasonsConfirmation =
-        new SendDecisionAndReasonsConfirmation();
+    private SendDecisionAndReasonsConfirmation sendDecisionAndReasonsConfirmation;
+
+    @BeforeEach
+    void setup() {
+        sendDecisionAndReasonsConfirmation = new SendDecisionAndReasonsConfirmation(timeToLiveDataService);
+    }
 
     @Test
     void should_return_confirmation() {
 
         when(callback.getEvent()).thenReturn(Event.SEND_DECISION_AND_REASONS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(AsylumCaseFieldDefinition.TTL, TTL.class)).thenReturn(Optional.of(ttl));
+        when(ttl.getSuspended()).thenReturn(YesOrNo.YES);
+        when(caseDetails.getState()).thenReturn(State.DECIDED);
 
         PostSubmitCallbackResponse callbackResponse =
             sendDecisionAndReasonsConfirmation.handle(callback);
@@ -53,6 +75,23 @@ class SendDecisionAndReasonsConfirmationTest {
             callbackResponse.getConfirmationBody().get())
             .contains(
                 "Both parties have been notified of the decision. They'll also be able to access the Decision and Reasons document from the Documents tab.");
+
+        verify(timeToLiveDataService, times(1)).updateTheClock(callback, false);
+    }
+
+    @Test
+    void should_not_trigger_manageCaseTtl_when_unsuccessful() {
+
+        when(callback.getEvent()).thenReturn(Event.SEND_DECISION_AND_REASONS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getState()).thenReturn(State.ENDED); // unexpected state (unsuccessful)
+
+        PostSubmitCallbackResponse callbackResponse =
+            sendDecisionAndReasonsConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+
+        verify(timeToLiveDataService, never()).updateTheClock(callback, false);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/SendDecisionAndReasonsConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/SendDecisionAndReasonsConfirmationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
 
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CurrentCaseStateUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CurrentCaseStateUpdaterTest.java
@@ -18,6 +18,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE_POU;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_JUDGE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_LEGAL_REPRESENTATIVE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CURRENT_CASE_STATE_VISIBLE_TO_SYSTEM;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DISABLE_OVERVIEW_PAGE;
 
 import java.util.Optional;
@@ -74,6 +75,7 @@ class CurrentCaseStateUpdaterTest {
             verify(asylumCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE_GENERIC, state);
             verify(asylumCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_HOME_OFFICE_ALL, state);
             verify(asylumCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_JUDGE, state);
+            verify(asylumCase, times(1)).write(CURRENT_CASE_STATE_VISIBLE_TO_SYSTEM, state);
             reset(asylumCase);
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ccdDataService/TimeToLiveDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ccdDataService/TimeToLiveDataServiceTest.java
@@ -1,0 +1,113 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.service.ccdDataService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDataContent;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.StartEventDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.SubmitEventDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.TTL;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.IdamService;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.ccddataservice.TimeToLiveDataService;
+import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.CcdDataApi;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class TimeToLiveDataServiceTest {
+
+    @Mock
+    private CcdDataApi ccdDataApi;
+    @Mock
+    private IdamService idamService;
+    @Mock
+    private AuthTokenGenerator serviceAuthorization;
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private TTL ttl;
+    @Mock
+    private StartEventDetails startEventDetails;
+    @Mock
+    private SubmitEventDetails submitEventDetails;
+
+    private static final String USER_TOKEN = "userToken";
+    private static final String S2S_TOKEN = "s2sToken";
+    private static final String UID = "uid";
+    private static final String CASE_TYPE= "Asylum";
+    private static final String JURISDICTION = "IA";
+    private static final String EVENT_TOKEN = "eventToken";
+    private static final long CASE_ID = 1;
+
+
+    private TimeToLiveDataService timeToLiveDataService;
+
+    @BeforeEach
+    void setup() {
+        timeToLiveDataService = new TimeToLiveDataService(ccdDataApi, idamService, serviceAuthorization);
+    }
+
+    @Test
+    void should_update_the_clock() {
+        when(idamService.getUserToken()).thenReturn(USER_TOKEN);
+        when(serviceAuthorization.generate()).thenReturn(S2S_TOKEN);
+        when(idamService.getSystemUserId(USER_TOKEN)).thenReturn(UID);
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(caseDetails.getId()).thenReturn(CASE_ID);
+        when(asylumCase.read(AsylumCaseFieldDefinition.TTL, TTL.class)).thenReturn(Optional.of(ttl));
+
+        when(ccdDataApi.startEvent(USER_TOKEN, S2S_TOKEN, UID, JURISDICTION, CASE_TYPE, "1", Event.MANAGE_CASE_TTL.toString()))
+            .thenReturn(startEventDetails);
+
+        when(startEventDetails.getToken()).thenReturn(EVENT_TOKEN);
+        when(startEventDetails.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        CaseDataContent submitRequest = new CaseDataContent(
+            "1",
+            Map.of("TTL", ttl),
+            Map.of("id", Event.MANAGE_CASE_TTL.toString()),
+            EVENT_TOKEN,
+            true);
+
+        ArgumentCaptor<CaseDataContent> caseDataContentArgumentCaptor = ArgumentCaptor.forClass(CaseDataContent.class);
+
+        when(ccdDataApi.submitEvent(
+            eq(USER_TOKEN),
+            eq(S2S_TOKEN),
+            eq("1"),
+            caseDataContentArgumentCaptor.capture())).thenReturn(submitEventDetails);
+
+        assertEquals(submitEventDetails, timeToLiveDataService.updateTheClock(callback, true));
+        assertEquals(submitRequest, caseDataContentArgumentCaptor.getValue());
+
+        verify(ccdDataApi, times(1)).submitEvent(USER_TOKEN, S2S_TOKEN, "1", caseDataContentArgumentCaptor.getValue());
+        verify(ttl, times(1)).setSuspended(YesOrNo.YES);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ccddataservice/TimeToLiveDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ccddataservice/TimeToLiveDataServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.iacaseapi.domain.service.ccdDataService;
+package uk.gov.hmcts.reform.iacaseapi.domain.service.ccddataservice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
@@ -28,7 +28,6 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.TTL;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.IdamService;
-import uk.gov.hmcts.reform.iacaseapi.domain.service.ccddataservice.TimeToLiveDataService;
 import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.CcdDataApi;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -58,7 +57,7 @@ public class TimeToLiveDataServiceTest {
     private static final String USER_TOKEN = "userToken";
     private static final String S2S_TOKEN = "s2sToken";
     private static final String UID = "uid";
-    private static final String CASE_TYPE= "Asylum";
+    private static final String CASE_TYPE = "Asylum";
     private static final String JURISDICTION = "IA";
     private static final String EVENT_TOKEN = "eventToken";
     private static final long CASE_ID = 1;


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6232](https://tools.hmcts.net/jira/browse/RIA-6232)


### Change description ###
- Added CcdDataApi, a feign client that communicates with ccd-data-store-api directly
- Added CcdDataService, which uses CcdDataApi. Other classes can extend when in need to interact with ccd-data-store-api directly
- Added TimeToLiveDataService, which extends from CcdDataService and is specific for TTL affairs
- Added all necessary model classes
- Added the use of timeToLieeDataService from some PostCallbackHandler to trigger the manageCaseTTL event and suspend the clock when needed
- Added the use of timeToLieeDataService from some other PostCallbackHandlers to trigger the manageCaseTTL event and re-start the clock when TTL had already been set by ccd
  - CCD will populate the TTL complex field automatically when the event has `TTLIncrement` in the definitions. However, if the clock gets suspended, the triggering of those events that should set a time-to-live only updates the date (`systemTTL`), so it's necessary to re-trigger manageCaseTTL from ia-case-api to forcefully write `suspended: NO`
- Amended old tests and added new tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
