### PR TITLE
RIA-6437: Save & submit Age Assessment appeal - part 3

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6437-add-stateless-age-assessment-start-appeal.json
+++ b/src/functionalTest/resources/scenarios/RIA-6437-add-stateless-age-assessment-start-appeal.json
@@ -1,0 +1,36 @@
+{
+  "description": "RIA-6437-add-stateless-age-assessment-start-appeal",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentativeOrgSuccess",
+    "input": {
+      "eventId": "startAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "legalRepresentativeEmailAddress": "{TEST_LAW_FIRM_ORG_SUCCESS_USERNAME}",
+        "template": "minimal-age-assessment-appeal-started.json",
+        "replacements": {
+          "appellantStateless": "isStateless"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-age-assessment-appeal-started.json",
+      "replacements": {
+        "appealType": "ageAssessment",
+        "appellantNationalities": [
+          {
+            "id" : "1",
+            "value": {
+              "code": "ZZ"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6437-add-stateless-age-assessment-submit-appeal-in-time.json
+++ b/src/functionalTest/resources/scenarios/RIA-6437-add-stateless-age-assessment-submit-appeal-in-time.json
@@ -1,0 +1,32 @@
+{
+  "description": "RIA-6437-add-stateless-age-assessment-submit-appeal-in-time",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "LegalRepresentativeOrgSuccess",
+    "input": {
+      "eventId": "submitAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "legalRepresentativeEmailAddress": "{TEST_LAW_FIRM_ORG_SUCCESS_USERNAME}",
+        "template": "minimal-age-assessment-appeal-started.json",
+        "replacements": {
+          "appellantInUk": "Yes",
+          "ageAssessment": "Yes",
+          "dateOnDecisionLetter": "{$TODAY-14}"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-age-assessment-appeal-started.json",
+      "replacements": {
+        "appealType": "ageAssessment",
+        "submissionOutOfTime": "No",
+        "dateOnDecisionLetter": "{$TODAY-14}"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/templates/minimal-age-assessment-appeal-started.json
+++ b/src/functionalTest/resources/templates/minimal-age-assessment-appeal-started.json
@@ -1,0 +1,24 @@
+{
+  "homeOfficeReferenceNumber": "123456789",
+  "homeOfficeDecisionDate": "{$TODAY}",
+  "appellantTitle": "Mr",
+  "appellantGivenNames": "Talha",
+  "appellantFamilyName": "Awan",
+  "aaAppellantDateOfBirth": "{$TODAY-7300}",
+  "appellantNationalities": [
+    {
+      "id": "1",
+      "value": {
+        "code": "IS"
+      }
+    }
+  ],
+  "aaAppellantHasFixedAddress": "No",
+  "aaContactPreference": "wantsSms",
+  "wantsSms": "Text message",
+  "aaMobileNumber": "07977111111",
+  "appealType": "ageAssessment",
+  "appealReferenceNumber": "DRAFT",
+  "isOutOfCountryEnabled": "Yes",
+  "appellantInUk": "Yes"
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtils.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers;
 
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PREV_JOURNEY_TYPE;
 
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 
@@ -31,5 +33,9 @@ public class HandlerUtils {
     public static boolean isAipToRepJourney(AsylumCase asylumCase) {
         return (asylumCase.read(PREV_JOURNEY_TYPE, JourneyType.class).orElse(null) == JourneyType.AIP)
             && isRepJourney(asylumCase);
+    }
+
+    public static boolean isAgeAssessmentAppeal(AsylumCase asylumCase) {
+        return (asylumCase.read(APPEAL_TYPE, AppealType.class)).orElse(null) == AppealType.AG;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
@@ -56,7 +57,8 @@ public class HearingTypeHandler implements PreSubmitCallbackHandler<AsylumCase> 
         if (callback.getEvent() == Event.EDIT_APPEAL && appealType != null) {
             if ((appealType == AppealType.DC || appealType == AppealType.RP)
                     || asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)
-                .orElse(NO) == YES) {
+                .orElse(NO) == YES
+                || HandlerUtils.isAgeAssessmentAppeal(asylumCase)) {
                 asylumCase.write(HEARING_TYPE_RESULT, YES);
             } else {
                 asylumCase.write(HEARING_TYPE_RESULT, YesOrNo.NO);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AGE_ASSESSMENT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE_FOR_DISPLAY;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_TYPE_RESULT;
@@ -8,6 +9,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealTypeForDisplay;
@@ -65,10 +67,16 @@ public class HearingTypeHandler implements PreSubmitCallbackHandler<AsylumCase> 
             }
         }
 
-        if (callback.getEvent() == Event.START_APPEAL && appealTypeForDisplay != null) {
-            if ((appealTypeForDisplay == AppealTypeForDisplay.DC || appealTypeForDisplay == AppealTypeForDisplay.RP)
-                    || asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)
-                    .orElse(NO) == YES) {
+        //if RP or DC or ADA
+        boolean isRpDcAda = appealTypeForDisplay != null
+            && (appealTypeForDisplay == AppealTypeForDisplay.DC || appealTypeForDisplay == AppealTypeForDisplay.RP
+            || asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class).orElse(NO) == YES);
+
+        //if ageAssessment
+        boolean isAgeAssessment = appealTypeForDisplay == null && (asylumCase.read(AGE_ASSESSMENT, YesOrNo.class).equals(Optional.of(YES)));
+
+        if (callback.getEvent() == Event.START_APPEAL) {
+            if (isRpDcAda || isAgeAssessment) {
                 asylumCase.write(HEARING_TYPE_RESULT, YES);
             } else {
                 asylumCase.write(HEARING_TYPE_RESULT, YesOrNo.NO);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeReferenceNumberTruncator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeReferenceNumberTruncator.java
@@ -56,7 +56,8 @@ public class HomeOfficeReferenceNumberTruncator implements PreSubmitCallbackHand
             Optional<String> maybeHomeOfficeReferenceNumber =
                 asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER);
 
-            if (maybeHomeOfficeReferenceNumber.isEmpty() && HandlerUtils.isAipJourney(asylumCase)) {
+            if ((maybeHomeOfficeReferenceNumber.isEmpty() && HandlerUtils.isAipJourney(asylumCase))
+                || HandlerUtils.isAgeAssessmentAppeal(asylumCase)) {
                 return new PreSubmitCallbackResponse<>(asylumCase);
             }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/LetterSentOrReceivedHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/LetterSentOrReceivedHandler.java
@@ -56,16 +56,19 @@ public class LetterSentOrReceivedHandler implements PreSubmitCallbackHandler<Asy
                 .read(APPELLANT_IN_UK, YesOrNo.class)
                 .orElseThrow(() -> new IllegalArgumentException("appellantInUk is missing"));
 
+        Optional<YesOrNo> isAgeAssessmentAppeal = asylumCase.read(AGE_ASSESSMENT, YesOrNo.class);
         Optional<YesOrNo> isAcceleratedDetainedAppeal = asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class);
         Optional<YesOrNo> appellantInDetention = asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class);
-
-        if ((isOutOfCountryEnabled.equals(YES) && appellantInUk.equals(NO))
+        if (isAgeAssessmentAppeal.equals(Optional.of(NO))) {
+            // Set the values only for non age assessment appeals. For age assessment, we have separate field - DATE_ON_DECISION_LETTER
+            if ((isOutOfCountryEnabled.equals(YES) && appellantInUk.equals(NO))
                 || isAcceleratedDetainedAppeal.equals(Optional.of(YesOrNo.YES))) {
-            asylumCase.write(LETTER_SENT_OR_RECEIVED, "Received");
-        } else if ((appellantInUk.equals(YES) && appellantInDetention.equals(Optional.of(YesOrNo.NO)))
+                asylumCase.write(LETTER_SENT_OR_RECEIVED, "Received");
+            } else if ((appellantInUk.equals(YES) && appellantInDetention.equals(Optional.of(YesOrNo.NO)))
                 || (appellantInUk.equals(YES) && appellantInDetention.equals(Optional.of(YesOrNo.YES))
                 && isAcceleratedDetainedAppeal.equals(Optional.of(NO)))) {
-            asylumCase.write(LETTER_SENT_OR_RECEIVED, "Sent");
+                asylumCase.write(LETTER_SENT_OR_RECEIVED, "Sent");
+            }
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtilsTest.java
@@ -2,14 +2,19 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,5 +51,20 @@ class HandlerUtilsTest {
     void given_rep_journey_aip_test_should_fail() {
         when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.of(JourneyType.REP));
         assertFalse(HandlerUtils.isAipJourney(asylumCase));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AppealType.class, names = {
+        "RP", "PA", "EA", "HU", "DC"
+    })
+    void given_non_aaa_test_should_fail(AppealType appealType) {
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(appealType));
+        assertFalse(HandlerUtils.isAgeAssessmentAppeal(asylumCase));
+    }
+
+    @Test
+    void given_aaa_test_should_pass() {
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.AG));
+        assertTrue(HandlerUtils.isAgeAssessmentAppeal(asylumCase));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtilsTest.java
@@ -14,7 +14,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandlerTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AGE_ASSESSMENT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE_FOR_DISPLAY;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_TYPE_RESULT;
@@ -84,7 +85,7 @@ class HearingTypeHandlerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"PA", "EA", "HU", "AG"})
+    @ValueSource(strings = {"PA", "EA", "HU"})
     void should_write_to_hearing_type_result_no_for_edit_appeal_event(String type) {
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
@@ -179,8 +180,19 @@ class HearingTypeHandlerTest {
     }
 
     @Test
-    void should_set_hearing_type_for_age_assessment_appeal() {
+    void should_set_hearing_type_for_age_assessment_start_appeal() {
+        when(asylumCase.read(AGE_ASSESSMENT, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        hearingTypeHandler.handle(MID_EVENT, callback);
+
+        verify(asylumCase, times(1)).write(asylumExtractor.capture(), hearingTypeResult.capture());
+        assertThat(asylumExtractor.getValue()).isEqualTo(HEARING_TYPE_RESULT);
+        assertThat(hearingTypeResult.getValue()).isEqualTo(YesOrNo.YES);
+    }
+
+    @Test
+    void should_set_hearing_type_for_age_assessment_edit_appeal() {
         when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.AG));
+        when(callback.getEvent()).thenReturn(Event.EDIT_APPEAL);
         hearingTypeHandler.handle(MID_EVENT, callback);
 
         verify(asylumCase, times(1)).write(asylumExtractor.capture(), hearingTypeResult.capture());

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandlerTest.java
@@ -2,11 +2,18 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE_FOR_DISPLAY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_TYPE_RESULT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
 
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -36,6 +45,12 @@ class HearingTypeHandlerTest {
     @Mock private Callback<AsylumCase> callback;
     @Mock private CaseDetails<AsylumCase> caseDetails;
     @Mock private AsylumCase asylumCase;
+
+    @Captor
+    private ArgumentCaptor<YesOrNo> hearingTypeResult;
+
+    @Captor
+    private ArgumentCaptor<AsylumCaseFieldDefinition> asylumExtractor;
 
     private final String isAcc = "Yes";
 
@@ -161,6 +176,16 @@ class HearingTypeHandlerTest {
             .hasMessage("callback must not be null")
             .isExactlyInstanceOf(NullPointerException.class);
 
+    }
+
+    @Test
+    void should_set_hearing_type_for_age_assessment_appeal() {
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.AG));
+        hearingTypeHandler.handle(MID_EVENT, callback);
+
+        verify(asylumCase, times(1)).write(asylumExtractor.capture(), hearingTypeResult.capture());
+        assertThat(asylumExtractor.getValue()).isEqualTo(HEARING_TYPE_RESULT);
+        assertThat(hearingTypeResult.getValue()).isEqualTo(YesOrNo.YES);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeReferenceNumberTruncatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeReferenceNumberTruncatorTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.OUT_OF_COUNTRY_DECISION_TYPE;
 
@@ -25,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacaseapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.OutOfCountryDecisionType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
@@ -89,6 +91,25 @@ class HomeOfficeReferenceNumberTruncatorTest {
         when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
         when(asylumCase.read(OUT_OF_COUNTRY_DECISION_TYPE, OutOfCountryDecisionType.class))
             .thenReturn(Optional.of(OutOfCountryDecisionType.REFUSAL_OF_HUMAN_RIGHTS));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            homeOfficeReferenceNumberTruncator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+        verify(asylumCase, never()).write(any(),any());
+
+        reset(asylumCase);
+    }
+
+    @Test
+    void should_not_do_anything_when_age_assessment_appeal() {
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class))
+            .thenReturn(Optional.of(AppealType.AG));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             homeOfficeReferenceNumberTruncator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/LetterSentOrReceivedHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/LetterSentOrReceivedHandlerTest.java
@@ -55,7 +55,7 @@ class LetterSentOrReceivedHandlerTest {
         when(callback.getEvent()).thenReturn(Event.START_APPEAL);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.empty()); //non-AIP
-
+        when(asylumCase.read(AGE_ASSESSMENT, YesOrNo.class)).thenReturn(Optional.of(NO));
     }
 
     @Test
@@ -155,6 +155,26 @@ class LetterSentOrReceivedHandlerTest {
         assertThatThrownBy(() -> letterSentOrReceivedHandler.canHandle(PreSubmitCallbackStage.MID_EVENT, null))
             .hasMessage("callback must not be null")
             .isExactlyInstanceOf(NullPointerException.class);
+
+    }
+
+    @Test
+    void should_not_write_received_or_sent_for_aaa() {
+
+        when(asylumCase.read(IS_OUT_OF_COUNTRY_ENABLED, YesOrNo.class)).thenReturn(Optional.of(isOutOfCountryEnabled));
+        when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.of(NO));
+
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(appellantInDetention));
+        when(asylumCase.read(AGE_ASSESSMENT, YesOrNo.class)).thenReturn(Optional.of(YES));
+
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            letterSentOrReceivedHandler.handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+        verify(asylumCase, never()).write(eq(LETTER_SENT_OR_RECEIVED), any());
 
     }
 


### PR DESCRIPTION
- Updated handlers to skip checks if it is a AAA case: HomeOfficeReferenceNumberTruncator, LetterSentOrReceivedHandlerTest,
- if AAA, check dateOnDecisionLetter and write if submission out of time or not.
- Added a helper method in HandlerUtils, to check if appeal type is AG.
- Added functional test to check start and submit AG appeal.

```
[ ] Yes
[x] No
```
