### PR TITLE
RIA-6459 Custodial date validator and midEvent endpoint parameter

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1554,13 +1554,19 @@ public enum AsylumCaseFieldDefinition {
     REQUEST_FEE_REMISSION_FLAG_FOR_SERVICE_REQUEST(
 
         "requestFeeRemissionFlagForServiceRequest", new TypeReference<YesOrNo>(){}),
+
     APPELLANT_IN_DETENTION(
         "appellantInDetention", new TypeReference<YesOrNo>(){}),
+
     IS_ACCELERATED_DETAINED_APPEAL(
         "isAcceleratedDetainedAppeal", new TypeReference<YesOrNo>(){}),
+
     DETENTION_STATUS(
         "detentionStatus", new TypeReference<String>(){}),
-    ;
+
+    DATE_CUSTODIAL_SENTENCE(
+        "dateCustodialSentence", new TypeReference<CustodialSentenceDate>(){}
+    );
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/CustodialSentenceDate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/CustodialSentenceDate.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+@Getter
+@AllArgsConstructor
+public class CustodialSentenceDate {
+
+    private String custodialDate;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/callback/Callback.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/callback/Callback.java
@@ -20,6 +20,8 @@ public class Callback<T extends CaseData> {
     private CaseDetails<T> caseDetails;
     private Optional<CaseDetails<T>> caseDetailsBefore = Optional.empty();
 
+    private String pageId = "";
+
     private Callback() {
         // noop -- for deserializer
     }
@@ -55,5 +57,13 @@ public class Callback<T extends CaseData> {
 
         return caseDetailsBefore;
 
+    }
+
+    public String getPageId() {
+        return pageId;
+    }
+
+    public void setPageId(String pageId) {
+        this.pageId = pageId;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CustodialDateValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CustodialDateValidator.java
@@ -17,7 +17,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 @Component
 public class CustodialDateValidator implements PreSubmitCallbackHandler<AsylumCase> {
 
-    private final static String CUSTODIAL_SENTENCE_PAGE_ID = "custodialSentence";
+    private static final String CUSTODIAL_SENTENCE_PAGE_ID = "custodialSentence";
 
     public boolean canHandle(
         PreSubmitCallbackStage callbackStage,
@@ -50,7 +50,7 @@ public class CustodialDateValidator implements PreSubmitCallbackHandler<AsylumCa
             LocalDate custodialDate = LocalDate.parse(custodialSentenceDate.getCustodialDate());
             if (!custodialDate.isAfter(LocalDate.now())) {
                 response.addError("Client's release date must be in the future");
-            };
+            }
         });
 
         return response;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CustodialDateValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CustodialDateValidator.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CustodialSentenceDate;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class CustodialDateValidator implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final static String CUSTODIAL_SENTENCE_PAGE_ID = "custodialSentence";
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.MID_EVENT
+               && callback.getPageId().equals(CUSTODIAL_SENTENCE_PAGE_ID)
+               && callback.getEvent() == Event.START_APPEAL;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+        PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
+
+        Optional<CustodialSentenceDate> optionalCustodialSentenceDate = asylumCase
+            .read(DATE_CUSTODIAL_SENTENCE, CustodialSentenceDate.class);
+
+        optionalCustodialSentenceDate.ifPresent(custodialSentenceDate -> {
+            LocalDate custodialDate = LocalDate.parse(custodialSentenceDate.getCustodialDate());
+            if (!custodialDate.isAfter(LocalDate.now())) {
+                response.addError("Client's release date must be in the future");
+            };
+        });
+
+        return response;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealAfterSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealAfterSubmitHandler.java
@@ -34,6 +34,7 @@ public class EditAppealAfterSubmitHandler implements PreSubmitCallbackHandler<As
     private final DateProvider dateProvider;
     private final int appealOutOfTimeDaysUk;
     private final int appealOutOfTimeDaysOoc;
+    private static final String HOME_OFFICE_DECISION_PAGE_ID = "homeOfficeDecision";
 
     public EditAppealAfterSubmitHandler(
         DateProvider dateProvider,
@@ -52,9 +53,10 @@ public class EditAppealAfterSubmitHandler implements PreSubmitCallbackHandler<As
         requireNonNull(callbackStage, "callbackStage must not be null");
         requireNonNull(callback, "callback must not be null");
 
-        return callbackStage == PreSubmitCallbackStage.MID_EVENT
+        return (callbackStage == PreSubmitCallbackStage.MID_EVENT
             || callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-            && callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT;
+            && callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT)
+            && callback.getPageId().equals(HOME_OFFICE_DECISION_PAGE_ID);
     }
 
     public PreSubmitCallbackResponse<AsylumCase> handle(

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEvent.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 public class StartAppealMidEvent implements PreSubmitCallbackHandler<AsylumCase> {
 
     private static final Pattern HOME_OFFICE_REF_PATTERN = Pattern.compile("^(([0-9]{4}\\-[0-9]{4}\\-[0-9]{4}\\-[0-9]{4})|([0-9]{1,9}))$");
+    private static final String HOME_OFFICE_DECISION_PAGE_ID = "homeOfficeDecision";
 
     public boolean canHandle(
             PreSubmitCallbackStage callbackStage,
@@ -27,7 +28,8 @@ public class StartAppealMidEvent implements PreSubmitCallbackHandler<AsylumCase>
         return callbackStage == PreSubmitCallbackStage.MID_EVENT
                 && (callback.getEvent() == Event.START_APPEAL
                     || callback.getEvent() == Event.EDIT_APPEAL
-                    || callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT);
+                    || callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT)
+               && callback.getPageId().equals(HOME_OFFICE_DECISION_PAGE_ID);
     }
 
     public PreSubmitCallbackResponse<AsylumCase> handle(

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/PreSubmitCallbackDispatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/PreSubmitCallbackDispatcher.java
@@ -120,6 +120,8 @@ public class PreSubmitCallbackDispatcher<T extends CaseData> {
                 callback.getEvent()
             );
 
+            callbackForHandler.setPageId(callback.getPageId());
+
             if (callbackStateHandler.canHandle(callbackStage, callbackForHandler)) {
 
                 PreSubmitCallbackResponse<T> callbackResponseFromHandler =
@@ -160,6 +162,8 @@ public class PreSubmitCallbackDispatcher<T extends CaseData> {
                     callback.getCaseDetailsBefore(),
                     callback.getEvent()
                 );
+
+                callbackForHandler.setPageId(callback.getPageId());
 
                 if (callbackHandler.canHandle(callbackStage, callbackForHandler)) {
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/controllers/PreSubmitCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/controllers/PreSubmitCallbackController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
@@ -159,8 +160,12 @@ public class PreSubmitCallbackController {
 
     @PostMapping(path = "/ccdMidEvent")
     public ResponseEntity<PreSubmitCallbackResponse<AsylumCase>> ccdMidEvent(
-        @Parameter(name = "Asylum case data", required = true) @NotNull @RequestBody Callback<AsylumCase> callback
+        @Parameter(name = "Asylum case data", required = true) @NotNull @RequestBody Callback<AsylumCase> callback,
+        @RequestParam(name = "pageId", required = false) String pageId
     ) {
+        if (pageId != null) {
+            callback.setPageId(pageId);
+        }
         return performStageRequest(PreSubmitCallbackStage.MID_EVENT, callback);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/CustodialSentenceDateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/CustodialSentenceDateTest.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class CustodialSentenceDateTest {
+
+    private final String custodialDate = "2022-11-09";
+
+    private CustodialSentenceDate custodialSentenceDate;
+
+    @Test
+    void should_hold_onto_values() {
+        custodialSentenceDate = new CustodialSentenceDate(custodialDate);
+        assertThat(custodialSentenceDate.getCustodialDate()).isEqualTo(custodialDate);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CustodialDateValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CustodialDateValidatorTest.java
@@ -1,0 +1,147 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.values;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CustodialSentenceDate;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class CustodialDateValidatorTest {
+
+    private final static String CUSTODIAL_SENTENCE_PAGE_ID = "custodialSentence";
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private CustodialSentenceDate custodialSentenceDate;
+    private LocalDate now;
+    private String callbackErrorMessage = "Client's release date must be in the future";
+    private CustodialDateValidator custodialDateValidator;
+
+    @BeforeEach
+    public void setUp() {
+        custodialDateValidator = new CustodialDateValidator();
+        now = LocalDate.now();
+
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getPageId()).thenReturn(CUSTODIAL_SENTENCE_PAGE_ID);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { CUSTODIAL_SENTENCE_PAGE_ID, ""})
+    void it_can_handle_callback(String pageId) {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getPageId()).thenReturn(pageId);
+
+            for (PreSubmitCallbackStage callbackStage : values()) {
+
+                boolean canHandle = custodialDateValidator.canHandle(callbackStage, callback);
+
+                if (event == Event.START_APPEAL
+                    && callbackStage == MID_EVENT
+                    && callback.getPageId().equals(CUSTODIAL_SENTENCE_PAGE_ID)) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> custodialDateValidator.handle(ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> custodialDateValidator.handle(ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> custodialDateValidator.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> custodialDateValidator.canHandle(MID_EVENT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void should_error_when_date_is_not_future() {
+        when(asylumCase.read(DATE_CUSTODIAL_SENTENCE, CustodialSentenceDate.class))
+            .thenReturn(Optional.of(custodialSentenceDate));
+
+        String yesterday = now.minusDays(1).toString();
+        when(custodialSentenceDate.getCustodialDate()).thenReturn(yesterday);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            custodialDateValidator.handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        assertNotNull(callback);
+        assertEquals(asylumCase, callbackResponse.getData());
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).hasSize(1).containsOnly(callbackErrorMessage);
+    }
+
+    @Test
+    void should_not_error_if_date_is_null() {
+        when(asylumCase.read(DATE_CUSTODIAL_SENTENCE, CustodialSentenceDate.class))
+            .thenReturn(Optional.empty());
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            custodialDateValidator.handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        assertNotNull(callback);
+        assertEquals(asylumCase, callbackResponse.getData());
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).isEmpty();
+    }
+}
+

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CustodialDateValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CustodialDateValidatorTest.java
@@ -39,7 +39,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallb
 @SuppressWarnings("unchecked")
 public class CustodialDateValidatorTest {
 
-    private final static String CUSTODIAL_SENTENCE_PAGE_ID = "custodialSentence";
+    private static final String CUSTODIAL_SENTENCE_PAGE_ID = "custodialSentence";
     @Mock
     private Callback<AsylumCase> callback;
     @Mock

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEventTest.java
@@ -21,6 +21,8 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -38,6 +40,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallb
 @SuppressWarnings("unchecked")
 class StartAppealMidEventTest {
 
+    private static final String HOME_OFFICE_DECISION_PAGE_ID = "homeOfficeDecision";
     @Mock
     private Callback<AsylumCase> callback;
     @Mock
@@ -59,21 +62,25 @@ class StartAppealMidEventTest {
         when(callback.getEvent()).thenReturn(Event.START_APPEAL);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getPageId()).thenReturn(HOME_OFFICE_DECISION_PAGE_ID);
     }
 
-    @Test
-    void it_can_handle_callback() {
+    @ParameterizedTest
+    @ValueSource(strings = { HOME_OFFICE_DECISION_PAGE_ID, ""})
+    void it_can_handle_callback(String pageId) {
 
         for (Event event : Event.values()) {
 
             when(callback.getEvent()).thenReturn(event);
+            when(callback.getPageId()).thenReturn(pageId);
 
             for (PreSubmitCallbackStage callbackStage : values()) {
 
                 boolean canHandle = startAppealMidEvent.canHandle(callbackStage, callback);
 
                 if ((event == Event.START_APPEAL || event == Event.EDIT_APPEAL || event == Event.EDIT_APPEAL_AFTER_SUBMIT)
-                    && callbackStage == MID_EVENT) {
+                    && callbackStage == MID_EVENT
+                    && callback.getPageId().equals(HOME_OFFICE_DECISION_PAGE_ID)) {
                     assertTrue(canHandle);
                 } else {
                     assertFalse(canHandle);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/controllers/PreSubmitCallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/controllers/PreSubmitCallbackControllerTest.java
@@ -1,7 +1,9 @@
 package uk.gov.hmcts.reform.iacaseapi.infrastructure.controllers;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -10,6 +12,8 @@ import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -86,17 +90,20 @@ class PreSubmitCallbackControllerTest {
         );
     }
 
-    @Test
-    void should_dispatch_mid_event_callback_then_return_response() {
+    @ParameterizedTest
+    @ValueSource(strings = {"somePageId", ""})
+    void should_dispatch_mid_event_callback_then_return_response(String pageIdParam) {
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
+        doCallRealMethod().when(callback).setPageId(pageIdParam);
+        doCallRealMethod().when(callback).getPageId();
 
         doReturn(callbackResponse)
             .when(callbackDispatcher)
             .handle(PreSubmitCallbackStage.MID_EVENT, callback);
 
         ResponseEntity<PreSubmitCallbackResponse<AsylumCase>> actualResponse =
-            preSubmitCallbackController.ccdMidEvent(callback);
+            preSubmitCallbackController.ccdMidEvent(callback, pageIdParam);
 
         assertNotNull(actualResponse);
 
@@ -104,6 +111,7 @@ class PreSubmitCallbackControllerTest {
             PreSubmitCallbackStage.MID_EVENT,
             callback
         );
+        assertEquals(pageIdParam, callback.getPageId());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6459](https://tools.hmcts.net/jira/browse/RIA-6459)


### Change description ###
- Added `pageId` parameter to `/ccdMidEvent` endpoint to allow for multiple midEvent calls from the same event, which necessary in `startAppeal` as part of this ticket (doesn't break other pre-existing calls because the parameter is optional and they'll keep working as before)
- Added validator for `custodialDate` to check it's a future date if present
- Did not make the field in Scenario 5 optional because it's being developed in another ticket and wasn't ready when opening this PR (it's a very small change in ia-ccd-definitions)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
