### PR TITLE
Ria 6148 detained appeal part 3

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -710,8 +710,8 @@ public enum AsylumCaseFieldDefinition {
     JOURNEY_TYPE(
         "journeyType", new TypeReference<JourneyType>(){}),
 
-    HEARING_TYPE(
-        "hearingType", new TypeReference<HearingType>(){}),
+    HEARING_TYPE_RESULT(
+        "hearingTypeResult", new TypeReference<HearingType>(){}),
 
     HEARING_DATE_RANGE_DESCRIPTION(
         "hearingDateRangeDescription", new TypeReference<String>() {}),
@@ -1508,6 +1508,12 @@ public enum AsylumCaseFieldDefinition {
 
     IS_APPEAL_REFERENCE_NUMBER_AVAILABLE(
         "isAppealReferenceNumberAvailable", new TypeReference<YesOrNo>(){}),
+
+    IS_ACCELERATED_DETAINED_IN_APPEAL(
+            "isAcceleratedDetainedAppeal", new TypeReference<String>(){}),
+
+    HEARING_TYPE(
+            "hearingType", new TypeReference<YesOrNo>(){}),
 
     SUBSCRIPTIONS(
         "subscriptions", new TypeReference<List<IdValue<Subscriber>>>(){}),

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1510,7 +1510,7 @@ public enum AsylumCaseFieldDefinition {
         "isAppealReferenceNumberAvailable", new TypeReference<YesOrNo>(){}),
 
     IS_ACCELERATED_DETAINED_APPEAL(
-            "isAcceleratedDetainedAppeal", new TypeReference<String>(){}),
+            "isAcceleratedDetainedAppeal", new TypeReference<YesOrNo>(){}),
 
     HEARING_TYPE(
             "hearingType", new TypeReference<YesOrNo>(){}),

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -39,9 +39,6 @@ public enum AsylumCaseFieldDefinition {
     HOME_OFFICE_DECISION_DATE(
         "homeOfficeDecisionDate", new TypeReference<String>(){}),
 
-    HOME_OFFICE_DECISION_DATE_ADA(
-            "homeOfficeDecisionDateADA", new TypeReference<String>(){}),
-
     APPELLANT_GIVEN_NAMES(
         "appellantGivenNames", new TypeReference<String>(){}),
 
@@ -1512,7 +1509,7 @@ public enum AsylumCaseFieldDefinition {
     IS_APPEAL_REFERENCE_NUMBER_AVAILABLE(
         "isAppealReferenceNumberAvailable", new TypeReference<YesOrNo>(){}),
 
-    IS_ACCELERATED_DETAINED_IN_APPEAL(
+    IS_ACCELERATED_DETAINED_APPEAL(
             "isAcceleratedDetainedAppeal", new TypeReference<String>(){}),
 
     HEARING_TYPE(

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1562,8 +1562,7 @@ public enum AsylumCaseFieldDefinition {
         "requestFeeRemissionFlagForServiceRequest", new TypeReference<YesOrNo>(){}),
     APPELLANT_IN_DETENTION(
         "appellantInDetention", new TypeReference<YesOrNo>(){}),
-    IS_ACCELERATED_DETAINED_APPEAL(
-        "isAcceleratedDetainedAppeal", new TypeReference<YesOrNo>(){}),
+
     DETENTION_STATUS(
         "detentionStatus", new TypeReference<String>(){}),
     ;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -39,6 +39,9 @@ public enum AsylumCaseFieldDefinition {
     HOME_OFFICE_DECISION_DATE(
         "homeOfficeDecisionDate", new TypeReference<String>(){}),
 
+    HOME_OFFICE_DECISION_DATE_ADA(
+            "homeOfficeDecisionDateADA", new TypeReference<String>(){}),
+
     APPELLANT_GIVEN_NAMES(
         "appellantGivenNames", new TypeReference<String>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealAfterSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealAfterSubmitHandler.java
@@ -75,7 +75,7 @@ public class EditAppealAfterSubmitHandler implements PreSubmitCallbackHandler<As
 
         Optional<OutOfCountryDecisionType> maybeOutOfCountryDecisionType = asylumCase.read(OUT_OF_COUNTRY_DECISION_TYPE, OutOfCountryDecisionType.class);
 
-        if (asylumCase.read(IS_ACCELERATED_DETAINED_IN_APPEAL, YesOrNo.class)
+        if (asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)
                 .orElse(NO) == NO) {
 
             if (maybeOutOfCountryDecisionType.isPresent()) {
@@ -106,6 +106,7 @@ public class EditAppealAfterSubmitHandler implements PreSubmitCallbackHandler<As
                                 .orElseThrow(() -> new RequiredFieldMissingException("homeOfficeDecisionDate is missing")));
             }
         } else {
+            //do nothing
 
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealAfterSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealAfterSubmitHandler.java
@@ -75,33 +75,40 @@ public class EditAppealAfterSubmitHandler implements PreSubmitCallbackHandler<As
 
         Optional<OutOfCountryDecisionType> maybeOutOfCountryDecisionType = asylumCase.read(OUT_OF_COUNTRY_DECISION_TYPE, OutOfCountryDecisionType.class);
 
-        if (maybeOutOfCountryDecisionType.isPresent()) {
-            OutOfCountryDecisionType decisionType = maybeOutOfCountryDecisionType.get();
+        if (asylumCase.read(IS_ACCELERATED_DETAINED_IN_APPEAL, YesOrNo.class)
+                .orElse(NO) == NO) {
 
-            if (decisionType == OutOfCountryDecisionType.REMOVAL_OF_CLIENT) {
-                Optional<String> maybeHomeOfficeDecisionLetterDate = asylumCase.read(DECISION_LETTER_RECEIVED_DATE);
+            if (maybeOutOfCountryDecisionType.isPresent()) {
+                OutOfCountryDecisionType decisionType = maybeOutOfCountryDecisionType.get();
 
+                if (decisionType == OutOfCountryDecisionType.REMOVAL_OF_CLIENT) {
+                    Optional<String> maybeHomeOfficeDecisionLetterDate = asylumCase.read(DECISION_LETTER_RECEIVED_DATE);
+
+                    decisionDate =
+                            parse(maybeHomeOfficeDecisionLetterDate
+                                    .orElseThrow(() -> new RequiredFieldMissingException("decisionLetterReceivedDate is not present")));
+                } else if (decisionType == OutOfCountryDecisionType.REFUSAL_OF_PROTECTION) {
+                    Optional<String> maybeDateClientLeaveUk = asylumCase.read(DATE_CLIENT_LEAVE_UK);
+
+                    decisionDate =
+                            parse(maybeDateClientLeaveUk
+                                    .orElseThrow(() -> new RequiredFieldMissingException("dateClientLeaveUk is not present")));
+                } else if (decisionType == OutOfCountryDecisionType.REFUSAL_OF_HUMAN_RIGHTS) {
+                    Optional<String> maybeDateEntryClearanceDecision = asylumCase.read(DATE_ENTRY_CLEARANCE_DECISION);
+
+                    decisionDate =
+                            parse(maybeDateEntryClearanceDecision
+                                    .orElseThrow(() -> new RequiredFieldMissingException("dateEntryClearanceDecision is not present")));
+                }
+            } else {
                 decisionDate =
-                    parse(maybeHomeOfficeDecisionLetterDate
-                        .orElseThrow(() -> new RequiredFieldMissingException("decisionLetterReceivedDate is not present")));
-            } else if (decisionType == OutOfCountryDecisionType.REFUSAL_OF_PROTECTION) {
-                Optional<String> maybeDateClientLeaveUk = asylumCase.read(DATE_CLIENT_LEAVE_UK);
-
-                decisionDate =
-                    parse(maybeDateClientLeaveUk
-                        .orElseThrow(() -> new RequiredFieldMissingException("dateClientLeaveUk is not present")));
-            } else if (decisionType == OutOfCountryDecisionType.REFUSAL_OF_HUMAN_RIGHTS) {
-                Optional<String> maybeDateEntryClearanceDecision = asylumCase.read(DATE_ENTRY_CLEARANCE_DECISION);
-
-                decisionDate =
-                    parse(maybeDateEntryClearanceDecision
-                        .orElseThrow(() -> new RequiredFieldMissingException("dateEntryClearanceDecision is not present")));
+                        parse(maybeHomeOfficeDecisionDate
+                                .orElseThrow(() -> new RequiredFieldMissingException("homeOfficeDecisionDate is missing")));
             }
         } else {
-            decisionDate =
-                parse(maybeHomeOfficeDecisionDate
-                    .orElseThrow(() -> new RequiredFieldMissingException("homeOfficeDecisionDate is missing")));
+
         }
+
 
 
         if (decisionDate != null

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
@@ -1,5 +1,10 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_TYPE_RESULT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
@@ -9,11 +14,6 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallb
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
-
-import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
 @Component
 public class HearingTypeHandler implements PreSubmitCallbackHandler<AsylumCase> {
@@ -44,7 +44,7 @@ public class HearingTypeHandler implements PreSubmitCallbackHandler<AsylumCase> 
 
         final String isAcceleratedDetainedAppeal =
                 asylumCase
-                        .read(IS_ACCELERATED_DETAINED_IN_APPEAL, String.class)
+                        .read(IS_ACCELERATED_DETAINED_APPEAL, String.class)
                         .orElse("");
 
         AppealType appealType = asylumCase.read(APPEAL_TYPE, AppealType.class)

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
@@ -50,24 +50,14 @@ public class HearingTypeHandler implements PreSubmitCallbackHandler<AsylumCase> 
         AppealType appealType = asylumCase.read(APPEAL_TYPE, AppealType.class)
             .orElse(null);
 
-        //AppealType.class
-
-        //Yes to show the screen
-
-        if(appealType!=null) {
-            if ((appealType.equals(Optional.of("Deprivation of citizenship"))
-                || appealType.getValue().equals(Optional.of("Revocation of a protection status")))
-                || isAcceleratedDetainedAppeal.equals("Yes")) {
-
+        if (appealType != null) {
+            if ((appealType == AppealType.DC || appealType == AppealType.RP)
+                    || isAcceleratedDetainedAppeal.equals("Yes")) {
                 asylumCase.write(HEARING_TYPE_RESULT, YesOrNo.YES);
-
             } else {
                 asylumCase.write(HEARING_TYPE_RESULT, YesOrNo.NO);
             }
         }
-
-
-
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_TYPE_RESULT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
@@ -42,18 +44,14 @@ public class HearingTypeHandler implements PreSubmitCallbackHandler<AsylumCase> 
                         .getCaseDetails()
                         .getCaseData();
 
-        final String isAcceleratedDetainedAppeal =
-                asylumCase
-                        .read(IS_ACCELERATED_DETAINED_APPEAL, String.class)
-                        .orElse("");
-
         AppealType appealType = asylumCase.read(APPEAL_TYPE, AppealType.class)
             .orElse(null);
 
         if (appealType != null) {
             if ((appealType == AppealType.DC || appealType == AppealType.RP)
-                    || isAcceleratedDetainedAppeal.equals("Yes")) {
-                asylumCase.write(HEARING_TYPE_RESULT, YesOrNo.YES);
+                    || asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)
+                .orElse(NO) == YES) {
+                asylumCase.write(HEARING_TYPE_RESULT, YES);
             } else {
                 asylumCase.write(HEARING_TYPE_RESULT, YesOrNo.NO);
             }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+@Component
+public class HearingTypeHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.MID_EVENT
+                && callback.getEvent() == Event.START_APPEAL;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase =
+                callback
+                        .getCaseDetails()
+                        .getCaseData();
+
+        final String isAcceleratedDetainedAppeal =
+                asylumCase
+                        .read(IS_ACCELERATED_DETAINED_IN_APPEAL, String.class)
+                        .orElse("");
+
+        AppealType appealType = asylumCase.read(APPEAL_TYPE, AppealType.class)
+                .orElseThrow(() -> new IllegalStateException("Appeal type is not present"));
+
+        //AppealType.class
+
+        //Yes to show the screen
+
+        if ((appealType.equals(Optional.of("Deprivation of citizenship"))
+                || appealType.getValue().equals(Optional.of("Revocation of a protection status")))
+                || isAcceleratedDetainedAppeal.equals("Yes")) {
+
+            asylumCase.write(HEARING_TYPE_RESULT, YesOrNo.YES);
+
+        } else {
+            asylumCase.write(HEARING_TYPE_RESULT, YesOrNo.NO);
+        }
+
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
@@ -48,21 +48,25 @@ public class HearingTypeHandler implements PreSubmitCallbackHandler<AsylumCase> 
                         .orElse("");
 
         AppealType appealType = asylumCase.read(APPEAL_TYPE, AppealType.class)
-                .orElseThrow(() -> new IllegalStateException("Appeal type is not present"));
+            .orElse(null);
 
         //AppealType.class
 
         //Yes to show the screen
 
-        if ((appealType.equals(Optional.of("Deprivation of citizenship"))
+        if(appealType!=null) {
+            if ((appealType.equals(Optional.of("Deprivation of citizenship"))
                 || appealType.getValue().equals(Optional.of("Revocation of a protection status")))
                 || isAcceleratedDetainedAppeal.equals("Yes")) {
 
-            asylumCase.write(HEARING_TYPE_RESULT, YesOrNo.YES);
+                asylumCase.write(HEARING_TYPE_RESULT, YesOrNo.YES);
 
-        } else {
-            asylumCase.write(HEARING_TYPE_RESULT, YesOrNo.NO);
+            } else {
+                asylumCase.write(HEARING_TYPE_RESULT, YesOrNo.NO);
+            }
         }
+
+
 
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandlerTest.java
@@ -1,0 +1,98 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class HearingTypeHandlerTest {
+
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+
+    private final String isAcc = "Yes";
+
+    private HearingTypeHandler hearingTypeHandler;
+
+    @BeforeEach
+    public void setUp() {
+        hearingTypeHandler = new HearingTypeHandler();
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, String.class)).thenReturn(Optional.of(isAcc));
+
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> hearingTypeHandler.handle(ABOUT_TO_SUBMIT, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> hearingTypeHandler.handle(ABOUT_TO_START, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = hearingTypeHandler.canHandle(callbackStage, callback);
+
+                if (callbackStage == PreSubmitCallbackStage.MID_EVENT && event.equals(Event.START_APPEAL)) {
+
+                    assertThat(canHandle).isEqualTo(true);
+                } else {
+                    assertThat(canHandle).isEqualTo(false);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> hearingTypeHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> hearingTypeHandler.canHandle(PreSubmitCallbackStage.MID_EVENT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+    }
+
+}


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-6418

Change description
This story cover the scenario where a LR appeals for a client who is in detention.

Existing screens to be removed if detained

Your client's address
The appellant's contact preference
New screens if detained

Is your client in detention?
Where is your client detained?
In which IRC is your client detained? (needs lookup functionality)
In which prison is your client detained? (needs lookup functionality)
Is your client still serving their custodial sentence?
Does your client have a pending bail application?
Is this an ADA?
Removal directions
Existing screens with changes if detained

Home Office details (only changes if ADA)
Change question about letter to: What date was the Home Office decision letter received?
Change label to: Date letter received
Remove envelope graphic
Overview tab
If appellant is detained, on overview tab add new row under Case details called Detention status. If ADA it should say Detained - Accelerated. If non-ADA it should say Detained

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[ x] No