### PR TITLE
RIA-6433 Added handlers to remove age assessment data if different pa…

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-236-revocation-grounds.json
+++ b/src/functionalTest/resources/scenarios/RIA-236-revocation-grounds.json
@@ -11,6 +11,7 @@
         "replacements": {
           "legalRepresentativeEmailAddress": "{TEST_LAW_FIRM_ORG_SUCCESS_USERNAME}",
           "appealType": "revocationOfProtection",
+          "appealTypeForDisplay": "revocationOfProtection",
           "appealGroundsRevocation": {
             "values": [
               "revocationHumanitarianProtection",
@@ -29,6 +30,7 @@
       "template": "minimal-appeal-started.json",
       "replacements": {
         "appealType": "revocationOfProtection",
+        "appealTypeForDisplay": "revocationOfProtection",
         "appealGroundsForDisplay": [
           "revocationHumanitarianProtection",
           "revocationRefugeeConvention"

--- a/src/functionalTest/resources/scenarios/RIA-6433-change-litigation-friend-age-assessment-edit-appeal.json
+++ b/src/functionalTest/resources/scenarios/RIA-6433-change-litigation-friend-age-assessment-edit-appeal.json
@@ -1,0 +1,32 @@
+{
+  "description": "RIA-6433-change-litigation-friend-age-assessment-edit-appeal",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentativeOrgSuccess",
+    "input": {
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "legalRepresentativeEmailAddress": "{TEST_LAW_FIRM_ORG_SUCCESS_USERNAME}",
+        "template": "minimal-age-assessment-appeal-started.json",
+        "replacements": {
+          "litigationFriend": "No",
+          "litigationFriendGivenName": "Given name",
+          "litigationFriendFamilyName": "Family name"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-age-assessment-appeal-started.json",
+      "replacements": {
+        "appealType": "ageAssessment",
+        "litigationFriendGivenName": null,
+        "litigationFriendFamilyName": null
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6433-change-organisation-on-decision-letter-age-assessment-edit-appeal.json
+++ b/src/functionalTest/resources/scenarios/RIA-6433-change-organisation-on-decision-letter-age-assessment-edit-appeal.json
@@ -1,0 +1,30 @@
+{
+  "description": "RIA-6433-change-organisation-on-decision-letter-age-assessment-edit-appeal",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentativeOrgSuccess",
+    "input": {
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "legalRepresentativeEmailAddress": "{TEST_LAW_FIRM_ORG_SUCCESS_USERNAME}",
+        "template": "minimal-age-assessment-appeal-started.json",
+        "replacements": {
+          "organisationOnDecisionLetter": "nationalAgeAssessmentBoard"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-age-assessment-appeal-started.json",
+      "replacements": {
+        "appealType": "ageAssessment",
+        "organisationOnDecisionLetter": "nationalAgeAssessmentBoard",
+        "localAuthority": null
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6433-edit-appeal-type-preparer.json
+++ b/src/functionalTest/resources/scenarios/RIA-6433-edit-appeal-type-preparer.json
@@ -1,0 +1,28 @@
+{
+  "description": "RIA-6433 Set appealTypeForDisplay from appealType (not AAA). Post NABA release",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "id": 1234,
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "appealTypeForDisplay": null
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "appealTypeForDisplay": "protection"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/templates/minimal-age-assessment-appeal-started.json
+++ b/src/functionalTest/resources/templates/minimal-age-assessment-appeal-started.json
@@ -20,5 +20,7 @@
   "appealReferenceNumber": "DRAFT",
   "isOutOfCountryEnabled": "Yes",
   "appellantInUk": "Yes",
-  "ageAssessment": "Yes"
+  "ageAssessment": "Yes",
+  "organisationOnDecisionLetter": "localAuthority",
+  "localAuthority": "localAuth1"
 }

--- a/src/functionalTest/resources/templates/minimal-appeal-started.json
+++ b/src/functionalTest/resources/templates/minimal-appeal-started.json
@@ -18,6 +18,7 @@
   "wantsSms": "Text message",
   "mobileNumber": "07977111111",
   "appealType": "protection",
+  "appealTypeForDisplay": "protection",
   "appealGroundsProtection": {
     "values": [
       "refugeeConvention"

--- a/src/functionalTest/resources/templates/minimal-appeal-submitted.json
+++ b/src/functionalTest/resources/templates/minimal-appeal-submitted.json
@@ -18,6 +18,7 @@
   "wantsSms": "Text message",
   "mobileNumber": "07977111111",
   "appealType": "protection",
+  "appealTypeForDisplay": "protection",
   "appealGroundsProtection": {
     "values": [
       "refugeeConvention"

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1650,7 +1650,39 @@ public enum AsylumCaseFieldDefinition {
         "listingAvailableForAda", new TypeReference<YesOrNo>(){}),
 
     CALCULATED_HEARING_DATE(
-        "calculatedHearingDate", new TypeReference<String>(){});
+        "calculatedHearingDate", new TypeReference<String>(){}),
+
+    ORGANISATION_ON_DECISION_LETTER(
+            "organisationOnDecisionLetter", new TypeReference<String>(){}),
+
+    LOCAL_AUTHORITY(
+            "localAuthority", new TypeReference<String>(){}),
+    HSC_TRUST(
+            "hscTrust", new TypeReference<String>(){}),
+
+    LITIGATION_FRIEND(
+            "litigationFriend", new TypeReference<YesOrNo>(){}),
+
+    LITIGATION_FRIEND_GIVEN_NAME(
+            "litigationFriendGivenName", new TypeReference<String>(){}),
+
+    LITIGATION_FRIEND_FAMILY_NAME(
+            "litigationFriendFamilyName", new TypeReference<String>(){}),
+
+    LITIGATION_FRIEND_COMPANY(
+            "litigationFriendCompany", new TypeReference<String>(){}),
+
+    LITIGATION_FRIEND_CONTACT_PREFERENCE(
+            "litigationFriendContactPreference", new TypeReference<ContactPreference>(){}),
+
+    LITIGATION_FRIEND_EMAIL(
+            "litigationFriendEmail", new TypeReference<String>(){}),
+
+    LITIGATION_FRIEND_PHONE_NUMBER(
+            "litigationFriendPhoneNumber", new TypeReference<String>(){}),
+
+    DECISION_LETTER_REFERENCE_NUMBER(
+            "decisionLetterReferenceNumber", new TypeReference<String>(){});
 
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1657,6 +1657,7 @@ public enum AsylumCaseFieldDefinition {
 
     LOCAL_AUTHORITY(
             "localAuthority", new TypeReference<String>(){}),
+
     HSC_TRUST(
             "hscTrust", new TypeReference<String>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/OrganisationOnDecisionLetter.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/OrganisationOnDecisionLetter.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum OrganisationOnDecisionLetter {
+
+    LOCAL_AUTHORITY("localAuthority"),
+    NATIONAL_AGE_ASSESSMENT_BOARD("nationalAgeAssessmentBoard"),
+    HSC_TRUST("hscTrust");
+
+    @JsonValue
+    private final String id;
+
+    OrganisationOnDecisionLetter(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AgeAssessmentDataEditAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AgeAssessmentDataEditAppealHandler.java
@@ -66,21 +66,21 @@ public class AgeAssessmentDataEditAppealHandler implements PreSubmitCallbackHand
 
             //Clear all 'hscTrust' field
             if (organisationOnDecisionLetter.equals(OrganisationOnDecisionLetter.LOCAL_AUTHORITY.toString())) {
-                log.info("Clearing Prison details for an IRC Detention centre.");
+                log.info("Clearing HSC Trust data");
                 asylumCase.clear(HSC_TRUST);
             }
 
             //Clear all 'localAuthority' & 'hscTrust' fields
             if (organisationOnDecisionLetter
                     .equals(OrganisationOnDecisionLetter.NATIONAL_AGE_ASSESSMENT_BOARD.toString())) {
-                log.info("Clearing IRC details for a Prison Detention Centre");
+                log.info("Clearing HSC Trust and local authority data");
                 asylumCase.clear(LOCAL_AUTHORITY);
                 asylumCase.clear(HSC_TRUST);
             }
 
             //Clear all 'localAuthority' field
             if (organisationOnDecisionLetter.equals(OrganisationOnDecisionLetter.HSC_TRUST.toString())) {
-                log.info("Clearing IRC details for a Prison Detention Centre");
+                log.info("Clearing local authority data");
                 asylumCase.clear(LOCAL_AUTHORITY);
             }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AgeAssessmentDataEditAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AgeAssessmentDataEditAppealHandler.java
@@ -111,6 +111,7 @@ public class AgeAssessmentDataEditAppealHandler implements PreSubmitCallbackHand
             asylumCase.clear(HSC_TRUST);
             asylumCase.clear(DECISION_LETTER_REFERENCE_NUMBER);
             asylumCase.clear(DATE_ON_DECISION_LETTER);
+            asylumCase.clear(LITIGATION_FRIEND);
             clearLitigationFriendData(asylumCase);
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AgeAssessmentDataEditAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AgeAssessmentDataEditAppealHandler.java
@@ -1,0 +1,129 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AGE_ASSESSMENT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_ON_DECISION_LETTER;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DECISION_LETTER_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HSC_TRUST;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LITIGATION_FRIEND;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LITIGATION_FRIEND_COMPANY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LITIGATION_FRIEND_CONTACT_PREFERENCE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LITIGATION_FRIEND_EMAIL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LITIGATION_FRIEND_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LITIGATION_FRIEND_GIVEN_NAME;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LITIGATION_FRIEND_PHONE_NUMBER;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LOCAL_AUTHORITY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ORGANISATION_ON_DECISION_LETTER;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ContactPreference;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.OrganisationOnDecisionLetter;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Slf4j
+@Component
+public class AgeAssessmentDataEditAppealHandler implements PreSubmitCallbackHandler<AsylumCase> {
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                && callback.getEvent() == Event.EDIT_APPEAL);
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        Optional<YesOrNo> isAgeAssessmentAppeal = asylumCase.read(AGE_ASSESSMENT, YesOrNo.class);
+
+        if (isAgeAssessmentAppeal.equals(Optional.of(YES))) {
+            String organisationOnDecisionLetter = asylumCase.read(ORGANISATION_ON_DECISION_LETTER, String.class)
+                    .orElseThrow(() -> new RequiredFieldMissingException("Organisation on decision letter missing"));
+
+            //Clear all 'hscTrust' field
+            if (organisationOnDecisionLetter.equals(OrganisationOnDecisionLetter.LOCAL_AUTHORITY.toString())) {
+                log.info("Clearing Prison details for an IRC Detention centre.");
+                asylumCase.clear(HSC_TRUST);
+            }
+
+            //Clear all 'localAuthority' & 'hscTrust' fields
+            if (organisationOnDecisionLetter
+                    .equals(OrganisationOnDecisionLetter.NATIONAL_AGE_ASSESSMENT_BOARD.toString())) {
+                log.info("Clearing IRC details for a Prison Detention Centre");
+                asylumCase.clear(LOCAL_AUTHORITY);
+                asylumCase.clear(HSC_TRUST);
+            }
+
+            //Clear all 'localAuthority' field
+            if (organisationOnDecisionLetter.equals(OrganisationOnDecisionLetter.HSC_TRUST.toString())) {
+                log.info("Clearing IRC details for a Prison Detention Centre");
+                asylumCase.clear(LOCAL_AUTHORITY);
+            }
+
+            //Clear litigation friend data
+            if (asylumCase.read(LITIGATION_FRIEND, YesOrNo.class).orElse(NO).equals(NO)) {
+                clearLitigationFriendData(asylumCase);
+            }
+
+            //Clear litigation friend contact preference data
+            if (asylumCase.read(LITIGATION_FRIEND, YesOrNo.class).orElse(NO).equals(YES)) {
+                log.info("Clearing Litigation Friend Contact Preference");
+                asylumCase.read(LITIGATION_FRIEND_CONTACT_PREFERENCE, ContactPreference.class).ifPresent(
+                        contactPreference -> {
+                            if (contactPreference.equals(ContactPreference.WANTS_EMAIL)) {
+                                asylumCase.clear(LITIGATION_FRIEND_PHONE_NUMBER);
+                            } else {
+                                asylumCase.clear(LITIGATION_FRIEND_EMAIL);
+                            }
+                        }
+                );
+            }
+        }
+
+        //Clear all age assessment related data
+        if (isAgeAssessmentAppeal.equals(Optional.of(NO))) {
+            asylumCase.clear(ORGANISATION_ON_DECISION_LETTER);
+            asylumCase.clear(LOCAL_AUTHORITY);
+            asylumCase.clear(HSC_TRUST);
+            asylumCase.clear(DECISION_LETTER_REFERENCE_NUMBER);
+            asylumCase.clear(DATE_ON_DECISION_LETTER);
+            clearLitigationFriendData(asylumCase);
+        }
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    private void clearLitigationFriendData(AsylumCase asylumCase) {
+        log.info("Clearing Litigation Friend data");
+        asylumCase.clear(LITIGATION_FRIEND_GIVEN_NAME);
+        asylumCase.clear(LITIGATION_FRIEND_FAMILY_NAME);
+        asylumCase.clear(LITIGATION_FRIEND_COMPANY);
+        asylumCase.clear(LITIGATION_FRIEND_CONTACT_PREFERENCE);
+        asylumCase.clear(LITIGATION_FRIEND_EMAIL);
+        asylumCase.clear(LITIGATION_FRIEND_PHONE_NUMBER);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealTypeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealTypeHandler.java
@@ -63,8 +63,7 @@ public class AppealTypeHandler implements PreSubmitCallbackHandler<AsylumCase> {
         } else {
             // After release of NABA, front-end will populate APPEAL_TYPE_FOR_DISPLAY instead of APPEAL_TYPE
             // So in order to manage the FieldShowConditions we are mapping the APPEAL_TYPE to same as APPEAL_TYPE_FOR_DISPLAY
-            if (asylumCase.read(APPEAL_TYPE, AppealType.class).isEmpty()
-                && !HandlerUtils.isAipJourney(asylumCase)) {
+            if (!HandlerUtils.isAipJourney(asylumCase)) {
 
                 AppealTypeForDisplay appealTypeForDisplay = asylumCase
                     .read(APPEAL_TYPE_FOR_DISPLAY, AppealTypeForDisplay.class)

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealTypePreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealTypePreparer.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealTypeForDisplay;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealTypePreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealTypePreparer.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AGE_ASSESSMENT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE_FOR_DISPLAY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealTypeForDisplay;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class EditAppealTypePreparer implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
+               && callback.getEvent() == Event.EDIT_APPEAL;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        // After release of NABA, the pre-NABA cases will not have APPEAL_TYPE_FOR_DISPLAY populated, so when they get
+        // to select appeal type screen (via EditAppeal event), it will not be pre-populated. This preparer will
+        // make sure APPEAL_TYPE_FOR_DISPLAY is written into from APPEAL_TYPE.
+        YesOrNo ageAssessment = asylumCase.read(AGE_ASSESSMENT, YesOrNo.class).orElse(NO);
+
+        if (ageAssessment.equals(NO)
+                && asylumCase.read(APPEAL_TYPE_FOR_DISPLAY, AppealTypeForDisplay.class).isEmpty()) {
+            AppealType appealType = asylumCase.read(APPEAL_TYPE, AppealType.class)
+                    .orElseThrow(() -> new IllegalStateException("Appeal type not present"));
+            asylumCase.write(APPEAL_TYPE_FOR_DISPLAY, AppealTypeForDisplay.from(appealType.getValue()));
+        }
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/OrganisationOnDecisionLetterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/OrganisationOnDecisionLetterTest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class OrganisationOnDecisionLetterTest {
+
+    @Test
+    void has_correct_values() {
+        assertEquals("localAuthority", OrganisationOnDecisionLetter.LOCAL_AUTHORITY.toString());
+        assertEquals("nationalAgeAssessmentBoard", OrganisationOnDecisionLetter.NATIONAL_AGE_ASSESSMENT_BOARD.toString());
+        assertEquals("hscTrust", OrganisationOnDecisionLetter.HSC_TRUST.toString());
+    }
+
+    @Test
+    void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
+        assertEquals(3, OrganisationOnDecisionLetter.values().length);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AgeAssessmentDataEditAppealHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AgeAssessmentDataEditAppealHandlerTest.java
@@ -126,6 +126,7 @@ public class AgeAssessmentDataEditAppealHandlerTest {
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.HSC_TRUST);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.DECISION_LETTER_REFERENCE_NUMBER);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.DATE_ON_DECISION_LETTER);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_GIVEN_NAME);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_FAMILY_NAME);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_COMPANY);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AgeAssessmentDataEditAppealHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AgeAssessmentDataEditAppealHandlerTest.java
@@ -1,0 +1,182 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ContactPreference;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.OrganisationOnDecisionLetter;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class AgeAssessmentDataEditAppealHandlerTest {
+
+    AgeAssessmentDataEditAppealHandler ageAssessmentDataEditAppealHandler;
+
+    @Mock Callback<AsylumCase> callback;
+    @Mock CaseDetails<AsylumCase> caseDetails;
+    @Mock AsylumCase asylumCase;
+
+    @BeforeEach
+    void setUp() {
+        ageAssessmentDataEditAppealHandler = new AgeAssessmentDataEditAppealHandler();
+        when(callback.getEvent()).thenReturn(Event.EDIT_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(AsylumCaseFieldDefinition.AGE_ASSESSMENT, YesOrNo.class))
+            .thenReturn(Optional.of(YesOrNo.YES));
+    }
+
+    @Test
+    void should_remove_hsc_trust_details_if_now_local_authority() {
+        when(asylumCase.read(AsylumCaseFieldDefinition.ORGANISATION_ON_DECISION_LETTER, String.class))
+            .thenReturn(Optional.of(OrganisationOnDecisionLetter.LOCAL_AUTHORITY.toString()));
+        PreSubmitCallbackResponse<AsylumCase> response = ageAssessmentDataEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+        assertNotNull(response);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.HSC_TRUST);
+    }
+
+    @Test
+    void should_remove_hsc_trust_details_if_now_national_age_assessment_board() {
+        when(asylumCase.read(AsylumCaseFieldDefinition.ORGANISATION_ON_DECISION_LETTER, String.class))
+                .thenReturn(Optional.of(OrganisationOnDecisionLetter.NATIONAL_AGE_ASSESSMENT_BOARD.toString()));
+        PreSubmitCallbackResponse<AsylumCase> response = ageAssessmentDataEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+        assertNotNull(response);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LOCAL_AUTHORITY);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.HSC_TRUST);
+    }
+
+    @Test
+    void should_remove_hsc_trust_details_if_now_hsc_trust() {
+        when(asylumCase.read(AsylumCaseFieldDefinition.ORGANISATION_ON_DECISION_LETTER, String.class))
+                .thenReturn(Optional.of(OrganisationOnDecisionLetter.HSC_TRUST.toString()));
+        PreSubmitCallbackResponse<AsylumCase> response = ageAssessmentDataEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+        assertNotNull(response);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LOCAL_AUTHORITY);
+    }
+
+    @Test
+    void should_remove_litigation_friend_details_if_now_no_litigation_friend() {
+        when(asylumCase.read(AsylumCaseFieldDefinition.ORGANISATION_ON_DECISION_LETTER, String.class))
+                .thenReturn(Optional.of(OrganisationOnDecisionLetter.LOCAL_AUTHORITY.toString()));
+        when(asylumCase.read(AsylumCaseFieldDefinition.LITIGATION_FRIEND, YesOrNo.class))
+                .thenReturn(Optional.of(YesOrNo.NO));
+        PreSubmitCallbackResponse<AsylumCase> response = ageAssessmentDataEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+        assertNotNull(response);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_GIVEN_NAME);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_FAMILY_NAME);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_COMPANY);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_CONTACT_PREFERENCE);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_PHONE_NUMBER);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_EMAIL);
+    }
+
+    @Test
+    void should_remove_litigation_friend_phone_number_if_now_wants_email() {
+        when(asylumCase.read(AsylumCaseFieldDefinition.ORGANISATION_ON_DECISION_LETTER, String.class))
+                .thenReturn(Optional.of(OrganisationOnDecisionLetter.LOCAL_AUTHORITY.toString()));
+        when(asylumCase.read(AsylumCaseFieldDefinition.LITIGATION_FRIEND, YesOrNo.class))
+                .thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(AsylumCaseFieldDefinition.LITIGATION_FRIEND_CONTACT_PREFERENCE, ContactPreference.class))
+                .thenReturn(Optional.of(ContactPreference.WANTS_EMAIL));
+        PreSubmitCallbackResponse<AsylumCase> response = ageAssessmentDataEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+        assertNotNull(response);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_PHONE_NUMBER);
+    }
+
+    @Test
+    void should_remove_litigation_friend_phone_number_if_now_wants_sms() {
+        when(asylumCase.read(AsylumCaseFieldDefinition.ORGANISATION_ON_DECISION_LETTER, String.class))
+                .thenReturn(Optional.of(OrganisationOnDecisionLetter.LOCAL_AUTHORITY.toString()));
+        when(asylumCase.read(AsylumCaseFieldDefinition.LITIGATION_FRIEND, YesOrNo.class))
+                .thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(AsylumCaseFieldDefinition.LITIGATION_FRIEND_CONTACT_PREFERENCE, ContactPreference.class))
+                .thenReturn(Optional.of(ContactPreference.WANTS_SMS));
+        PreSubmitCallbackResponse<AsylumCase> response = ageAssessmentDataEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+        assertNotNull(response);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_EMAIL);
+    }
+
+    @Test
+    void should_remove_all_age_assessment_details_if_now_not_age_assessment() {
+        when(asylumCase.read(AsylumCaseFieldDefinition.AGE_ASSESSMENT, YesOrNo.class))
+                .thenReturn(Optional.of(YesOrNo.NO));
+        PreSubmitCallbackResponse<AsylumCase> response = ageAssessmentDataEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+        assertNotNull(response);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.ORGANISATION_ON_DECISION_LETTER);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LOCAL_AUTHORITY);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.HSC_TRUST);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.DECISION_LETTER_REFERENCE_NUMBER);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.DATE_ON_DECISION_LETTER);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_GIVEN_NAME);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_FAMILY_NAME);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_COMPANY);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_CONTACT_PREFERENCE);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_PHONE_NUMBER);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LITIGATION_FRIEND_EMAIL);
+    }
+
+    @Test
+    void handling_should_throw_if_detention_facility_not_available() {
+        assertThatThrownBy(() -> ageAssessmentDataEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Organisation on decision letter missing")
+            .isExactlyInstanceOf(RequiredFieldMissingException.class);
+    }
+
+    @Test
+    void check_canHandle() {
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            for (PreSubmitCallbackStage stage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = ageAssessmentDataEditAppealHandler.canHandle(stage, callback);
+                if ((event == Event.EDIT_APPEAL) && (stage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT)) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+        }
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+        assertThatThrownBy(() -> ageAssessmentDataEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        assertThatThrownBy(() -> ageAssessmentDataEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void handling_should_throw_if_argument_null() {
+        assertThatThrownBy(() -> ageAssessmentDataEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> ageAssessmentDataEditAppealHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealTypeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealTypeHandlerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -16,6 +17,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.EDIT_APPEAL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.START_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority.EARLIEST;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
@@ -59,6 +61,11 @@ public class AppealTypeHandlerTest {
     }
 
     @Test
+    void set_to_earliest() {
+        assertThat(appealTypeHandler.getDispatchPriority()).isEqualTo(EARLIEST);
+    }
+
+    @Test
     void should_set_appealType_to_ag_if_ageAssessment_yes() {
         when(callback.getEvent()).thenReturn(START_APPEAL);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
@@ -82,7 +89,6 @@ public class AppealTypeHandlerTest {
         when(asylumCase.read(AGE_ASSESSMENT, YesOrNo.class)).thenReturn(Optional.of(NO));
         when(asylumCase.read(APPEAL_TYPE_FOR_DISPLAY, AppealTypeForDisplay.class))
             .thenReturn(Optional.of(AppealTypeForDisplay.HU));
-        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.empty());
         when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.empty());
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
@@ -102,7 +108,6 @@ public class AppealTypeHandlerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(asylumCase.read(AGE_ASSESSMENT, YesOrNo.class)).thenReturn(Optional.of(NO));
-        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.empty());
         when(asylumCase.read(APPEAL_TYPE_FOR_DISPLAY, AppealTypeForDisplay.class))
             .thenReturn(Optional.empty());
         when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.empty());

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealTypePreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealTypePreparerTest.java
@@ -1,5 +1,23 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AGE_ASSESSMENT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE_FOR_DISPLAY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.EDIT_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
+
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,25 +33,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.EDIT_APPEAL;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.START_APPEAL;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority.EARLIEST;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealTypePreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealTypePreparerTest.java
@@ -1,0 +1,164 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealTypeForDisplay;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.EDIT_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.START_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority.EARLIEST;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class EditAppealTypePreparerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+
+    private EditAppealTypePreparer editAppealTypePreparer;
+
+    @BeforeEach
+    void setup() {
+        editAppealTypePreparer = new EditAppealTypePreparer();
+    }
+
+    @Test
+    void should_set_appealTypeForDisplay_if_ageAssessment_no_and_appealTypeForDisplay_is_empty() {
+        when(callback.getEvent()).thenReturn(EDIT_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(AGE_ASSESSMENT, YesOrNo.class)).thenReturn(Optional.of(NO));
+        when(asylumCase.read(APPEAL_TYPE_FOR_DISPLAY, AppealTypeForDisplay.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class))
+                .thenReturn(Optional.of(AppealType.RP));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            editAppealTypePreparer.handle(ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).write(APPEAL_TYPE_FOR_DISPLAY,
+                AppealTypeForDisplay.from(AppealType.RP.getValue()));
+    }
+
+    @Test
+    void should_not_set_appealTypeForDisplay_if_ageAssessment_no_and_appealTypeForDisplay_is_not_empty() {
+        when(callback.getEvent()).thenReturn(EDIT_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(AGE_ASSESSMENT, YesOrNo.class)).thenReturn(Optional.of(NO));
+        when(asylumCase.read(APPEAL_TYPE_FOR_DISPLAY, AppealTypeForDisplay.class))
+                .thenReturn(Optional.of(AppealTypeForDisplay.RP));
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class))
+                .thenReturn(Optional.of(AppealType.RP));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                editAppealTypePreparer.handle(ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(0)).write(APPEAL_TYPE_FOR_DISPLAY,
+                AppealTypeForDisplay.from(AppealType.RP.getValue()));
+    }
+
+    @Test
+    void should_throw_error_if_appealType_and_appealTypeForDisplay_are_both_empty() {
+        when(callback.getEvent()).thenReturn(EDIT_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(AGE_ASSESSMENT, YesOrNo.class)).thenReturn(Optional.of(NO));
+        when(asylumCase.read(APPEAL_TYPE_FOR_DISPLAY, AppealTypeForDisplay.class))
+            .thenReturn(Optional.empty());
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> editAppealTypePreparer.handle(ABOUT_TO_SUBMIT, callback))
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = editAppealTypePreparer.canHandle(callbackStage, callback);
+
+                if (callbackStage == ABOUT_TO_START && event == EDIT_APPEAL) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> editAppealTypePreparer.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> editAppealTypePreparer.canHandle(ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> editAppealTypePreparer.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> editAppealTypePreparer.handle(ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void handler_throws_error_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> editAppealTypePreparer.handle(ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6433


### Change description ###
Added handlers to remove age assessment data if different path is chosen (non AAA)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
