### PR TITLE
RIA-6501 Make new text for Judge Review show up for all appeal types …

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/MakeAnApplicationTypes.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/MakeAnApplicationTypes.java
@@ -7,7 +7,7 @@ public enum  MakeAnApplicationTypes {
     ADJOURN("Adjourn"),
     EXPEDITE("Expedite"),
     JUDGE_REVIEW("Judge's review of application decision"),
-    JUDGE_REVIEW_LR("Judge's review of Legal Officer decision"),
+    JUDGE_REVIEW_LO("Judge's review of Legal Officer decision"),
     LINK_OR_UNLINK("Link/unlink appeals"),
     TIME_EXTENSION("Time extension"),
     TRANSFER("Transfer"),

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MakeAnApplicationMidEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MakeAnApplicationMidEvent.java
@@ -81,7 +81,7 @@ public class MakeAnApplicationMidEvent implements PreSubmitCallbackHandler<Asylu
                     + "of each appeal you want to link to or unlink from.");
                 break;
             case JUDGE_REVIEW:
-            case JUDGE_REVIEW_LR:
+            case JUDGE_REVIEW_LO:
                 asylumCase.write(MAKE_AN_APPLICATION_DETAILS_LABEL,
                     "Tell us which application decision you want to be reviewed by a Judge and explain why you think the original decision "
                     + "was wrong.");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/MakeAnApplicationTypesProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/MakeAnApplicationTypesProvider.java
@@ -18,6 +18,11 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 public class MakeAnApplicationTypesProvider {
 
     private static final String ROLE_LEGAL_REP = "caseworker-ia-legalrep-solicitor";
+    private static final String ROLE_HO_APC = "caseworker-ia-homeofficeapc";
+    private static final String ROLE_HO_LART = "caseworker-ia-homeofficelart";
+    private static final String ROLE_HO_POU = "caseworker-ia-homeofficepou";
+    private static final String ROLE_HO_RESPONDENT = "caseworker-ia-respondentofficer";
+    private static final List<String> HO_ROLES = List.of(ROLE_HO_APC, ROLE_HO_LART, ROLE_HO_POU, ROLE_HO_RESPONDENT);
 
     private final UserDetails userDetails;
 
@@ -33,6 +38,9 @@ public class MakeAnApplicationTypesProvider {
 
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
+        boolean hasHomeOfficeRole = userDetails.getRoles()
+            .stream().anyMatch(HO_ROLES::contains);
+
         DynamicList dynamicList;
         final List<Value> values = new ArrayList<>();
         switch (currentState) {
@@ -42,13 +50,16 @@ public class MakeAnApplicationTypesProvider {
                 if (hasRole(ROLE_LEGAL_REP)) {
                     values.add(new Value(UPDATE_APPEAL_DETAILS.name(),
                         UPDATE_APPEAL_DETAILS.toString()));
+                }
 
-                    if (isAcceleratedDetainedAppeal(asylumCase)) {
-                        values.remove(0); // remove JUDGE_REVIEW
-                        values.add(new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()));
-                        values.add(new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
-                            TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()));
-                    }
+                if (hasRole(ROLE_LEGAL_REP) || hasHomeOfficeRole) {
+                    values.remove(0); // remove JUDGE_REVIEW
+                    values.add(new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()));
+                }
+
+                if (isAcceleratedDetainedAppeal(asylumCase) && hasRole(ROLE_LEGAL_REP)) {
+                    values.add(new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
+                        TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()));
                 }
 
                 values.add(new Value(WITHDRAW.name(), WITHDRAW.toString()));
@@ -58,11 +69,10 @@ public class MakeAnApplicationTypesProvider {
                 break;
 
             case ENDED:
-                values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
-
-                if (isAcceleratedDetainedAppeal(asylumCase) && hasRole(ROLE_LEGAL_REP)) {
-                    values.remove(0); // remove JUDGE_REVIEW
-                    values.add(new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()));
+                if (hasRole(ROLE_LEGAL_REP) || hasHomeOfficeRole) {
+                    values.add(new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()));
+                } else {
+                    values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
                 }
 
                 values.add(new Value(REINSTATE.name(), REINSTATE.toString()));
