### PR TITLE
RIA-6508: Remove AA* fields from the asylumCaseDefinitions

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -101,5 +101,6 @@
         <cve>CVE-2021-4235</cve>
         <cve>CVE-2022-3064</cve>
         <cve>CVE-2021-4277</cve>
+        <cve>CVE-2022-45143</cve>
     </suppress>
 </suppressions>

--- a/src/functionalTest/resources/templates/minimal-age-assessment-appeal-started.json
+++ b/src/functionalTest/resources/templates/minimal-age-assessment-appeal-started.json
@@ -13,10 +13,10 @@
       }
     }
   ],
-  "aaAppellantHasFixedAddress": "No",
-  "aaContactPreference": "wantsSms",
+  "appellantHasFixedAddress": "No",
+  "contactPreference": "wantsSms",
   "wantsSms": "Text message",
-  "aaMobileNumber": "07977111111",
+  "mobileNumber": "07977111111",
   "appealReferenceNumber": "DRAFT",
   "isOutOfCountryEnabled": "Yes",
   "appellantInUk": "Yes",

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -60,12 +60,6 @@ public enum AsylumCaseFieldDefinition {
     APPELLANT_ADDRESS(
         "appellantAddress", new TypeReference<AddressUk>(){}),
 
-    AA_APPELLANT_HAS_FIXED_ADDRESS(
-        "aaAppellantHasFixedAddress", new TypeReference<YesOrNo>(){}),
-
-    AA_APPELLANT_ADDRESS(
-        "aaAppellantAddress", new TypeReference<AddressUk>(){}),
-
     SEARCH_POSTCODE(
         "searchPostcode", new TypeReference<String>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DeriveHearingCentreHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DeriveHearingCentreHandler.java
@@ -1,9 +1,6 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AA_APPELLANT_ADDRESS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AA_APPELLANT_HAS_FIXED_ADDRESS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AGE_ASSESSMENT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_ADDRESS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_HAS_FIXED_ADDRESS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPLICATION_CHANGE_DESIGNATED_HEARING_CENTRE;
@@ -23,7 +20,6 @@ import java.util.Arrays;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.HearingCentre;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
@@ -111,14 +107,10 @@ public class DeriveHearingCentreHandler implements PreSubmitCallbackHandler<Asyl
             }
         }
 
