### PR TITLE
RIA-6604: Added handlers for Ada suitability review event

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6604-ada-suitability-confirmation-suitable.json
+++ b/src/functionalTest/resources/scenarios/RIA-6604-ada-suitability-confirmation-suitable.json
@@ -1,0 +1,27 @@
+{
+  "description": "RIA-6604 ada suitability review confirmation - suitable",
+  "request": {
+    "uri": "/asylum/ccdSubmitted",
+    "credentials": "Judge",
+    "input": {
+      "eventId": "adaSuitabilityReview",
+      "state": "respondentReview",
+      "id": 1234,
+      "caseData": {
+        "template": "minimal-ada-appeal-submitted.json",
+        "replacements": {
+          "suitabilityReviewJudge": "Judge x",
+          "suitabilityReviewDecision": "suitable",
+          "suitabilityReviewReason": "Reason1"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "confirmation": {
+      "header": "# Appeal determined suitable to continue as ADA",
+      "body": "#### What happens next\n\nAll parties have been notified. The Accelerated Detained Appeal Suitability Decision is available to view in the documents tab.<br>"
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6604-ada-suitability-confirmation-unsuitable.json
+++ b/src/functionalTest/resources/scenarios/RIA-6604-ada-suitability-confirmation-unsuitable.json
@@ -1,0 +1,32 @@
+{
+  "description": "RIA-6604 ada suitability review confirmation - unsuitable",
+  "request": {
+    "uri": "/asylum/ccdSubmitted",
+    "credentials": "Judge",
+    "input": {
+      "eventId": "adaSuitabilityReview",
+      "state": "respondentReview",
+      "id": 1234,
+      "caseData": {
+        "template": "minimal-ada-appeal-submitted.json",
+        "replacements": {
+          "suitabilityReviewJudge": "Judge x",
+          "suitabilityReviewDecision": "unsuitable",
+          "suitabilityReviewReason": "Reason1"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "replacements": {
+      "suitabilityReviewJudge": "Judge x",
+      "suitabilityReviewDecision": "unsuitable",
+      "suitabilityReviewReason": "Reason1"
+    },
+    "confirmation": {
+      "header": "# Appeal determined unsuitable to continue as ADA",
+      "body": "#### What happens next\n\nAll parties have been notified. The Accelerated Detained Appeal Suitability Decision is available to view in the documents tab.<br>\n\nYou must [transfer this appeal out of the accelerated detained appeal process.](/Overview)"
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6604-ada-suitability-retrigger-errors.json
+++ b/src/functionalTest/resources/scenarios/RIA-6604-ada-suitability-retrigger-errors.json
@@ -1,0 +1,27 @@
+{
+  "description": "RIA-6604 ada suitability re-trigger - return error message",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "Judge",
+    "input": {
+      "eventId": "adaSuitabilityReview",
+      "state": "respondentReview",
+      "id": 1234,
+      "caseData": {
+        "template": "minimal-ada-appeal-submitted.json",
+        "replacements": {
+          "suitabilityReviewJudge": "Judge x",
+          "suitabilityReviewDecision": "unsuitable",
+          "suitabilityReviewReason": "Reason1"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": ["ADA suitability has already been determined for this appeal."],
+    "caseData": {
+      "template": "minimal-ada-appeal-submitted.json"
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AdaSuitabilityReviewDecision.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AdaSuitabilityReviewDecision.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum AdaSuitabilityReviewDecision {
+
+    SUITABLE("suitable"),
+    UNSUITABLE("unsuitable");
+
+    @JsonValue
+    private final String value;
+
+    AdaSuitabilityReviewDecision(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1683,7 +1683,10 @@ public enum AsylumCaseFieldDefinition {
             "litigationFriendPhoneNumber", new TypeReference<String>(){}),
 
     DECISION_LETTER_REFERENCE_NUMBER(
-            "decisionLetterReferenceNumber", new TypeReference<String>(){});
+            "decisionLetterReferenceNumber", new TypeReference<String>(){}),
+
+    SUITABILITY_REVIEW_DECISION(
+            "suitabilityReviewDecision", new TypeReference<AdaSuitabilityReviewDecision>(){});
 
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -118,7 +118,7 @@ public enum Event {
     GENERATE_SERVICE_REQUEST("generateServiceRequest"),
 
     PIP_ACTIVATION("pipActivation"),
-
+    ADA_SUITABILITY_REVIEW("adaSuitabilityReview"),
     @JsonEnumDefaultValue
     UNKNOWN("unknown");
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AdaSuitabilityReviewConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AdaSuitabilityReviewConfirmation.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AdaSuitabilityReviewDecision;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+@Component
+public class AdaSuitabilityReviewConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    @Override
+    public boolean canHandle(
+        Callback<AsylumCase> callback
+    ) {
+
+        requireNonNull(callback, "callback must not be null");
+        return callback.getEvent() == Event.ADA_SUITABILITY_REVIEW;
+    }
+
+    @Override
+    public PostSubmitCallbackResponse handle(
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+        final AdaSuitabilityReviewDecision decision =
+            asylumCase.read(AsylumCaseFieldDefinition.SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)
+                .orElseThrow(() -> new RequiredFieldMissingException("ADA suitability review decision unavailable."));
+
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+
+        if (decision.equals(AdaSuitabilityReviewDecision.SUITABLE)) {
+            postSubmitResponse.setConfirmationHeader("# Appeal determined suitable to continue as ADA");
+            postSubmitResponse.setConfirmationBody(
+                "#### What happens next\n\n"
+                    + "All parties have been notified. The Accelerated Detained Appeal Suitability Decision is available to view in the documents tab.<br>"
+            );
+        } else {
+            postSubmitResponse.setConfirmationHeader("# Appeal determined unsuitable to continue as ADA");
+            postSubmitResponse.setConfirmationBody(
+                "#### What happens next\n\n"
+                    + "All parties have been notified. The Accelerated Detained Appeal Suitability Decision is available to view in the documents tab.<br>"
+                + "\n\nYou must [transfer this appeal out of the accelerated detained appeal process.](/Overview)"
+            );
+        }
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdaSuitabilityReviewPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdaSuitabilityReviewPreparer.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SUITABILITY_REVIEW_DECISION;
+
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AdaSuitabilityReviewDecision;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class AdaSuitabilityReviewPreparer implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
+               && callback.getEvent() == Event.ADA_SUITABILITY_REVIEW;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
+
+        Optional<AdaSuitabilityReviewDecision> mayBeDecision = asylumCase.read(SUITABILITY_REVIEW_DECISION);
+        if (mayBeDecision.isPresent()) {
+            response.addError("ADA suitability has already been determined for this appeal.");
+        }
+
+        return response;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -362,6 +362,7 @@ security:
       - "generateUpperTribunalBundle"
       - "asyncStitchingComplete"
       - "markAddendumEvidenceAsReviewed"
+      - "adaSuitabilityReview"
     caseworker-ia-system:
       - "requestHearingRequirementsFeature"
       - "moveToPaymentPending"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -116,10 +116,12 @@ class EventTest {
         assertEquals("endAppealAutomatically", Event.END_APPEAL_AUTOMATICALLY.toString());
         assertEquals("generateServiceRequest", Event.GENERATE_SERVICE_REQUEST.toString());
         assertEquals("pipActivation", Event.PIP_ACTIVATION.toString());
+        assertEquals("adaSuitabilityReview", Event.ADA_SUITABILITY_REVIEW.toString());
+
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(113, Event.values().length);
+        assertEquals(114, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AdaSuitabilityReviewConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AdaSuitabilityReviewConfirmationTest.java
@@ -1,0 +1,132 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SUITABILITY_REVIEW_DECISION;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AdaSuitabilityReviewDecision;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class AdaSuitabilityReviewConfirmationTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+
+    private AdaSuitabilityReviewConfirmation adaSuitabilityReviewConfirmation = new AdaSuitabilityReviewConfirmation();
+
+    @ParameterizedTest
+    @EnumSource(value = AdaSuitabilityReviewDecision.class, names = {"SUITABLE", "UNSUITABLE"})
+    void should_return_confirmation(AdaSuitabilityReviewDecision decision) {
+
+        when(callback.getEvent()).thenReturn(Event.ADA_SUITABILITY_REVIEW);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)).thenReturn(Optional.of(decision));
+
+        PostSubmitCallbackResponse callbackResponse =
+            adaSuitabilityReviewConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        if (decision.equals(AdaSuitabilityReviewDecision.SUITABLE)) {
+            assertThat(
+                callbackResponse.getConfirmationHeader().get())
+                .contains("# Appeal determined suitable to continue as ADA");
+
+            assertThat(
+                callbackResponse.getConfirmationBody().get())
+                .contains("All parties have been notified. The Accelerated Detained Appeal Suitability Decision is available to view in the documents tab.<br>");
+        }
+        if (decision.equals(AdaSuitabilityReviewDecision.UNSUITABLE)) {
+            assertThat(
+                callbackResponse.getConfirmationHeader().get())
+                .contains("# Appeal determined unsuitable to continue as ADA");
+
+            assertThat(
+                callbackResponse.getConfirmationBody().get())
+                .contains("All parties have been notified. The Accelerated Detained Appeal Suitability Decision is available to view in the documents tab.<br>");
+        }
+
+    }
+
+    @Test
+    void handling_should_throw_if_decision_is_missing() {
+
+        when(callback.getEvent()).thenReturn(Event.ADA_SUITABILITY_REVIEW);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adaSuitabilityReviewConfirmation.handle(callback))
+            .hasMessage("ADA suitability review decision unavailable.")
+            .isExactlyInstanceOf(RequiredFieldMissingException.class);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> adaSuitabilityReviewConfirmation.handle(callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            boolean canHandle = adaSuitabilityReviewConfirmation.canHandle(callback);
+
+            if (event == Event.ADA_SUITABILITY_REVIEW) {
+
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> adaSuitabilityReviewConfirmation.canHandle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> adaSuitabilityReviewConfirmation.handle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdaSuitabilityReviewPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdaSuitabilityReviewPreparerTest.java
@@ -1,0 +1,107 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SUITABILITY_REVIEW_DECISION;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AdaSuitabilityReviewDecision;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class AdaSuitabilityReviewPreparerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+
+    private AdaSuitabilityReviewPreparer adaSuitabilityReviewPreparer = new AdaSuitabilityReviewPreparer();
+
+    @ParameterizedTest
+    @EnumSource(value = AdaSuitabilityReviewDecision.class, names = {"SUITABLE", "UNSUITABLE"})
+    void should_return_confirmation(AdaSuitabilityReviewDecision decision) {
+
+        when(callback.getEvent()).thenReturn(Event.ADA_SUITABILITY_REVIEW);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION)).thenReturn(Optional.of(decision));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            adaSuitabilityReviewPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getErrors().size() > 0);
+        assertTrue(callbackResponse.getErrors().contains("ADA suitability has already been determined for this appeal."));
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> adaSuitabilityReviewPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> adaSuitabilityReviewPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+            for (PreSubmitCallbackStage stage: PreSubmitCallbackStage.values()) {
+                when(callback.getEvent()).thenReturn(event);
+                boolean canHandle = adaSuitabilityReviewPreparer.canHandle(stage, callback);
+
+                if (event == Event.ADA_SUITABILITY_REVIEW && stage == PreSubmitCallbackStage.ABOUT_TO_START) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> adaSuitabilityReviewPreparer.canHandle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> adaSuitabilityReviewPreparer.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> adaSuitabilityReviewPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> adaSuitabilityReviewPreparer.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+
+}


### PR DESCRIPTION
- New event and related fields.
- Preparer to add error when Judges try to re-trigger the event in respondentReview state.
- Confirmation handler to add header and body depending on decision.
- Functional tests and unit tests.

<html>
<body>
<!--StartFragment--><p>Testing notes</p>
<div class="table-wrap">


Appeal Type | ADASuitability Event available after Upload Appeal Response | Decision | PostState | Event available post decision | Error message on re-trigger
-- | -- | -- | -- | -- | --
Detained - ADA (DC) | Yes | Suitable | prepareForHearing | No | Not applicable
Detained - ADA (DC) | Yes | Unsuitable | respondentReview | Yes | Yes
Detained - nonADA (AG) | No | Not applicable | Not applicable | Not applicable | Not applicable
Non-Detained - nonAAA (DC) | No | Not applicable | Not applicable | Not applicable | Not applicable


</div><!--EndFragment-->
</body>
</html>

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