@@ -78,19 +88,23 @@ public class MakeAnApplicationTypesProvider {
             case REASONS_FOR_APPEAL_SUBMITTED:
             case RESPONDENT_REVIEW:
             case SUBMIT_HEARING_REQUIREMENTS:
-                values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
-                values.add(new Value(TIME_EXTENSION.name(), TIME_EXTENSION.toString()));
+                if (hasRole(ROLE_LEGAL_REP) || hasHomeOfficeRole) {
+                    values.add(new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()));
+                } else {
+                    values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
+                }
+
                 if (hasRole(ROLE_LEGAL_REP)) {
                     values.add(new Value(UPDATE_APPEAL_DETAILS.name(),
                         UPDATE_APPEAL_DETAILS.toString()));
 
                     if (isAcceleratedDetainedAppeal(asylumCase)) {
-                        values.remove(0); // remove JUDGE_REVIEW
-                        values.add(new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()));
                         values.add(new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
                             TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()));
                     }
                 }
+
+                values.add(new Value(TIME_EXTENSION.name(), TIME_EXTENSION.toString()));
                 values.add(new Value(WITHDRAW.name(), WITHDRAW.toString()));
                 values.add(new Value(LINK_OR_UNLINK.name(), LINK_OR_UNLINK.toString()));
                 values.add(new Value(OTHER.name(), OTHER.toString()));
@@ -98,24 +112,31 @@ public class MakeAnApplicationTypesProvider {
 
             case FTPA_SUBMITTED:
             case FTPA_DECIDED:
-                values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
-                values.add(new Value(TIME_EXTENSION.name(), TIME_EXTENSION.toString()));
+                if (hasRole(ROLE_LEGAL_REP) || hasHomeOfficeRole) {
+                    values.add(new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()));
+                } else {
+                    values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
+                }
+
                 if (hasRole(ROLE_LEGAL_REP)) {
                     values.add(new Value(UPDATE_APPEAL_DETAILS.name(),
                         UPDATE_APPEAL_DETAILS.toString()));
-
-                    if (isAcceleratedDetainedAppeal(asylumCase)) {
-                        values.remove(0); // remove JUDGE_REVIEW
-                        values.add(new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()));
-                    }
                 }
+
+                values.add(new Value(TIME_EXTENSION.name(), TIME_EXTENSION.toString()));
                 values.add(new Value(LINK_OR_UNLINK.name(), LINK_OR_UNLINK.toString()));
                 values.add(new Value(OTHER.name(), OTHER.toString()));
                 break;
 
             case FINAL_BUNDLING:
-                values.add(new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()));
+                if (hasRole(ROLE_LEGAL_REP) || hasHomeOfficeRole) {
+                    values.add(new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()));
+                } else {
+                    values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
+                }
+
                 values.add(new Value(TIME_EXTENSION.name(), TIME_EXTENSION.toString()));
+
                 if (hasRole(ROLE_LEGAL_REP)) {
                     values.add(new Value(UPDATE_APPEAL_DETAILS.name(),
                         UPDATE_APPEAL_DETAILS.toString()));
@@ -123,8 +144,6 @@ public class MakeAnApplicationTypesProvider {
                         UPDATE_HEARING_REQUIREMENTS.toString()));
 
                     if (isAcceleratedDetainedAppeal(asylumCase)) {
-                        values.remove(0); // remove JUDGE_REVIEW
-                        values.add(new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()));
                         values.add(new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
                             TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()));
                     }
@@ -135,8 +154,14 @@ public class MakeAnApplicationTypesProvider {
                 break;
 
             case LISTING:
-                values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
+                if (hasRole(ROLE_LEGAL_REP) || hasHomeOfficeRole) {
+                    values.add(new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()));
+                } else {
+                    values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
+                }
+
                 values.add(new Value(TIME_EXTENSION.name(), TIME_EXTENSION.toString()));
+
                 if (hasRole(ROLE_LEGAL_REP)) {
                     values.add(new Value(UPDATE_APPEAL_DETAILS.name(),
                         UPDATE_APPEAL_DETAILS.toString()));
@@ -144,8 +169,6 @@ public class MakeAnApplicationTypesProvider {
                         UPDATE_HEARING_REQUIREMENTS.toString()));
 
                     if (isAcceleratedDetainedAppeal(asylumCase)) {
-                        values.remove(0); // remove JUDGE_REVIEW
-                        values.add(new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()));
                         values.add(new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
                             TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()));
                     }
@@ -158,11 +181,17 @@ public class MakeAnApplicationTypesProvider {
             case PREPARE_FOR_HEARING:
             case PRE_HEARING:
             case DECISION:
-                values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
+                if (hasRole(ROLE_LEGAL_REP) || hasHomeOfficeRole) {
+                    values.add(new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()));
+                } else {
+                    values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
+                }
+
                 values.add(new Value(ADJOURN.name(), ADJOURN.toString()));
                 values.add(new Value(EXPEDITE.name(), EXPEDITE.toString()));
                 values.add(new Value(TRANSFER.name(), TRANSFER.toString()));
                 values.add(new Value(TIME_EXTENSION.name(), TIME_EXTENSION.toString()));
