### PR TITLE
RIA-6533 List ADA Case direction

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/DirectionTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/DirectionTag.java
@@ -9,6 +9,7 @@ public enum DirectionTag {
     CASE_EDIT("caseEdit"),
     LEGAL_REPRESENTATIVE_REVIEW("legalRepresentativeReview"),
     LEGAL_REPRESENTATIVE_HEARING_REQUIREMENTS("legalRepresentativeHearingRequirements"),
+    ADA_LIST_CASE("adaListCase"),
     REQUEST_NEW_HEARING_REQUIREMENTS("requestNewHearingRequirements"),
     RESPONDENT_EVIDENCE("respondentEvidence"),
     RESPONDENT_REVIEW("respondentReview"),

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
@@ -21,7 +21,6 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallb
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
-import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.DirectionAppender;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.HearingCentreFinder;
@@ -174,34 +173,6 @@ public class ListEditCaseHandler implements PreSubmitCallbackHandler<AsylumCase>
             );
 
         asylumCase.write(DIRECTIONS, allDirections);
-
-        //------
-        //asylumCase.write(SEND_DIRECTION_PARTIES, Parties.RESPONDENT);
-        //
-        //LocalDate appealSubmissionDate = asylumCase.read(APPEAL_SUBMISSION_DATE, String.class)
-        //    .map(LocalDate::parse)
-        //    .orElseThrow(() -> new IllegalStateException("appealSubmissionDate is missing"));
-        //
-        //String directionDueDate = appealSubmissionDate
-        //    .plusDays(dueInDaysSinceSubmission) // 15
-        //    .toString();
-        //
-        //asylumCase.write(SEND_DIRECTION_DATE_DUE, directionDueDate);
-        //
-        //asylumCase.write(SEND_DIRECTION_EXPLANATION,
-        //    "You have a direction for this case.\n"
-        //    + "\n"
-        //    + "The accelerated detained appeal has been listed and you should tell the Tribunal if the appellant has any hearing requirements.\n"
-        //    + "\n"
-        //    + "# Next steps\n"
-        //    + "Log in to the service and select the case from your case list. You’ll be able to submit the hearing requirements by selecting Submit hearing requirements from the Next step dropdown on the overview tab.\n"
-        //    + "\n"
-        //    + "The Tribunal will review the hearing requirements and any requests for additional adjustments.\n"
-        //    + "\n"
-        //    + "If you do not submit the hearing requirements by the date indicated below, the Tribunal may not be able to accommodate the appellant’s needs for the hearing.\n"
-        //    + "\n"
-        //    + "You must complete this direction by: " + directionDueDate
-        //);
 
         return asylumCase;
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
@@ -163,9 +162,7 @@ public class ListEditCaseHandler implements PreSubmitCallbackHandler<AsylumCase>
                 + "\n"
                 + "The Tribunal will review the hearing requirements and any requests for additional adjustments.\n"
                 + "\n"
