### PR TITLE
RIA-6547: Enabled the functional tests

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-3680-home-office-reference-mid-event.json
+++ b/src/functionalTest/resources/scenarios/RIA-3680-home-office-reference-mid-event.json
@@ -1,8 +1,7 @@
 {
-  "description": "RIA-3680 Home Office Reference Number Mid-Event - wrong home-office reference number for startAppeal event - disabled",
-  "disabled": "true",
+  "description": "RIA-3680 Home Office Reference Number Mid-Event - wrong home-office reference number for startAppeal event",
   "request": {
-    "uri": "/asylum/ccdMidEvent",
+    "uri": "/asylum/ccdMidEvent?pageId=homeOfficeDecision",
     "credentials": "LegalRepresentativeOrgSuccess",
     "input": {
       "eventId": "startAppeal",
@@ -23,7 +22,6 @@
     "caseData": {
       "template": "minimal-appeal-started.json",
       "replacements": {
-        "submissionOutOfTime": "No",
         "homeOfficeDecisionDate": "{$TODAY-14}",
         "appealReferenceNumber": "DRAFT",
         "homeOfficeReferenceNumber": "1234-422321-5678-87562AC"

--- a/src/functionalTest/resources/scenarios/RIA-3680-home-office-reference-mid-event_edit_appeal.json
+++ b/src/functionalTest/resources/scenarios/RIA-3680-home-office-reference-mid-event_edit_appeal.json
@@ -1,8 +1,7 @@
 {
-  "description": "RIA-3680 Home Office Reference Number Mid-Event - wrong home-office reference number for editAppeal event - disabled",
-  "disabled": "true",
+  "description": "RIA-3680 Home Office Reference Number Mid-Event - wrong home-office reference number for editAppeal event",
   "request": {
-    "uri": "/asylum/ccdMidEvent",
+    "uri": "/asylum/ccdMidEvent?pageId=homeOfficeDecision",
     "credentials": "LegalRepresentative",
     "input": {
       "eventId": "editAppeal",
@@ -22,7 +21,6 @@
     "caseData": {
       "template": "minimal-appeal-started.json",
       "replacements": {
-        "submissionOutOfTime": "No",
         "homeOfficeDecisionDate": "{$TODAY-14}",
         "appealReferenceNumber": "DRAFT",
         "homeOfficeReferenceNumber": "A123456789"

--- a/src/functionalTest/resources/scenarios/RIA-515-lodge-appeal-confirmation.json
+++ b/src/functionalTest/resources/scenarios/RIA-515-lodge-appeal-confirmation.json
@@ -1,6 +1,6 @@
 {
   "description": "RIA-515 Lodge appeal confirmation - disable",
-  "disabled": "true",
+  "launchDarklyKey": "wa-R3-feature:false",
   "request": {
     "uri": "/asylum/ccdSubmitted",
     "credentials": "LegalRepresentative",


### PR DESCRIPTION
- RIA-515* failed after WA R2 merge; added a LD flag to exclude WA R3 feature while running this test.
- RIA-3680* - failed due to change in EditAppealAfterSubmit handler. It was changed to be triggered only at MidEvent with pageId & about_to_submit in Edit_Appeal_After_Submit. It no longer sets the field Submission_out_of_time as Yes/No at Start/Edit Appeal. This scenario is already covered in RIA-369.