+
                 if (hasRole(ROLE_LEGAL_REP)) {
                     values.add(new Value(UPDATE_APPEAL_DETAILS.name(),
                         UPDATE_APPEAL_DETAILS.toString()));
@@ -170,8 +199,6 @@ public class MakeAnApplicationTypesProvider {
                         UPDATE_HEARING_REQUIREMENTS.toString()));
 
                     if (isAcceleratedDetainedAppeal(asylumCase)) {
-                        values.remove(0); // remove JUDGE_REVIEW
-                        values.add(new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()));
                         values.add(new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
                             TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()));
                     }
@@ -182,14 +209,17 @@ public class MakeAnApplicationTypesProvider {
                 break;
 
             case DECIDED:
-                values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
+                if (hasRole(ROLE_LEGAL_REP) || hasHomeOfficeRole) {
+                    values.add(new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()));
+                } else {
+                    values.add(new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()));
+                }
+
                 if (hasRole(ROLE_LEGAL_REP)) {
                     values.add(new Value(UPDATE_APPEAL_DETAILS.name(),
                         UPDATE_APPEAL_DETAILS.toString()));
 
                     if (isAcceleratedDetainedAppeal(asylumCase)) {
-                        values.remove(0); // remove JUDGE_REVIEW
-                        values.add(new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()));
                         values.add(new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
                             TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()));
                     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/MakeAnApplicationTypesProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/MakeAnApplicationTypesProvider.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.service;
 
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -98,7 +99,7 @@ public class MakeAnApplicationTypesProvider {
                     values.add(new Value(UPDATE_APPEAL_DETAILS.name(),
                         UPDATE_APPEAL_DETAILS.toString()));
 
-                    if (isAcceleratedDetainedAppeal(asylumCase)) {
+                    if (isAcceleratedDetainedAppeal(asylumCase) && currentState != PENDING_PAYMENT) {
                         values.add(new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
                             TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()));
                     }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/MakeAnApplicationTypesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/MakeAnApplicationTypesTest.java
@@ -12,7 +12,7 @@ class MakeAnApplicationTypesTest {
         assertEquals("Expedite", MakeAnApplicationTypes.EXPEDITE.toString());
         assertEquals("Link/unlink appeals", MakeAnApplicationTypes.LINK_OR_UNLINK.toString());
         assertEquals("Judge's review of application decision", MakeAnApplicationTypes.JUDGE_REVIEW.toString());
-        assertEquals("Judge's review of Legal Officer decision", MakeAnApplicationTypes.JUDGE_REVIEW_LR.toString());
+        assertEquals("Judge's review of Legal Officer decision", MakeAnApplicationTypes.JUDGE_REVIEW_LO.toString());
         assertEquals("Time extension", MakeAnApplicationTypes.TIME_EXTENSION.toString());
         assertEquals("Transfer", MakeAnApplicationTypes.TRANSFER.toString());
         assertEquals("Withdraw", MakeAnApplicationTypes.WITHDRAW.toString());

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/MakeAnApplicationTypesProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/MakeAnApplicationTypesProviderTest.java
@@ -23,6 +23,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.DECIDED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.ENDED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.FINAL_BUNDLING;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.LISTING;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.PENDING_PAYMENT;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -148,8 +149,15 @@ class MakeAnApplicationTypesProviderTest {
             new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
                 TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()),
             new Value(OTHER.name(), OTHER.toString()));
+
+        if (state.equals(PENDING_PAYMENT)) {
+            values.remove(5);
+        }
+
         DynamicList actualList =
             new DynamicList(values.get(0), values);
+
+
 
         DynamicList expectedList = makeAnApplicationTypesProvider.getMakeAnApplicationTypes(callback);
         assertNotNull(expectedList);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/MakeAnApplicationTypesProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/MakeAnApplicationTypesProviderTest.java
@@ -7,8 +7,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.ADJOURN;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.EXPEDITE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.JUDGE_REVIEW;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.JUDGE_REVIEW_LR;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.JUDGE_REVIEW_LO;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.LINK_OR_UNLINK;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.OTHER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.REINSTATE;
@@ -79,7 +78,7 @@ class MakeAnApplicationTypesProviderTest {
             new Value(UPDATE_APPEAL_DETAILS.name(), UPDATE_APPEAL_DETAILS.toString()),
             new Value(WITHDRAW.name(), WITHDRAW.toString()),
             new Value(LINK_OR_UNLINK.name(), LINK_OR_UNLINK.toString()),
-            new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()),
+            new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()),
             new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
                 TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()),
             new Value(OTHER.name(), OTHER.toString()));
