### PR TITLE
RIA-6586 Transfer out of ada event

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6586-transfer-out-of-ada-in-appeal-submitted-state.json
+++ b/src/functionalTest/resources/scenarios/RIA-6586-transfer-out-of-ada-in-appeal-submitted-state.json
@@ -1,0 +1,33 @@
+{
+  "description": "RIA-6586 Transfer out of ADA in appeal submitted state TCW",
+  "launchDarklyKey": "remissions-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "transferOutOfAda",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "harmondsworth",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "decisionLetterReceivedDate": "{$TODAY-3}"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "hearingCentre": "harmondsworth",
+        "isAcceleratedDetainedAppeal": "No",
+        "ageAssessment": "No",
+        "hasTransferredOutOfAda": "Yes"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6586-transfer-out-of-ada-in-appeal-submitted-state.json
+++ b/src/functionalTest/resources/scenarios/RIA-6586-transfer-out-of-ada-in-appeal-submitted-state.json
@@ -25,7 +25,6 @@
       "replacements": {
         "hearingCentre": "harmondsworth",
         "isAcceleratedDetainedAppeal": "No",
-        "ageAssessment": "No",
         "hasTransferredOutOfAda": "Yes"
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-6604-ada-suitability-confirmation-unsuitable.json
+++ b/src/functionalTest/resources/scenarios/RIA-6604-ada-suitability-confirmation-unsuitable.json
@@ -26,7 +26,7 @@
     },
     "confirmation": {
       "header": "# Appeal determined unsuitable to continue as ADA",
-      "body": "#### What happens next\n\nAll parties have been notified. The Accelerated Detained Appeal Suitability Decision is available to view in the documents tab.<br>\n\nYou must [transfer this appeal out of the accelerated detained appeal process.](/Overview)"
+      "body": "#### What happens next\n\nAll parties have been notified. The Accelerated Detained Appeal Suitability Decision is available to view in the documents tab.<br>\n\nYou must [transfer this appeal out of the accelerated detained appeal process.](/case/IA/Asylum/1234/trigger/transferOutOfAda)."
     }
   }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1690,7 +1690,12 @@ public enum AsylumCaseFieldDefinition {
             "decisionLetterReferenceNumber", new TypeReference<String>(){}),
 
     SUITABILITY_REVIEW_DECISION(
-            "suitabilityReviewDecision", new TypeReference<AdaSuitabilityReviewDecision>(){});
+            "suitabilityReviewDecision", new TypeReference<AdaSuitabilityReviewDecision>(){}),
+    HAS_TRANSFERRED_OUT_OF_ADA(
+            "hasTransferredOutOfAda", new TypeReference<YesOrNo>(){}),
+    TRANSFER_OUT_OF_ADA_DATE(
+            "transferOutOfAdaDate", new TypeReference<String>(){}),
+    ;
 
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -116,6 +116,7 @@ public enum Event {
     MARK_PAYMENT_REQUEST_SENT("markPaymentRequestSent"),
     END_APPEAL_AUTOMATICALLY("endAppealAutomatically"),
     GENERATE_SERVICE_REQUEST("generateServiceRequest"),
+    TRANSFER_OUT_OF_ADA("transferOutOfAda"),
 
     PIP_ACTIVATION("pipActivation"),
     ADA_SUITABILITY_REVIEW("adaSuitabilityReview"),

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AdaSuitabilityReviewConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AdaSuitabilityReviewConfirmation.java
@@ -36,6 +36,8 @@ public class AdaSuitabilityReviewConfirmation implements PostSubmitCallbackHandl
         final AdaSuitabilityReviewDecision decision =
             asylumCase.read(AsylumCaseFieldDefinition.SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)
                 .orElseThrow(() -> new RequiredFieldMissingException("ADA suitability review decision unavailable."));
+        String transferOutOfAdaUrl = "/trigger/transferOutOfAda";
+
 
         PostSubmitCallbackResponse postSubmitResponse =
             new PostSubmitCallbackResponse();
@@ -51,7 +53,8 @@ public class AdaSuitabilityReviewConfirmation implements PostSubmitCallbackHandl
             postSubmitResponse.setConfirmationBody(
                 "#### What happens next\n\n"
                     + "All parties have been notified. The Accelerated Detained Appeal Suitability Decision is available to view in the documents tab.<br>"
-                + "\n\nYou must [transfer this appeal out of the accelerated detained appeal process.](/Overview)"
+                + "\n\nYou must [transfer this appeal out of the accelerated detained appeal process.](/case/IA/Asylum/"
+                    + callback.getCaseDetails().getId() + transferOutOfAdaUrl + ")."
             );
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/TransferOutOfAdaConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/TransferOutOfAdaConfirmation.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+@Component
+public class TransferOutOfAdaConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    @Override
+    public boolean canHandle(
+            Callback<AsylumCase> callback
+    ) {
+
+        requireNonNull(callback, "callback must not be null");
+        return callback.getEvent() == Event.TRANSFER_OUT_OF_ADA;
+    }
+
+    @Override
+    public PostSubmitCallbackResponse handle(
+            Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+                new PostSubmitCallbackResponse();
+
+        postSubmitResponse.setConfirmationHeader("# You've transferred the case out of ADA");
+        postSubmitResponse.setConfirmationBody(
+                "#### What happens next\n\n"
+                        + "All parties will be notified that this is no longer an accelerated detained appeal.\n\n"
+                        + "A Legal Officer will review the case and decide next steps."
+        );
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandler.java
@@ -54,7 +54,6 @@ public class TransferOutOfAdaHandler implements PreSubmitCallbackHandler<AsylumC
         if (isAcceleratedDetainedAppeal.equals(Optional.of(YesOrNo.YES))) {
 
             asylumCase.write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.NO);
-            asylumCase.write(AGE_ASSESSMENT, YesOrNo.NO);
             asylumCase.write(DETENTION_STATUS, DetentionStatus.DETAINED);
             asylumCase.write(TRANSFER_OUT_OF_ADA_DATE, dateProvider.now().toString());
             asylumCase.write(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.YES);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandler.java
@@ -1,0 +1,67 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.*;
+
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DetentionStatus;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class TransferOutOfAdaHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final DateProvider dateProvider;
+
+    public TransferOutOfAdaHandler(DateProvider dateProvider) {
+        this.dateProvider = dateProvider;
+    }
+
+    public boolean canHandle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                && callback.getEvent() == TRANSFER_OUT_OF_ADA;
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback) {
+
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+                callback
+                        .getCaseDetails()
+                        .getCaseData();
+
+        Optional<YesOrNo> isAcceleratedDetainedAppeal = asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class);
+
+        if (isAcceleratedDetainedAppeal.equals(Optional.of(YesOrNo.YES))) {
+
+            asylumCase.write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.NO);
+            asylumCase.write(AGE_ASSESSMENT, YesOrNo.NO);
+            asylumCase.write(DETENTION_STATUS, DetentionStatus.DETAINED);
+            asylumCase.write(TRANSFER_OUT_OF_ADA_DATE, dateProvider.now().toString());
+            asylumCase.write(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.YES);
+        }
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -271,6 +271,7 @@ security:
       - "markEvidenceAsReviewed"
       - "completeClarifyQuestions"
       - "markAddendumEvidenceAsReviewed"
