### PR TITLE
RIA-6611 RIA-6573 Restrict notifications for endAppealAutomatically o…

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -96,5 +96,8 @@
     <suppress>
         <cve>CVE-2021-37533</cve>
         <cve>CVE-2021-4277</cve>
+        <cve>CVE-2021-4235</cve>
+        <cve>CVE-2022-3064</cve>
+        <cve>CVE-2022-45143</cve>
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
 import com.google.common.collect.Lists;
 import java.util.List;
@@ -12,6 +13,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.PaymentStatus;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.NotificationSender;
 
@@ -40,10 +42,10 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
         requireNonNull(callbackStage, "callbackStage must not be null");
         requireNonNull(callback, "callback must not be null");
         return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-            && getEventsToHandle().contains(callback.getEvent());
+            && getEventsToHandle(callback).contains(callback.getEvent());
     }
 
-    private List<Event> getEventsToHandle() {
+    private List<Event> getEventsToHandle(Callback<AsylumCase> callback) {
         List<Event> eventsToHandle = Lists.newArrayList(
             Event.SUBMIT_APPEAL,
             Event.SEND_DIRECTION,
@@ -110,11 +112,13 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
             Event.MANAGE_FEE_UPDATE,
             Event.REQUEST_FEE_REMISSION,
             Event.RECORD_OUT_OF_TIME_DECISION,
-            Event.END_APPEAL_AUTOMATICALLY,
             Event.UPDATE_PAYMENT_STATUS
         );
         if (!isSaveAndContinueEnabled) {
             eventsToHandle.add(Event.BUILD_CASE);
+        }
+        if (!isPaid(callback)) {
+            eventsToHandle.add(Event.END_APPEAL_AUTOMATICALLY);
         }
         return eventsToHandle;
     }
@@ -130,5 +134,12 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
         AsylumCase asylumCaseWithNotificationMarker = notificationSender.send(callback);
 
         return new PreSubmitCallbackResponse<>(asylumCaseWithNotificationMarker);
+    }
+
+    private boolean isPaid(Callback<AsylumCase> callback) {
+        return callback.getCaseDetails().getCaseData()
+            .read(PAYMENT_STATUS, PaymentStatus.class)
+            .map(paymentStatus -> paymentStatus.equals(PaymentStatus.PAID))
+            .orElse(false);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6611](https://tools.hmcts.net/jira/browse/RIA-6611)
[RIA-6573](https://tools.hmcts.net/jira/browse/RIA-6573)


### Change description ###
- Notifications are triggered solely based on what event is executing, so even when the "endAppealAutomatically" event results in the appeal not ending (because it got paid) the notification for ending the appeal gets sent anyway. This fix makes the notification be triggered only if the event is "endAppealAutomatically" AND the `paymentStatus` is not `Paid`.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
