### PR TITLE
RIA-6594 RIA-6572 Allow appeals with empty remissions to be ended

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -94,6 +94,7 @@
         <cve>CVE-2022-41946</cve>
     </suppress>
     <suppress>
-        <cve>CVE-2021-37533</cve>    
+        <cve>CVE-2021-37533</cve>
+        <cve>CVE-2021-4277</cve>
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AutomaticEndAppealForNonPaymentEaHuTrigger.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AutomaticEndAppealForNonPaymentEaHuTrigger.java
@@ -1,12 +1,16 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType.EA;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType.EU;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType.HU;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REMISSION_TYPE;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
@@ -51,8 +55,8 @@ public class AutomaticEndAppealForNonPaymentEaHuTrigger implements PostSubmitCal
         Optional<AppealType> appealType = asylumCase.read(APPEAL_TYPE, AppealType.class);
 
         return callback.getEvent() == Event.SUBMIT_APPEAL
-               && (remissionType.isPresent() && remissionType.get() == RemissionType.NO_REMISSION)
-               && (appealType.isPresent() && (appealType.get() == AppealType.EA || appealType.get() == AppealType.HU));
+               && (remissionType.map(remission -> remission.equals(RemissionType.NO_REMISSION)).orElse(true))
+               && (appealType.isPresent() && Set.of(EA, HU, EU).contains(appealType.get()));
     }
 
     public PostSubmitCallbackResponse handle(


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6594](https://tools.hmcts.net/jira/browse/RIA-6594)
[RIA-6572](https://tools.hmcts.net/jira/browse/RIA-6572)


### Change description ###
- AIP appeals don't have the `remissionType` field set, so originally the handler wouldn't be called (condition exiting at L54 [AutomaticEndAppealForNonPaymentEaHuTrigger.java](https://github.com/hmcts/ia-case-api/compare/ia-case-api-aip-payment...RIA-6594_RIA-6572_end_aip_appeals_automatically?expand=1#diff-3e8f7b7a43aa24ca1ac6c9db4c76908919575f827b75e23fe697b6597ab1f4ec))
- AIP appeals can now use the handler to set the 14 days timer to trigger `endAppeal` since the condition treats an empty `remissionType` as `noRemission`. This shouldn't accidentally allow other appeal types to use the handler, since the following condition filters out any appeal that isn't HU, EA, EU.

| `appealType` | `journeyType` | `remissionType`  |   | TRIGGER OR NOT |
|--------------|---------------|------------------|---|----------------|
| EA/EU/HU     | LR            | noRemission      |   | TRIGGER        |
| EA/EU/HU     | LR            | OTHER REMISSIONS |   | DON'T TRIGGER  |
| EA/EU/HU     | AIP           | null             |   | TRIGGER        |
| DC/RP        | LR            | null             |   | DON'T TRIGGER  |
| DC/RP        | AIP           | null             |   | DON'T TRIGGER  |


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
