### PR TITLE
RIA-6563: Fix the state for appeal after submit

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AppealTypeForDisplay.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AppealTypeForDisplay.java
@@ -11,7 +11,8 @@ public enum AppealTypeForDisplay {
     PA("protection", "Refusal of protection claim"),
     EA("refusalOfEu", "Refusal of application under the EEA regulations"),
     HU("refusalOfHumanRights", "Refusal of a human rights claim"),
-    DC("deprivation", "Deprivation of citizenship");
+    DC("deprivation", "Deprivation of citizenship"),
+    EU("euSettlementScheme", "EU Settlement Scheme");
 
     @JsonValue
     private String value;

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AppealTypeForDisplayTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AppealTypeForDisplayTest.java
@@ -15,6 +15,7 @@ class AppealTypeForDisplayTest {
         assertThat(AppealTypeForDisplay.from("refusalOfEu").equals(Optional.of(AppealTypeForDisplay.EA)));
         assertThat(AppealTypeForDisplay.from("refusalOfHumanRights").equals(Optional.of(AppealTypeForDisplay.HU)));
         assertThat(AppealTypeForDisplay.from("deprivation").equals(Optional.of(AppealTypeForDisplay.DC)));
+        assertThat(AppealTypeForDisplay.from("euSettlementScheme").equals(Optional.of(AppealTypeForDisplay.EU)));
     }
 
     @Test
@@ -24,6 +25,7 @@ class AppealTypeForDisplayTest {
         assertEquals("Refusal of application under the EEA regulations", AppealTypeForDisplay.EA.getDescription());
         assertEquals("Refusal of a human rights claim", AppealTypeForDisplay.HU.getDescription());
         assertEquals("Deprivation of citizenship", AppealTypeForDisplay.DC.getDescription());
+        assertEquals("EU Settlement Scheme", AppealTypeForDisplay.EU.getDescription());
     }
 
     @Test
@@ -33,6 +35,6 @@ class AppealTypeForDisplayTest {
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(5, AppealTypeForDisplay.values().length);
+        assertEquals(6, AppealTypeForDisplay.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/FeesHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/FeesHandlerTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;


### PR DESCRIPTION
- For all ADA types, move the appeal to appealSubmitted irrespective of appealType (treat them as RP/DC).
- For Detained (Non-ADA) move the appeal to paymentPending for HU/EA/EUSS
- For PA, move appeal to submitted with paymentStatus = paymentPending.

(https://tools.hmcts.net/jira/browse/RIA-6563)
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
