### PR TITLE
RIA-6575 Return instead of throwing exception for paid appeals

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -96,5 +96,7 @@
     <suppress>
         <cve>CVE-2021-37533</cve>
         <cve>CVE-2021-4277</cve>
+        <cve>CVE-2021-4235</cve>
+        <cve>CVE-2022-3064</cve>
     </suppress>
 </suppressions>

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandlerTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6575](https://tools.hmcts.net/jira/browse/RIA-6575)


### Change description ###
- `endAppealAutomatically` is called automatically from **ia-timed-event-service** 14 days after submission. When the payment status is `Paid`, the handler returns instead of making the necessary changes for ended appeals
- When the payment status is `Paid`, the state does not update to `ended` thanks to a condition in **ia-ccd-definitions** (PR https://github.com/hmcts/ia-ccd-definitions/compare/RIA-6575_endAppealAutomatically_post_state_condition?expand=1)
- Throwing an exception is read as an unsuccessful call to **ia-case-api** (504) from **ia-timed-event-service**, which would keep on rescheduling the event every half-hour.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
