### PR TITLE
RIA-6450: Address 500 Errors - Exceptions related to large SMS text

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -78,4 +78,17 @@
         <cve>CVE-2022-42003</cve>
         <cve>CVE-2022-42004</cve>
     </suppress>
+    <suppress>
+        <notes>Temporarily suppress snakeyaml vulnerabilities</notes>
+        <cve>CVE-2022-41854</cve>
+    </suppress>
+    <suppress>
+        <notes>Temporarily suppress Spring Security related vulnerabilities</notes>
+        <cve>CVE-2022-31690</cve>
+        <cve>CVE-2022-31692</cve>
+    </suppress>
+    <suppress>
+        <notes>Temporarily suppress Apache Tomcat related vulnerabilities</notes>
+        <cve>CVE-2022-42252</cve>
+    </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1554,6 +1554,8 @@ public enum AsylumCaseFieldDefinition {
     REQUEST_FEE_REMISSION_FLAG_FOR_SERVICE_REQUEST(
 
         "requestFeeRemissionFlagForServiceRequest", new TypeReference<YesOrNo>(){}),
+    REMOVE_APPEAL_FROM_ONLINE_REASON(
+        "removeAppealFromOnlineReason", new TypeReference<String>(){})
     ;
 
     private final String value;


### PR DESCRIPTION
- Related to the event 'removeAppealFromOnline' for appellant in person
- when sms is selected as preferred contact channel.
- Return a meaningful error message when an attempt is made to
- send an SMS larger than is supported by gov.notify

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6450


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
