### PR TITLE
RIA-6421 clearing detained fields when editing to non-detained

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetainedEditAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetainedEditAppealHandler.java
@@ -1,15 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_ADDRESS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_HAS_FIXED_ADDRESS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_IN_DETENTION;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_OUT_OF_COUNTRY_ADDRESS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CONTACT_PREFERENCE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.EMAIL;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HAS_CORRESPONDENCE_ADDRESS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.MOBILE_NUMBER;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SEARCH_POSTCODE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
@@ -64,6 +56,24 @@ public class DetainedEditAppealHandler implements PreSubmitCallbackHandler<Asylu
             asylumCase.clear(CONTACT_PREFERENCE);
             asylumCase.clear(EMAIL);
             asylumCase.clear(MOBILE_NUMBER);
+        } else if (appellantInDetention.equals(NO)) {
+            // Clear all 'detained' fields when switching to non-detained case
+            asylumCase.clear(DETENTION_STATUS);
+            asylumCase.clear(DETENTION_FACILITY);
+
+            asylumCase.clear(PRISON_NAME);
+            asylumCase.clear(PRISON_NOMS);
+            asylumCase.clear(CUSTODIAL_SENTENCE);
+            asylumCase.clear(DATE_CUSTODIAL_SENTENCE);
+
+            asylumCase.clear(OTHER_DETENTION_FACILITY_NAME);
+
+            asylumCase.clear(IRC_NAME);
+
+            asylumCase.clear(HAS_PENDING_BAIL_APPLICATIONS);
+            asylumCase.clear(BAIL_APPLICATION_NUMBER);
+
+            asylumCase.clear(IS_ACCELERATED_DETAINED_APPEAL);
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionFacilityEditAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionFacilityEditAppealHandler.java
@@ -14,6 +14,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.DetentionFacility.IRC;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.DetentionFacility.OTHER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.DetentionFacility.PRISON;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
@@ -27,6 +28,8 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallb
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+import java.util.List;
 
 @Slf4j
 @Component
@@ -42,8 +45,10 @@ public class DetentionFacilityEditAppealHandler implements PreSubmitCallbackHand
         requireNonNull(callbackStage, "callbackStage must not be null");
         requireNonNull(callback, "callback must not be null");
 
+        Event event = callback.getEvent();
+
         return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-            && callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT;
+            && List.of(EDIT_APPEAL, EDIT_APPEAL_AFTER_SUBMIT).contains(event);
     }
 
     public PreSubmitCallbackResponse<AsylumCase> handle(

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetainedEditAppealHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetainedEditAppealHandlerTest.java
@@ -38,12 +38,12 @@ public class DetainedEditAppealHandlerTest {
         when(callback.getEvent()).thenReturn(Event.EDIT_APPEAL);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(AsylumCaseFieldDefinition.APPELLANT_IN_DETENTION, YesOrNo.class))
-            .thenReturn(Optional.of(YesOrNo.YES));
     }
 
     @Test
     void should_remove_appellant_address_and_contact_info() {
+        when(asylumCase.read(AsylumCaseFieldDefinition.APPELLANT_IN_DETENTION, YesOrNo.class))
+                .thenReturn(Optional.of(YesOrNo.YES));
         PreSubmitCallbackResponse<AsylumCase> response = detainedEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
         assertNotNull(response);
         verify(asylumCase, times(1))
@@ -57,6 +57,29 @@ public class DetainedEditAppealHandlerTest {
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.CONTACT_PREFERENCE);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.EMAIL);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.MOBILE_NUMBER);
+    }
+
+    @Test
+    void should_remove_detained_fields_when_editing_to_non_detained() {
+        when(asylumCase.read(AsylumCaseFieldDefinition.APPELLANT_IN_DETENTION, YesOrNo.class))
+                .thenReturn(Optional.of(YesOrNo.NO));
+        PreSubmitCallbackResponse<AsylumCase> response = detainedEditAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+        assertNotNull(response);
+        verify(asylumCase, times(1))
+                .clear(AsylumCaseFieldDefinition.DETENTION_STATUS);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.DETENTION_FACILITY);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.PRISON_NAME);
+        verify(asylumCase, times(1))
+                .clear(AsylumCaseFieldDefinition.PRISON_NOMS);
+        verify(asylumCase, times(1))
+                .clear(AsylumCaseFieldDefinition.CUSTODIAL_SENTENCE);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.OTHER_DETENTION_FACILITY_NAME);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.IRC_NAME);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.HAS_PENDING_BAIL_APPLICATIONS);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.BAIL_APPLICATION_NUMBER);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL);
+
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionFacilityEditAppealHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionFacilityEditAppealHandlerTest.java
@@ -7,7 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,7 +118,9 @@ public class DetentionFacilityEditAppealHandlerTest {
             when(callback.getEvent()).thenReturn(event);
             for (PreSubmitCallbackStage stage : PreSubmitCallbackStage.values()) {
                 boolean canHandle = detentionFacilityEditAppealHandler.canHandle(stage, callback);
-                if ((event == Event.EDIT_APPEAL_AFTER_SUBMIT) && (stage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT)) {
+                if (stage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                        && List.of(EDIT_APPEAL, EDIT_APPEAL_AFTER_SUBMIT).contains(callback.getEvent()))
+                {
                     assertTrue(canHandle);
                 } else {
                     assertFalse(canHandle);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6421

### Change description ###

- Added editAppeal event to DetentionFacilityEditAppealHandler so that when you edit between IRC, Prison or Other the other old fields are cleared for editAppeal event as well as editAppealAfterSubmit
- Added detained fields being cleared in DetainedEditAppealHandler when editing appellantInDetention from Yes to No and checked that caseData had removed these fields

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
