### PR TITLE
RIA-6441: Stop 'start_appeal' mid_event to go in 'EditAppealAfterSubm…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealAfterSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealAfterSubmitHandler.java
@@ -64,8 +64,8 @@ public class EditAppealAfterSubmitHandler implements PreSubmitCallbackHandler<As
         requireNonNull(callback, "callback must not be null");
 
         return (callbackStage == PreSubmitCallbackStage.MID_EVENT
-            || callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-            && callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT)
+            || callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT)
+            && callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT
             && callback.getPageId().equals(HOME_OFFICE_DECISION_PAGE_ID);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealAfterSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealAfterSubmitHandlerTest.java
@@ -437,8 +437,8 @@ class EditAppealAfterSubmitHandlerTest {
 
                 boolean canHandle = editAppealAfterSubmitHandler.canHandle(callbackStage, callback);
 
-                if ((event == Event.EDIT_APPEAL_AFTER_SUBMIT
-                    && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                if (event == Event.EDIT_APPEAL_AFTER_SUBMIT
+                    && (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                     || callbackStage == PreSubmitCallbackStage.MID_EVENT)
                     && callback.getPageId().equals(HOME_OFFICE_DECISION_PAGE_ID)) {
 


### PR DESCRIPTION
…it' handler
