### PR TITLE
RIA-6528 Hearing&Appointment tab for ADA

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -803,6 +803,9 @@ public enum AsylumCaseFieldDefinition {
     SUBMIT_HEARING_REQUIREMENTS_AVAILABLE(
         "submitHearingRequirementsAvailable", new TypeReference<YesOrNo>() {}),
 
+    ACCELERATED_DETAINED_APPEAL_LISTED(
+        "acceleratedDetainedAppealListed", new TypeReference<YesOrNo>() {}),
+
     AUTOMATIC_DIRECTION_REQUESTING_HEARING_REQUIREMENTS(
         "automaticDirectionRequestingHearingRequirements", new TypeReference<String>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
@@ -93,6 +93,8 @@ public class ListEditCaseHandler implements PreSubmitCallbackHandler<AsylumCase>
             .equals(YesOrNo.YES);
 
         if (isAcceleratedDetainedAppeal) {
+            asylumCase.write(ACCELERATED_DETAINED_APPEAL_LISTED, YesOrNo.YES);
+
             // reset flag that makes ListCase available for accelerated detained appeals in
             // awaitingRespondentEvidence
             asylumCase.write(LISTING_AVAILABLE_FOR_ADA, YesOrNo.NO);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandlerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ACCELERATED_DETAINED_APPEAL_LISTED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ACTUAL_CASE_HEARING_LENGTH;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ATTENDING_APPELLANT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ATTENDING_APPELLANTS_LEGAL_REPRESENTATIVE;
@@ -108,6 +109,7 @@ class ListEditCaseHandlerTest {
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
 
+        verify(asylumCase, times(1)).write(ACCELERATED_DETAINED_APPEAL_LISTED, YesOrNo.YES);
         verify(asylumCase, times(1)).write(LISTING_AVAILABLE_FOR_ADA, YesOrNo.NO);
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6528](https://tools.hmcts.net/jira/browse/RIA-6528)


### Change description ###
- Set new flag ACCELERATED_DETAINED_APPEAL_LISTED to Yes when an ADA case gets listed. The flag is then used in CCD to show the Hearing & Appointment tab on the UI. Another flag was normally used (SUBMIT_HEARING_REQUIREMENTS_AVAILABLE) but this is also used for other things, so it may unlock stuff that shouldn't be unlocked at this stage for an ADA case


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
