### PR TITLE
RIA-6572 Wire AIP into the cancelling of automatic end of appeal

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/CancelAutomaticEndAppealPaidConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/CancelAutomaticEndAppealPaidConfirmation.java
@@ -1,7 +1,8 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AUTOMATIC_END_APPEAL_TIMED_EVENT_ID;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PAYMENT_STATUS;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -14,6 +15,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.PaymentStatus;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.Scheduler;
 import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.model.TimedEvent;
@@ -46,8 +48,12 @@ public class CancelAutomaticEndAppealPaidConfirmation implements PostSubmitCallb
                 .orElse(PaymentStatus.PAYMENT_PENDING);
         Optional<String> timedEventId = asylumCase.read(AUTOMATIC_END_APPEAL_TIMED_EVENT_ID);
 
+        Event qualifyingEvent = HandlerUtils.isAipJourney(asylumCase)
+            ? Event.PAYMENT_APPEAL
+            : Event.UPDATE_PAYMENT_STATUS;
+
         return  timedEventServiceEnabled
-                && callback.getEvent() == Event.UPDATE_PAYMENT_STATUS
+                && callback.getEvent() == qualifyingEvent
                 && paymentStatus == PaymentStatus.PAID
                 && timedEventId.isPresent();
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6572](https://tools.hmcts.net/jira/browse/RIA-6572)


### Change description ###
- An AIP payment doesn't seem to use the `updatePaymentStatus` event to update the payment status, but it's resolved within the `paymentAppeal` event, which needs to be the qualifying event for the AIP journey for the CancelAutomaticEndAppealPaidConfirmation handler to update the trigger schedule to 100 years


Example below:
- 15:03:35: case 1674572435640710 is submitted, `endAppealAutomatically` event scheduled for 2 minutes later (15:05:35)
- 15:03:58: case 1674572435640710 gets paid, `endAppealAutomatically` event re-scheduled for ~100 years later (15:05:35)
- nothing gets logged on ia-case-api between 15:03 and 15:06, when the `endAppealAutomatically` event was first supposed to be triggered (but wasn't, because of it being successfully rescheduled for a century later)

![image](https://user-images.githubusercontent.com/56549133/214339937-b9df0281-b824-4aa8-b55f-3985e0c81880.png)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