+      - "transferOutOfAda"
     caseworker-ia-admofficer:
       - "listCma"
       - "listCase"
@@ -364,6 +365,7 @@ security:
       - "asyncStitchingComplete"
       - "markAddendumEvidenceAsReviewed"
       - "adaSuitabilityReview"
+      - "transferOutOfAda"
     caseworker-ia-system:
       - "requestHearingRequirementsFeature"
       - "moveToPaymentPending"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -117,11 +117,12 @@ class EventTest {
         assertEquals("generateServiceRequest", Event.GENERATE_SERVICE_REQUEST.toString());
         assertEquals("pipActivation", Event.PIP_ACTIVATION.toString());
         assertEquals("adaSuitabilityReview", Event.ADA_SUITABILITY_REVIEW.toString());
+        assertEquals("transferOutOfAda", Event.TRANSFER_OUT_OF_ADA.toString());
 
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(114, Event.values().length);
+        assertEquals(115, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AdaSuitabilityReviewConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AdaSuitabilityReviewConfirmationTest.java
@@ -12,8 +12,6 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.iacaseapi.domain.RequiredFieldMissingException;
@@ -38,40 +36,60 @@ class AdaSuitabilityReviewConfirmationTest {
 
     private AdaSuitabilityReviewConfirmation adaSuitabilityReviewConfirmation = new AdaSuitabilityReviewConfirmation();
 
-    @ParameterizedTest
-    @EnumSource(value = AdaSuitabilityReviewDecision.class, names = {"SUITABLE", "UNSUITABLE"})
-    void should_return_confirmation(AdaSuitabilityReviewDecision decision) {
+    @Test
+    void should_return_confirmation_for_suitable() {
 
         when(callback.getEvent()).thenReturn(Event.ADA_SUITABILITY_REVIEW);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)).thenReturn(Optional.of(decision));
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)).thenReturn(Optional.of(AdaSuitabilityReviewDecision.SUITABLE));
 
         PostSubmitCallbackResponse callbackResponse =
-            adaSuitabilityReviewConfirmation.handle(callback);
+                adaSuitabilityReviewConfirmation.handle(callback);
 
         assertNotNull(callbackResponse);
         assertTrue(callbackResponse.getConfirmationHeader().isPresent());
         assertTrue(callbackResponse.getConfirmationBody().isPresent());
 
-        if (decision.equals(AdaSuitabilityReviewDecision.SUITABLE)) {
-            assertThat(
+        assertThat(
                 callbackResponse.getConfirmationHeader().get())
                 .contains("# Appeal determined suitable to continue as ADA");
 
-            assertThat(
+        assertThat(
                 callbackResponse.getConfirmationBody().get())
                 .contains("All parties have been notified. The Accelerated Detained Appeal Suitability Decision is available to view in the documents tab.<br>");
-        }
-        if (decision.equals(AdaSuitabilityReviewDecision.UNSUITABLE)) {
-            assertThat(
+    }
+
+    @Test
+    void should_return_confirmation_for_unsuitable() {
+
+        long caseId = 1234;
+
+        when(callback.getEvent()).thenReturn(Event.ADA_SUITABILITY_REVIEW);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)).thenReturn(Optional.of(AdaSuitabilityReviewDecision.UNSUITABLE));
+        when(caseDetails.getId()).thenReturn(caseId);
+
+        PostSubmitCallbackResponse callbackResponse =
+                adaSuitabilityReviewConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        assertThat(
                 callbackResponse.getConfirmationHeader().get())
                 .contains("# Appeal determined unsuitable to continue as ADA");
 
-            assertThat(
+        assertThat(
                 callbackResponse.getConfirmationBody().get())
                 .contains("All parties have been notified. The Accelerated Detained Appeal Suitability Decision is available to view in the documents tab.<br>");
-        }
+
+        assertThat(
+                callbackResponse.getConfirmationBody().get())
+                .contains("You must [transfer this appeal out of the accelerated detained appeal process.]"
+                        + "(/case/IA/Asylum/" + caseId + "/trigger/transferOutOfAda)");
 
     }
 
@@ -84,16 +102,16 @@ class AdaSuitabilityReviewConfirmationTest {
         when(asylumCase.read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> adaSuitabilityReviewConfirmation.handle(callback))
-            .hasMessage("ADA suitability review decision unavailable.")
-            .isExactlyInstanceOf(RequiredFieldMissingException.class);
+                .hasMessage("ADA suitability review decision unavailable.")
+                .isExactlyInstanceOf(RequiredFieldMissingException.class);
     }
 
     @Test
     void handling_should_throw_if_cannot_actually_handle() {
 
         assertThatThrownBy(() -> adaSuitabilityReviewConfirmation.handle(callback))
-            .hasMessage("Cannot handle callback")
-            .isExactlyInstanceOf(IllegalStateException.class);
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
     }
 
     @Test
@@ -120,12 +138,12 @@ class AdaSuitabilityReviewConfirmationTest {
     void should_not_allow_null_arguments() {
 
         assertThatThrownBy(() -> adaSuitabilityReviewConfirmation.canHandle(null))
-            .hasMessage("callback must not be null")
-            .isExactlyInstanceOf(NullPointerException.class);
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> adaSuitabilityReviewConfirmation.handle(null))
-            .hasMessage("callback must not be null")
-            .isExactlyInstanceOf(NullPointerException.class);
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
     }
 
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/TransferOutOfAdaConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/TransferOutOfAdaConfirmationTest.java
@@ -1,0 +1,103 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class TransferOutOfAdaConfirmationTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+
+    private TransferOutOfAdaConfirmation transferOutOfAdaConfirmation = new TransferOutOfAdaConfirmation();
+
+    @Test
+    void should_return_confirmation_for_transferring_out_of_ada() {
+
+        when(callback.getEvent()).thenReturn(Event.TRANSFER_OUT_OF_ADA);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        PostSubmitCallbackResponse callbackResponse =
+                transferOutOfAdaConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        assertThat(
+                callbackResponse.getConfirmationHeader().get())
+                .contains("# You've transferred the case out of ADA");
+
+        assertThat(
+                callbackResponse.getConfirmationBody().get())
+                .contains("#### What happens next\n\n"
+                        + "All parties will be notified that this is no longer an accelerated detained appeal.\n\n"
+                        + "A Legal Officer will review the case and decide next steps.");
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> transferOutOfAdaConfirmation.handle(callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            boolean canHandle = transferOutOfAdaConfirmation.canHandle(callback);
+
+            if (event == Event.TRANSFER_OUT_OF_ADA) {
+
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> transferOutOfAdaConfirmation.canHandle(null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> transferOutOfAdaConfirmation.handle(null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandlerTest.java
@@ -62,7 +62,6 @@ class TransferOutOfAdaHandlerTest {
         assertEquals(asylumCase, callbackResponse.getData());
 
         verify(asylumCase).write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.NO);
-        verify(asylumCase).write(AGE_ASSESSMENT, YesOrNo.NO);
         verify(asylumCase).write(DETENTION_STATUS, DetentionStatus.DETAINED);
         verify(asylumCase).write(TRANSFER_OUT_OF_ADA_DATE, dateProvider.now().toString());
         verify(asylumCase).write(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.YES);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandlerTest.java
@@ -1,0 +1,119 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DetentionStatus;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class TransferOutOfAdaHandlerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private DateProvider dateProvider;
+
+    private TransferOutOfAdaHandler transferOutOfAdaHandler;
+
+    private LocalDate date = LocalDate.now();
+
+    @BeforeEach
+    public void setup() {
+
+        when(dateProvider.now()).thenReturn(date);
+        transferOutOfAdaHandler = new TransferOutOfAdaHandler(dateProvider);
+    }
+
+    @Test
+    void transferring_from_ada_to_non_ada_and_updating_case_data() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(callback.getEvent()).thenReturn(Event.TRANSFER_OUT_OF_ADA);
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                transferOutOfAdaHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase).write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.NO);
+        verify(asylumCase).write(AGE_ASSESSMENT, YesOrNo.NO);
+        verify(asylumCase).write(DETENTION_STATUS, DetentionStatus.DETAINED);
+        verify(asylumCase).write(TRANSFER_OUT_OF_ADA_DATE, dateProvider.now().toString());
+        verify(asylumCase).write(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.YES);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        assertThatThrownBy(
+                () -> transferOutOfAdaHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = transferOutOfAdaHandler.canHandle(callbackStage, callback);
+                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                        && ((callback.getEvent() == Event.TRANSFER_OUT_OF_ADA))) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> transferOutOfAdaHandler.canHandle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(
+                () -> transferOutOfAdaHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> transferOutOfAdaHandler.handle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> transferOutOfAdaHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6586

### Change description ###

- Updated link to event in adaSuitability confirmation screen
- Added functional test for moving out of ADA in appeal submitted state, edited adaSuitability Unsuitable functional test with new confirmation link to event
- New confirmation screen after completing 'transferOutOfAda' event
- Handler to update caseData values and flag
- TCW and Judge authorisation to the event in application.yaml
- New and updated unit tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
