### PR TITLE
RIA-6526 Set flags for listCase for accelerated detained appeals

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6526-list-case-ada-start.json
+++ b/src/functionalTest/resources/scenarios/RIA-6526-list-case-ada-start.json
@@ -1,0 +1,106 @@
+{
+  "description": "RIA-6526 List accelerated detained appeal case from awaitingRespondentEvidence state",
+  "launchDarklyKey": "reheard-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 3683,
+      "eventId": "listCase",
+      "state": "awaitingRespondentEvidence",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isAcceleratedDetainedAppeal": "Yes",
+          "listingAvailableForAda": "Yes",
+          "isReheardAppealEnabled": "Yes",
+          "currentHearingDetailsVisible": "No",
+          "ariaListingReference": "LP/12345/2019",
+          "hearingCentre": "manchester",
+          "listCaseHearingCentre": "manchester",
+          "listCaseHearingLength": "300",
+          "listCaseHearingDate": "2020-10-28T10:30:00.000",
+          "listCaseRequirementsVulnerabilities": "some vulnerabilities",
+          "listCaseRequirementsMultimedia": "some multimedia",
+          "listCaseRequirementsSingleSexCourt": "some single-sex court",
+          "listCaseRequirementsInCameraCourt": "some in-camera court",
+          "listCaseRequirementsOther": "some other requirements",
+          "reviewedUpdatedHearingRequirements": "Yes",
+          "doesTheCaseNeedToBeRelisted": "Yes",
+          "haveHearingAttendeesAndDurationBeenRecorded": "Yes",
+          "attendingTcw": "some TCW",
+          "attendingJudge": "some Judge",
+          "attendingAppellant": "some Appellant",
+          "attendingHomeOfficeLegalRepresentative": "some HO",
+          "attendingAppellantsLegalRepresentative": "some legal rep",
+          "actualCaseHearingLength": {
+            "hours": "2",
+            "minutes": "30"
+          },
+          "hearingConductionOptions": "allParticipants",
+          "hearingRecordingDocuments": [
+            {
+              "id": "cbe101ff-7f87-423e-93cd-f731adf7d979",
+              "value": {
+                "document": {
+                  "document_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6",
+                  "document_filename": "HearingRecording.mp3",
+                  "document_binary_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6/binary"
+                },
+                "description": "some description"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "isAcceleratedDetainedAppeal": "Yes",
+        "isReheardAppealEnabled": "Yes",
+        "currentHearingDetailsVisible": "No",
+        "ariaListingReference": "LP/12345/2019",
+        "hearingCentre": "manchester",
+        "listCaseHearingCentre": "manchester",
+        "listCaseHearingLength": "300",
+        "listCaseHearingDate": "2020-10-28T10:30:00.000",
+        "listCaseRequirementsVulnerabilities": "some vulnerabilities",
+        "listCaseRequirementsMultimedia": "some multimedia",
+        "listCaseRequirementsSingleSexCourt": "some single-sex court",
+        "listCaseRequirementsInCameraCourt": "some in-camera court",
+        "listCaseRequirementsOther": "some other requirements",
+        "reviewedUpdatedHearingRequirements": "Yes",
+        "doesTheCaseNeedToBeRelisted": "Yes",
+        "haveHearingAttendeesAndDurationBeenRecorded": "Yes",
+        "attendingTcw": "some TCW",
+        "attendingJudge": "some Judge",
+        "attendingAppellant": "some Appellant",
+        "attendingHomeOfficeLegalRepresentative": "some HO",
+        "attendingAppellantsLegalRepresentative": "some legal rep",
+        "actualCaseHearingLength": {
+          "hours": "2",
+          "minutes": "30"
+        },
+        "hearingConductionOptions": "allParticipants",
+        "hearingRecordingDocuments": [
+          {
+            "id": "cbe101ff-7f87-423e-93cd-f731adf7d979",
+            "value": {
+              "document": {
+                "document_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6",
+                "document_filename": "HearingRecording.mp3",
+                "document_binary_url": "http://dm-store:4506/documents/9f57720d-5a80-43b7-8896-359f7788a1d6/binary"
+              },
+              "description": "some description"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6526-request-respondent-evidence-ada-start.json
+++ b/src/functionalTest/resources/scenarios/RIA-6526-request-respondent-evidence-ada-start.json
@@ -1,0 +1,64 @@
+{
+  "description": "RIA-6526 request respondent evidence for accelerated detained appeal (flag setting)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "requestRespondentEvidence",
+      "state": "awaitingRespondentEvidence",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isAcceleratedDetainedAppeal": "Yes",
+          "homeOfficeSearchStatus": "SUCCESS",
+          "sendDirectionExplanation": "Send your evidence",
+          "sendDirectionDateDue": "2022-01-01",
+          "directions": [
+            {
+              "id": "1",
+              "value": {
+                "explanation": "Do the first thing",
+                "parties": "legalRepresentative",
+                "dateDue": "2018-12-31",
+                "dateSent": "2018-12-25",
+                "tag": ""
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "listingAvailableForAda": "Yes",
+        "directions": [
+          {
+            "id": "2",
+            "value": {
+              "explanation": "Send your evidence",
+              "parties": "respondent",
+              "dateDue": "2022-01-01",
+              "dateSent": "{$TODAY}",
+              "tag": "respondentEvidence"
+            }
+          },
+          {
+            "id": "1",
+            "value": {
+              "explanation": "Do the first thing",
+              "parties": "legalRepresentative",
+              "dateDue": "2018-12-31",
+              "dateSent": "2018-12-25",
+              "tag": ""
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1630,7 +1630,13 @@ public enum AsylumCaseFieldDefinition {
         "removalOrderDate", new TypeReference<String>(){}),
     
     APPELLANT_PIN_IN_POST(
-        "appellantPinInPost", new TypeReference<PinInPostDetails>(){});
+        "appellantPinInPost", new TypeReference<PinInPostDetails>(){}),
+
+    LISTING_AVAILABLE_FOR_ADA(
+        "listingAvailableForAda", new TypeReference<YesOrNo>(){}),
+
+    CALCULATED_HEARING_DATE(
+        "calculatedHearingDate", new TypeReference<String>(){});
 
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
@@ -88,6 +88,10 @@ public class ListEditCaseHandler implements PreSubmitCallbackHandler<AsylumCase>
         asylumCase.clear(REHEARD_CASE_LISTED_WITHOUT_HEARING_REQUIREMENTS);
         addBaseLocationAndStaffLocationFromHearingCentre(asylumCase);
 
+        // reset flag that makes ListCase available for accelerated detained appeals in
+        // awaitingRespondentEvidence
+        asylumCase.clear(LISTING_AVAILABLE_FOR_ADA);
+
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
@@ -88,9 +88,16 @@ public class ListEditCaseHandler implements PreSubmitCallbackHandler<AsylumCase>
         asylumCase.clear(REHEARD_CASE_LISTED_WITHOUT_HEARING_REQUIREMENTS);
         addBaseLocationAndStaffLocationFromHearingCentre(asylumCase);
 
-        // reset flag that makes ListCase available for accelerated detained appeals in
-        // awaitingRespondentEvidence
-        asylumCase.clear(LISTING_AVAILABLE_FOR_ADA);
+        boolean isAcceleratedDetainedAppeal = asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)
+            .orElse(YesOrNo.NO)
+            .equals(YesOrNo.YES);
+
+        if (isAcceleratedDetainedAppeal) {
+            // reset flag that makes ListCase available for accelerated detained appeals in
+            // awaitingRespondentEvidence
+            asylumCase.write(LISTING_AVAILABLE_FOR_ADA, YesOrNo.NO);
+        }
+
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestRespondentEvidenceHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestRespondentEvidenceHandler.java
@@ -1,8 +1,14 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CALCULATED_HEARING_DATE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LISTING_AVAILABLE_FOR_ADA;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.UPLOAD_HOME_OFFICE_BUNDLE_AVAILABLE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.*;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
@@ -11,9 +17,16 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallb
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.DueDateService;
 
 @Component
 public class RequestRespondentEvidenceHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private DueDateService dueDateService;
+
+    public RequestRespondentEvidenceHandler(DueDateService dueDateService) {
+        this.dueDateService = dueDateService;
+    }
 
     public boolean canHandle(
         PreSubmitCallbackStage callbackStage,
@@ -40,8 +53,25 @@ public class RequestRespondentEvidenceHandler implements PreSubmitCallbackHandle
                 .getCaseData();
 
         // Set a new flag here to be used for validation in the preparer.
-        asylumCase.write(UPLOAD_HOME_OFFICE_BUNDLE_AVAILABLE, YesOrNo.YES);
+        asylumCase.write(UPLOAD_HOME_OFFICE_BUNDLE_AVAILABLE, YES);
+
+        if (isAcceleratedDetainedAppeal(asylumCase)) {
+            // Set flag used to allow ListCase to be visible in awaitingRespondentEvidence state when
+            // case is accelerated detained appeal
+            asylumCase.write(LISTING_AVAILABLE_FOR_ADA, YES);
+
+            // Calculate date to display on Overview tab
+            String calculatedListedHearingDate = dueDateService.calculateDueDate(ZonedDateTime.now(), 22)
+                .format(DateTimeFormatter.ofPattern("d MMMM yyyy"));
+            asylumCase.write(CALCULATED_HEARING_DATE, calculatedListedHearingDate);
+        }
 
         return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    private boolean isAcceleratedDetainedAppeal(AsylumCase asylumCase) {
+        return asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)
+            .orElse(NO)
+            .equals(YES);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandlerTest.java
@@ -20,6 +20,8 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_CENTRE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_CONDUCTION_OPTIONS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_RECORDING_DOCUMENTS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LISTING_AVAILABLE_FOR_ADA;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_CENTRE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REHEARD_CASE_LISTED_WITHOUT_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REVIEWED_UPDATED_HEARING_REQUIREMENTS;
@@ -94,6 +96,19 @@ class ListEditCaseHandlerTest {
         verify(asylumCase, times(1)).clear(HEARING_CONDUCTION_OPTIONS);
         verify(asylumCase, times(1)).clear(HEARING_RECORDING_DOCUMENTS);
         verify(asylumCase, times(1)).clear(REHEARD_CASE_LISTED_WITHOUT_HEARING_REQUIREMENTS);
+    }
+
+    @Test
+    void should_set_listCase_availability_to_no_if_case_accelerated() {
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            listEditCaseHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).write(LISTING_AVAILABLE_FOR_ADA, YesOrNo.NO);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestRespondentEvidenceHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestRespondentEvidenceHandlerTest.java
@@ -3,12 +3,21 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CALCULATED_HEARING_DATE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LISTING_AVAILABLE_FOR_ADA;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.UPLOAD_HOME_OFFICE_BUNDLE_AVAILABLE;
 
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,11 +29,19 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.DueDateService;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.holidaydates.HolidayService;
 
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
 class RequestRespondentEvidenceHandlerTest {
+
+    private static final List<LocalDate> HOLIDAYS = List.of(
+        LocalDate.of(2022, Month.DECEMBER, 25),
+        LocalDate.of(2022, Month.JANUARY, 1),
+        LocalDate.of(2022, Month.APRIL, 15)
+    );
 
     @Mock
     private Callback<AsylumCase> callback;
@@ -33,23 +50,44 @@ class RequestRespondentEvidenceHandlerTest {
     @Mock
     private AsylumCase asylumCase;
 
+    private HolidayService holidayService;
+    private DueDateService dueDateService;
+
     private RequestRespondentEvidenceHandler requestRespondentEvidenceHandler;
 
     @BeforeEach
     public void setUp() {
+        holidayService = new HolidayService(HOLIDAYS);
+        dueDateService = new DueDateService(holidayService);
         requestRespondentEvidenceHandler =
-            new RequestRespondentEvidenceHandler();
+            new RequestRespondentEvidenceHandler(dueDateService);
     }
 
     @Test
-    void should_set_the_flag_on_valid_case_data() {
+    void should_set_the_bundle_flag_on_valid_case_data() {
 
         when(callback.getEvent()).thenReturn(Event.REQUEST_RESPONDENT_EVIDENCE);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.empty());
 
         requestRespondentEvidenceHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
         verify(asylumCase).write(UPLOAD_HOME_OFFICE_BUNDLE_AVAILABLE, YesOrNo.YES);
+    }
+
+    @Test
+    void should_write_necessary_fields_for_accelerated_detained_appeals() {
+        // Testing limited by ZonedDateTime being a final class: it can't be involved in mocking/spying
+
+        when(callback.getEvent()).thenReturn(Event.REQUEST_RESPONDENT_EVIDENCE);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        requestRespondentEvidenceHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+        verify(asylumCase).write(LISTING_AVAILABLE_FOR_ADA, YesOrNo.YES);
+
+        verify(asylumCase).write(eq(CALCULATED_HEARING_DATE), anyString());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6526](https://tools.hmcts.net/jira/browse/RIA-6526)


### Change description ###
- Added `CALCULATED_HEARING_DATE` flag and calculations to elaborate it
- Added `LISTING_AVAILABLE_FOR_ADA` flag that ccd will need to use to display the listCase event in `awaitingRespondentEvidence` (set in the event that results in that state, i.e. `REQUEST_RESPONDENT_EVIDENCE`)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