-                + "If you do not submit the hearing requirements by the date indicated below, the Tribunal may not be able to accommodate the appellant’s needs for the hearing.\n"
-                + "\n"
-                + "You must complete this direction by: " + directionDueDate.format(DateTimeFormatter.ofPattern("dd MMMM yyyy")),
+                + "If you do not submit the hearing requirements by the date indicated below, the Tribunal may not be able to accommodate the appellant’s needs for the hearing.",
                 Parties.LEGAL_REPRESENTATIVE,
                 directionDueDate.toString(),
                 DirectionTag.ADA_LIST_CASE,

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/DirectionPartiesResolver.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/DirectionPartiesResolver.java
@@ -19,6 +19,7 @@ public class DirectionPartiesResolver {
 
         switch (callback.getEvent()) {
 
+            case LIST_CASE:
             case REQUEST_CASE_EDIT:
             case REQUEST_CASE_BUILDING:
             case FORCE_REQUEST_CASE_BUILDING:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -102,6 +102,7 @@ requestRespondentReview.dueInDays: 14
 appellantReasonsForAppeal.dueInDays: 28
 paymentAfterRemissionRejection.dueInMinutes: 20160
 paymentEaHuNoRemission.dueInMinutes: 20160
+adaCaseListedDirection.dueInDaysSinceSubmission: 15
 
 core_case_data_api_url_template: "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases"
 core_case_data_api_metatdata_url: "/caseworkers/{uid}/jurisdictions/{jid}/case-types/{ctid}/cases/pagination_metadata"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/DirectionTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/DirectionTagTest.java
@@ -8,6 +8,7 @@ class DirectionTagTest {
 
     @Test
     void has_correct_values() {
+        assertEquals("adaListCase", DirectionTag.ADA_LIST_CASE.toString());
         assertEquals("buildCase", DirectionTag.BUILD_CASE.toString());
         assertEquals("caseEdit", DirectionTag.CASE_EDIT.toString());
         assertEquals("legalRepresentativeReview", DirectionTag.LEGAL_REPRESENTATIVE_REVIEW.toString());
@@ -27,6 +28,6 @@ class DirectionTagTest {
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(14, DirectionTag.values().length);
+        assertEquals(15, DirectionTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandlerTest.java
@@ -11,12 +11,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ACCELERATED_DETAINED_APPEAL_LISTED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ACTUAL_CASE_HEARING_LENGTH;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_SUBMISSION_DATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ATTENDING_APPELLANT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ATTENDING_APPELLANTS_LEGAL_REPRESENTATIVE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ATTENDING_HOME_OFFICE_LEGAL_REPRESENTATIVE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ATTENDING_JUDGE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ATTENDING_TCW;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CURRENT_HEARING_DETAILS_VISIBLE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DIRECTIONS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DOES_THE_CASE_NEED_TO_BE_RELISTED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_CENTRE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_CONDUCTION_OPTIONS;
@@ -27,6 +29,9 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REHEARD_CASE_LISTED_WITHOUT_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REVIEWED_UPDATED_HEARING_REQUIREMENTS;
 
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,13 +41,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.Direction;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DirectionTag;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.HearingCentre;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.Parties;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.DirectionAppender;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.HearingCentreFinder;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -60,14 +70,32 @@ class ListEditCaseHandlerTest {
     private HearingCentreFinder hearingCentreFinder;
     @Mock
     private CaseManagementLocationService caseManagementLocationService;
+    @Mock
+    private DirectionAppender directionAppender;
+    private int dueDaysSinceSubmission = 15;
+
+    private String directionExplanation = "You have a direction for this case.\n"
+                                          + "\n"
+                                          + "The accelerated detained appeal has been listed and you should tell the Tribunal if the appellant has any hearing requirements.\n"
+                                          + "\n"
+                                          + "# Next steps\n"
+                                          + "Log in to the service and select the case from your case list. You’ll be able to submit the hearing requirements by selecting Submit hearing requirements from the Next step dropdown on the overview tab.\n"
+                                          + "\n"
+                                          + "The Tribunal will review the hearing requirements and any requests for additional adjustments.\n"
+                                          + "\n"
+                                          + "If you do not submit the hearing requirements by the date indicated below, the Tribunal may not be able to accommodate the appellant’s needs for the hearing.\n"
+                                          + "\n"
+                                          + "You must complete this direction by: 16 December 2022";
 
     private ListEditCaseHandler listEditCaseHandler;
 
     @BeforeEach
     public void setUp() {
 
-        listEditCaseHandler =
-            new ListEditCaseHandler(hearingCentreFinder, caseManagementLocationService);
+        listEditCaseHandler = new ListEditCaseHandler(hearingCentreFinder,
+            caseManagementLocationService,
+            dueDaysSinceSubmission,
+            directionAppender);
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getEvent()).thenReturn(Event.LIST_CASE);
@@ -100,8 +128,29 @@ class ListEditCaseHandlerTest {
     }
 
     @Test
-    void should_set_listCase_availability_to_no_if_case_accelerated() {
+    void should_set_flags_and_add_direction_if_ada() {
+        Direction expectedDirection = new Direction(directionExplanation,
+            Parties.LEGAL_REPRESENTATIVE,
+            "2022-12-16",
+            LocalDate.now().toString(),
+            DirectionTag.ADA_LIST_CASE,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            "1",
+            Event.LIST_CASE.toString());
+
+        List<IdValue<Direction>> expectedListOfDirections = List.of(new IdValue<>("1", expectedDirection));
+
         when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(APPEAL_SUBMISSION_DATE, String.class)).thenReturn(Optional.of("2022-12-01"));
+        when(asylumCase.read(DIRECTIONS)).thenReturn(Optional.empty());
+        when(directionAppender.append(asylumCase,
+            Collections.emptyList(),
+            directionExplanation,
+            Parties.LEGAL_REPRESENTATIVE,
+            "2022-12-16",
+            DirectionTag.ADA_LIST_CASE,
+            Event.LIST_CASE.toString())).thenReturn(expectedListOfDirections);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             listEditCaseHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
@@ -111,6 +160,7 @@ class ListEditCaseHandlerTest {
 
         verify(asylumCase, times(1)).write(ACCELERATED_DETAINED_APPEAL_LISTED, YesOrNo.YES);
         verify(asylumCase, times(1)).write(LISTING_AVAILABLE_FOR_ADA, YesOrNo.NO);
+        verify(asylumCase, times(1)).write(DIRECTIONS, expectedListOfDirections);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandlerTest.java
@@ -83,9 +83,7 @@ class ListEditCaseHandlerTest {
                                           + "\n"
                                           + "The Tribunal will review the hearing requirements and any requests for additional adjustments.\n"
                                           + "\n"
-                                          + "If you do not submit the hearing requirements by the date indicated below, the Tribunal may not be able to accommodate the appellant’s needs for the hearing.\n"
-                                          + "\n"
-                                          + "You must complete this direction by: 16 December 2022";
+                                          + "If you do not submit the hearing requirements by the date indicated below, the Tribunal may not be able to accommodate the appellant’s needs for the hearing.";
 
     private ListEditCaseHandler listEditCaseHandler;
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/DirectionPartiesResolverTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/DirectionPartiesResolverTest.java
@@ -52,6 +52,7 @@ class DirectionPartiesResolverTest {
             ImmutableMap
                 .<Event, Parties>builder()
                 .put(Event.SEND_DIRECTION, expectedDirectionParties)
+                .put(Event.LIST_CASE, Parties.LEGAL_REPRESENTATIVE)
                 .put(Event.REQUEST_CASE_EDIT, Parties.LEGAL_REPRESENTATIVE)
                 .put(Event.REQUEST_RESPONDENT_EVIDENCE, Parties.RESPONDENT)
                 .put(Event.REQUEST_RESPONDENT_REVIEW, Parties.RESPONDENT)


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6533](https://tools.hmcts.net/jira/browse/RIA-6533)
A direction has to be created when an admin lists an ADA case (in `awaitingRespondentEvidence` state) and a notification with the same content has to be sent to the LR.

### Change description ###
- Changed ListEditCaseHandler to manage flags for Accelerated Detained Appeal and add a direction.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