-        boolean isAgeAssessmentAppeal = asylumCase.read(AGE_ASSESSMENT, YesOrNo.class).orElse(NO) == YES;
-        AsylumCaseFieldDefinition appellantHasFixedAddress = isAgeAssessmentAppeal ? AA_APPELLANT_HAS_FIXED_ADDRESS : APPELLANT_HAS_FIXED_ADDRESS;
-        AsylumCaseFieldDefinition appellantAddressField = isAgeAssessmentAppeal ? AA_APPELLANT_ADDRESS : APPELLANT_ADDRESS;
-
-        if (asylumCase.read(appellantHasFixedAddress, YesOrNo.class)
+        if (asylumCase.read(APPELLANT_HAS_FIXED_ADDRESS, YesOrNo.class)
                 .orElse(NO) == YES) {
 
-            Optional<AddressUk> optionalAppellantAddress = asylumCase.read(appellantAddressField);
+            Optional<AddressUk> optionalAppellantAddress = asylumCase.read(APPELLANT_ADDRESS);
 
             if (optionalAppellantAddress.isPresent()) {
                 AddressUk appellantAddress = optionalAppellantAddress.get();

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DerivePostcodeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DerivePostcodeHandler.java
@@ -8,7 +8,6 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YE
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
@@ -53,13 +52,10 @@ public class DerivePostcodeHandler implements PreSubmitCallbackHandler<AsylumCas
     private Optional<String> getAppellantPostcode(
         AsylumCase asylumCase
     ) {
-        boolean isAgeAssessmentAppeal = asylumCase.read(AGE_ASSESSMENT, YesOrNo.class).orElse(NO) == YES;
-        AsylumCaseFieldDefinition appellantHasFixedAddress = isAgeAssessmentAppeal ? AA_APPELLANT_HAS_FIXED_ADDRESS : APPELLANT_HAS_FIXED_ADDRESS;
-        AsylumCaseFieldDefinition appellantAddressField = isAgeAssessmentAppeal ? AA_APPELLANT_ADDRESS : APPELLANT_ADDRESS;
-        if (asylumCase.read(appellantHasFixedAddress, YesOrNo.class)
+        if (asylumCase.read(APPELLANT_HAS_FIXED_ADDRESS, YesOrNo.class)
                 .orElse(NO) == YES) {
 
-            Optional<AddressUk> optionalAppellantAddress = asylumCase.read(appellantAddressField);
+            Optional<AddressUk> optionalAppellantAddress = asylumCase.read(APPELLANT_ADDRESS);
 
             if (optionalAppellantAddress.isPresent()) {
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DeriveHearingCentreHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DeriveHearingCentreHandlerTest.java
@@ -11,9 +11,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AA_APPELLANT_ADDRESS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AA_APPELLANT_HAS_FIXED_ADDRESS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AGE_ASSESSMENT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_ADDRESS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_HAS_FIXED_ADDRESS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPLICATION_CHANGE_DESIGNATED_HEARING_CENTRE;
@@ -107,54 +104,6 @@ class DeriveHearingCentreHandlerTest {
         when(asylumCase.read(APPELLANT_ADDRESS)).thenReturn(Optional.of(addressUk));
         when(addressUk.getPostCode()).thenReturn(Optional.of("A123 4BC"));
         when(hearingCentreFinder.find("A123 4BC")).thenReturn(hearingCentre);
-
-        CaseManagementLocation expectedCaseManagementLocation =
-            new CaseManagementLocation(Region.NATIONAL, baseLocation);
-        when(caseManagementLocationService.getCaseManagementLocation(staffLocation))
-            .thenReturn(expectedCaseManagementLocation);
-
-        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-            deriveHearingCentreHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
-
-        assertNotNull(callbackResponse);
-        assertEquals(asylumCase, callbackResponse.getData());
-        verify(hearingCentreFinder, times(1)).find("A123 4BC");
-        verify(asylumCase, times(1)).write(HEARING_CENTRE, hearingCentre);
-
-        verify(asylumCase, times(1)).write(STAFF_LOCATION, staffLocation);
-        verify(asylumCase, times(1))
-            .write(CASE_MANAGEMENT_LOCATION, expectedCaseManagementLocation);
-
-        verify(asylumCase, times(1)).write(APPLICATION_CHANGE_DESIGNATED_HEARING_CENTRE, hearingCentre);
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-        "SUBMIT_APPEAL, MANCHESTER, Manchester, MANCHESTER",
-        "EDIT_APPEAL_AFTER_SUBMIT, MANCHESTER, Manchester, MANCHESTER",
-
-        "SUBMIT_APPEAL, TAYLOR_HOUSE, Taylor House, TAYLOR_HOUSE",
-        "EDIT_APPEAL_AFTER_SUBMIT, TAYLOR_HOUSE, Taylor House, TAYLOR_HOUSE",
-
-        "SUBMIT_APPEAL, HATTON_CROSS, Hatton Cross, HATTON_CROSS",
-        "EDIT_APPEAL_AFTER_SUBMIT, HATTON_CROSS, Hatton Cross, HATTON_CROSS",
-
-        "SUBMIT_APPEAL, NEWCASTLE, Newcastle,",
-        "EDIT_APPEAL_AFTER_SUBMIT, NEWCASTLE, Newcastle,"
-    })
-    void should_derive_hearing_centre_from_aa_appellant_postcode(
-        Event event, HearingCentre hearingCentre, String staffLocation, BaseLocation baseLocation) {
-
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(callback.getEvent()).thenReturn(event);
-        when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(HEARING_CENTRE)).thenReturn(Optional.empty());
-        when(asylumCase.read(APPELLANT_HAS_FIXED_ADDRESS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
-        when(asylumCase.read(AA_APPELLANT_ADDRESS)).thenReturn(Optional.of(addressUk));
-        when(addressUk.getPostCode()).thenReturn(Optional.of("A123 4BC"));
-        when(hearingCentreFinder.find("A123 4BC")).thenReturn(hearingCentre);
-        when(asylumCase.read(AGE_ASSESSMENT, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
-        when(asylumCase.read(AA_APPELLANT_HAS_FIXED_ADDRESS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 
         CaseManagementLocation expectedCaseManagementLocation =
             new CaseManagementLocation(Region.NATIONAL, baseLocation);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DerivePostcodeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DerivePostcodeHandlerTest.java
@@ -11,9 +11,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AA_APPELLANT_ADDRESS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AA_APPELLANT_HAS_FIXED_ADDRESS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AGE_ASSESSMENT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_ADDRESS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_HAS_FIXED_ADDRESS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SEARCH_POSTCODE;
@@ -66,24 +63,6 @@ class DerivePostcodeHandlerTest {
         when(asylumCase.read(APPELLANT_HAS_FIXED_ADDRESS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(asylumCase.read(APPELLANT_ADDRESS)).thenReturn(Optional.of(addressUk));
         when(addressUk.getPostCode()).thenReturn(Optional.of("A123 4BC"));
-
-        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-            derivePostcodeHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
-
-        assertNotNull(callbackResponse);
-        assertEquals(asylumCase, callbackResponse.getData());
-        verify(asylumCase, times(1)).write(SEARCH_POSTCODE, "A123 4BC");
-    }
-
-    @Test
-    void should_derive_postcode_from_aa_appellant_address() {
-
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(AA_APPELLANT_ADDRESS)).thenReturn(Optional.of(addressUk));
-        when(addressUk.getPostCode()).thenReturn(Optional.of("A123 4BC"));
-        when(asylumCase.read(AGE_ASSESSMENT, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
-        when(asylumCase.read(AA_APPELLANT_HAS_FIXED_ADDRESS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             derivePostcodeHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);


### PR DESCRIPTION
- Since the order of the screens (For Appellant details) is same, we will use the same fields for the non-AAA and AAA flows.
- Updated handlers, tests and functionalTestTemplate.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