@@ -105,7 +104,7 @@ class MakeAnApplicationTypesProviderTest {
         Collections.addAll(values,
             new Value(UPDATE_APPEAL_DETAILS.name(), UPDATE_APPEAL_DETAILS.toString()),
             new Value(LINK_OR_UNLINK.name(), LINK_OR_UNLINK.toString()),
-            new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()),
+            new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()),
             new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
                 TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()),
             new Value(OTHER.name(), OTHER.toString()));
@@ -145,7 +144,7 @@ class MakeAnApplicationTypesProviderTest {
             new Value(UPDATE_APPEAL_DETAILS.name(), UPDATE_APPEAL_DETAILS.toString()),
             new Value(WITHDRAW.name(), WITHDRAW.toString()),
             new Value(LINK_OR_UNLINK.name(), LINK_OR_UNLINK.toString()),
-            new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()),
+            new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()),
             new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
                 TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()),
             new Value(OTHER.name(), OTHER.toString()));
@@ -176,7 +175,7 @@ class MakeAnApplicationTypesProviderTest {
             new Value(TIME_EXTENSION.name(), TIME_EXTENSION.toString()),
             new Value(UPDATE_APPEAL_DETAILS.name(), UPDATE_APPEAL_DETAILS.toString()),
             new Value(LINK_OR_UNLINK.name(), LINK_OR_UNLINK.toString()),
-            new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()),
+            new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()),
             new Value(OTHER.name(), OTHER.toString()));
         DynamicList actualList =
             new DynamicList(values.get(0), values);
@@ -209,7 +208,7 @@ class MakeAnApplicationTypesProviderTest {
             new Value(UPDATE_HEARING_REQUIREMENTS.name(), UPDATE_HEARING_REQUIREMENTS.toString()),
             new Value(WITHDRAW.name(), WITHDRAW.toString()),
             new Value(LINK_OR_UNLINK.name(), LINK_OR_UNLINK.toString()),
-            new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()),
+            new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()),
             new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
                 TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()),
             new Value(OTHER.name(), OTHER.toString()));
@@ -233,7 +232,7 @@ class MakeAnApplicationTypesProviderTest {
 
         final List<Value> values = new ArrayList<>();
         Collections.addAll(values,
-            new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()),
+            new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()),
             new Value(REINSTATE.name(), REINSTATE.toString()));
         DynamicList actualList =
             new DynamicList(values.get(0), values);
@@ -260,7 +259,7 @@ class MakeAnApplicationTypesProviderTest {
             new Value(UPDATE_HEARING_REQUIREMENTS.name(), UPDATE_HEARING_REQUIREMENTS.toString()),
             new Value(WITHDRAW.name(), WITHDRAW.toString()),
             new Value(LINK_OR_UNLINK.name(), LINK_OR_UNLINK.toString()),
-            new Value(JUDGE_REVIEW_LR.name(), JUDGE_REVIEW_LR.toString()),
+            new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()),
             new Value(TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.name(),
                 TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()),
             new Value(OTHER.name(), OTHER.toString()));
@@ -284,7 +283,7 @@ class MakeAnApplicationTypesProviderTest {
 
         final List<Value> values = new ArrayList<>();
         Collections.addAll(values,
-            new Value(JUDGE_REVIEW.name(), JUDGE_REVIEW.toString()),
+            new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()),
             new Value(TIME_EXTENSION.name(), TIME_EXTENSION.toString()),
             new Value(UPDATE_APPEAL_DETAILS.name(), UPDATE_APPEAL_DETAILS.toString()),
             new Value(UPDATE_HEARING_REQUIREMENTS.name(), UPDATE_HEARING_REQUIREMENTS.toString()),


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6501](https://tools.hmcts.net/jira/browse/RIA-6501)


### Change description ###
- changed ~`JUDGE_REVIEW_LR`~ variable name to `JUDGE_REVIEW_LO` to reflect the application type text concerning Legal Officers (and to generify it since it's not typical of LRs-only but HOs too)
- made `JUDGE_REVIEW_LO` display instead of `JUDGE_REVIEW` not only when it's ADA appeal type and LR role, but for all appeal types and LR+HO roles



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
