### PR TITLE
RIA-6662 Progress bars for appeals transferred out of ADA

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1713,6 +1713,9 @@ public enum AsylumCaseFieldDefinition {
     ADA_SUFFIX(
         "adaSuffix", new TypeReference<String>(){}),
 
+    HEARING_REQ_SUFFIX(
+        "hearingReqSuffix", new TypeReference<String>(){}),
+
     INTERNAL_APPELLANT_EMAIL(
             "internalAppellantEmail", new TypeReference<String>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -111,6 +112,14 @@ public class DraftHearingRequirementsHandler implements PreSubmitCallbackHandler
         if (isAcceleratedDetainedAppeal) {
             asylumCase.clear(ADA_HEARING_REQUIREMENTS_SUBMITTABLE);
             asylumCase.write(ADA_HEARING_REQUIREMENTS_TO_REVIEW, YesOrNo.YES);
+        }
+
+        boolean appealTransferredOutOfAda = asylumCase.read(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class)
+            .map(yesOrNo -> yesOrNo.equals(YES))
+            .orElse(false);
+
+        if (appealTransferredOutOfAda) {
+            asylumCase.write(ADA_EDIT_LISTING_AVAILABLE, YES);
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListCasePreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListCasePreparer.java
@@ -71,6 +71,24 @@ public class ListCasePreparer implements PreSubmitCallbackHandler<AsylumCase> {
             });
         }
 
+        boolean hasTransferredOutOfAda = asylumCase.read(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class)
+            .map(field -> field.equals(YesOrNo.YES))
+            .orElse(false);
+
+        boolean listCaseWasTriggeredInAdaJourney = asylumCase.read(CURRENT_HEARING_DETAILS_VISIBLE, YesOrNo.class)
+            .map(field -> field.equals(YesOrNo.YES))
+            .orElse(false);
+
+        if (callback.getEvent().equals(Event.LIST_CASE)
+            && hasTransferredOutOfAda
+            && listCaseWasTriggeredInAdaJourney) {
+            // direct user to use EDIT_CASE_LISTING instead of LIST_CASE if the appeal was transferred out of ADA after listing
+
+            PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
+            response.addError("Case was listed before being transferred out of ADA. Edit case listing instead.");
+            return response;
+        }
+
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ProgressBarAdaSuffixAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ProgressBarAdaSuffixAppender.java
@@ -2,13 +2,17 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ADA_SUFFIX;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_REQ_SUFFIX;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SUBMIT_HEARING_REQUIREMENTS_AVAILABLE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
+import java.util.Set;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
@@ -18,6 +22,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 public class ProgressBarAdaSuffixAppender implements PreSubmitCallbackHandler<AsylumCase> {
 
     private static final String ADA_SUFFIX_STRING = "_ada";
+    private static final String AFTER_HEARING_REQ = "_afterHearingReq";
 
     public boolean canHandle(
         PreSubmitCallbackStage callbackStage,
@@ -27,7 +32,12 @@ public class ProgressBarAdaSuffixAppender implements PreSubmitCallbackHandler<As
         requireNonNull(callback, "callback must not be null");
 
         return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-               && callback.getEvent() == Event.SUBMIT_APPEAL;
+               && Set.of(SUBMIT_APPEAL, TRANSFER_OUT_OF_ADA).contains(callback.getEvent());
+    }
+
+    @Override
+    public DispatchPriority getDispatchPriority() {
+        return DispatchPriority.LATEST;
     }
 
     public PreSubmitCallbackResponse<AsylumCase> handle(
@@ -44,8 +54,20 @@ public class ProgressBarAdaSuffixAppender implements PreSubmitCallbackHandler<As
             .ifPresent(isAda -> {
                 if (isAda.equals(YES)) {
                     asylumCase.write(ADA_SUFFIX, ADA_SUFFIX_STRING);
+                } else {
+                    asylumCase.write(ADA_SUFFIX, "");
                 }
             });
+
+        // Set suffix to append to URLs of images when appeal transfers out of ADA after submitHearingRequirements
+        if (callback.getEvent().equals(TRANSFER_OUT_OF_ADA)) {
+            asylumCase.read(SUBMIT_HEARING_REQUIREMENTS_AVAILABLE, YesOrNo.class)
+                .ifPresent(yesOrNo -> {
+                    if (yesOrNo.equals(YES)) {
+                        asylumCase.write(HEARING_REQ_SUFFIX, AFTER_HEARING_REQ);
+                    }
+                });
+        }
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandler.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 
 import java.util.Optional;
 import org.springframework.stereotype.Component;
@@ -53,10 +54,19 @@ public class TransferOutOfAdaHandler implements PreSubmitCallbackHandler<AsylumC
 
         if (isAcceleratedDetainedAppeal.equals(Optional.of(YesOrNo.YES))) {
 
-            asylumCase.write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.NO);
+            asylumCase.write(IS_ACCELERATED_DETAINED_APPEAL, NO);
             asylumCase.write(DETENTION_STATUS, DetentionStatus.DETAINED);
             asylumCase.write(TRANSFER_OUT_OF_ADA_DATE, dateProvider.now().toString());
             asylumCase.write(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.YES);
+
+            asylumCase.write(LISTING_AVAILABLE_FOR_ADA, NO);
+
+            asylumCase.write(ADA_HEARING_ADJUSTMENTS_UPDATABLE, NO);
+            asylumCase.write(ADA_HEARING_REQUIREMENTS_UPDATABLE, NO);
+            asylumCase.write(ADA_HEARING_REQUIREMENTS_TO_REVIEW, NO);
+            asylumCase.write(ADA_HEARING_REQUIREMENTS_SUBMITTABLE, NO);
+            asylumCase.write(ADA_EDIT_LISTING_AVAILABLE, NO);
+
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandlerTest.java
@@ -209,6 +209,18 @@ class DraftHearingRequirementsHandlerTest {
     }
 
     @Test
+    void should_set_flag_for_editing_listing_if_transferring_out_of_ada() {
+
+        when(asylumCase.read(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            draftHearingRequirementsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        verify(asylumCase, times(1))
+            .write(eq(ADA_EDIT_LISTING_AVAILABLE), eq(YesOrNo.YES));
+    }
+
+    @Test
     void handling_should_throw_if_cannot_actually_handle() {
 
         assertThatThrownBy(

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListCasePreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListCasePreparerTest.java
@@ -194,6 +194,24 @@ class ListCasePreparerTest {
     }
 
     @Test
+    void should_set_error_when_transferred_out_of_ada_after_listing() {
+
+        when(asylumCase.read(AsylumCaseFieldDefinition.HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class))
+            .thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(AsylumCaseFieldDefinition.CURRENT_HEARING_DETAILS_VISIBLE, YesOrNo.class))
+            .thenReturn(Optional.of(YesOrNo.YES));
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            listCasePreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+        Assertions.assertThat(callbackResponse.getErrors()).hasSize(1);
+        Assertions.assertThat(callbackResponse.getErrors()).containsExactlyInAnyOrder(
+            "Case was listed before being transferred out of ADA. Edit case listing instead.");
+    }
+
+
+    @Test
     void should_work_for_old_flow_when_requirements_not_captured() {
 
         when(asylumCase.read(AsylumCaseFieldDefinition.HEARING_CENTRE))

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ProgressBarAdaSuffixAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ProgressBarAdaSuffixAppenderTest.java
@@ -11,13 +11,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ADA_SUFFIX;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_REQ_SUFFIX;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SUBMIT_HEARING_REQUIREMENTS_AVAILABLE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.SUBMIT_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.TRANSFER_OUT_OF_ADA;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,7 +68,7 @@ class ProgressBarAdaSuffixAppenderTest {
     @Test
     void should_write_ada_suffix_if_appeal_is_ada() {
 
-        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        when(callback.getEvent()).thenReturn(SUBMIT_APPEAL);
         when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YES));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
@@ -77,16 +82,19 @@ class ProgressBarAdaSuffixAppenderTest {
 
     private static Stream<Arguments> noAda() {
         return Stream.of(
-            Arguments.of(Optional.empty()),
-            Arguments.of(Optional.of(NO))
+            Arguments.of(Optional.of(NO), SUBMIT_APPEAL),
+            Arguments.of(Optional.of(NO), TRANSFER_OUT_OF_ADA),
+            // isAcceleratedDetainedAppeal is always set, but empty optional scenario is tested for code coverage
+            Arguments.of(Optional.empty(), SUBMIT_APPEAL),
+            Arguments.of(Optional.empty(), TRANSFER_OUT_OF_ADA)
         );
     }
 
     @ParameterizedTest
     @MethodSource("noAda")
-    void should_not_write_ada_suffix_if_appeal_is_not_ada(Optional<YesOrNo> isAcceleratedDetainedAppealOpt) {
+    void should_write_blank_ada_suffix_if_appeal_is_not_ada(Optional<YesOrNo> isAcceleratedDetainedAppealOpt, Event event) {
 
-        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        when(callback.getEvent()).thenReturn(event);
         when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(isAcceleratedDetainedAppealOpt);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
@@ -95,7 +103,50 @@ class ProgressBarAdaSuffixAppenderTest {
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
 
-        verify(asylumCase, never()).write(ADA_SUFFIX, "_ada");
+        if (isAcceleratedDetainedAppealOpt.isPresent()) {
+            verify(asylumCase, times(1)).write(ADA_SUFFIX, "");
+        } else {
+            verify(asylumCase, never()).write(ADA_SUFFIX, "_ada");
+        }
+
+    }
+
+    @Test
+    void should_write_suffix_for_out_of_ada_appeals_after_hearing_requirements() {
+
+        when(callback.getEvent()).thenReturn(TRANSFER_OUT_OF_ADA);
+        when(asylumCase.read(SUBMIT_HEARING_REQUIREMENTS_AVAILABLE, YesOrNo.class)).thenReturn(Optional.of(YES));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            progressBarAdaSuffixAppender.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).write(HEARING_REQ_SUFFIX, "_afterHearingReq");
+    }
+
+    private static Stream<Arguments> noSubmitHearingRequirements() {
+        return Stream.of(
+            Arguments.of(Optional.empty()),
+            Arguments.of(Optional.of(NO))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("noSubmitHearingRequirements")
+    void should_not_write_suffix_for_out_of_ada_appeals_after_hearing_requirements(Optional<YesOrNo> submitHearingRequirementsAvailable) {
+
+        when(callback.getEvent()).thenReturn(TRANSFER_OUT_OF_ADA);
+        when(asylumCase.read(SUBMIT_HEARING_REQUIREMENTS_AVAILABLE, YesOrNo.class)).thenReturn(submitHearingRequirementsAvailable);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            progressBarAdaSuffixAppender.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, never()).write(HEARING_REQ_SUFFIX, "_afterHearingReq");
     }
 
     @Test
@@ -109,8 +160,8 @@ class ProgressBarAdaSuffixAppenderTest {
 
                 boolean canHandle = progressBarAdaSuffixAppender.canHandle(callbackStage, callback);
 
-                if (callback.getEvent() == Event.SUBMIT_APPEAL
-                    && callbackStage == ABOUT_TO_SUBMIT) {
+                if (Set.of(SUBMIT_APPEAL, TRANSFER_OUT_OF_ADA).contains(event)
+                         && callbackStage == ABOUT_TO_SUBMIT) {
 
                     assertTrue(canHandle);
                 } else {

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandlerTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 
 import java.time.LocalDate;
 import java.util.Optional;

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandlerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -65,6 +66,13 @@ class TransferOutOfAdaHandlerTest {
         verify(asylumCase).write(DETENTION_STATUS, DetentionStatus.DETAINED);
         verify(asylumCase).write(TRANSFER_OUT_OF_ADA_DATE, dateProvider.now().toString());
         verify(asylumCase).write(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.YES);
+
+        verify(asylumCase).write(LISTING_AVAILABLE_FOR_ADA, YesOrNo.NO);
+        verify(asylumCase).write(ADA_HEARING_ADJUSTMENTS_UPDATABLE, YesOrNo.NO);
+        verify(asylumCase).write(ADA_HEARING_REQUIREMENTS_UPDATABLE, YesOrNo.NO);
+        verify(asylumCase).write(ADA_HEARING_REQUIREMENTS_TO_REVIEW, YesOrNo.NO);
+        verify(asylumCase).write(ADA_HEARING_REQUIREMENTS_SUBMITTABLE, YesOrNo.NO);
+        verify(asylumCase).write(ADA_EDIT_LISTING_AVAILABLE, YesOrNo.NO);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6662](https://tools.hmcts.net/jira/browse/RIA-6662)


### Change description ###
- Six flag fields from the ADA journey reset to `NO`
- `adaSuffix` gets set to `"_ada"` when case is ADA and set to `""` when case transfers out of ADA

The below are changes to the logic I've made to allow myself to progress the case, but I have no acceptance criteria to go by:
- UI error added to prevent user from triggering `LIST_CASE` after the case has been listed (redirecting the user to use `EDIT_CASE_LISTING` instead
- Added flag suffix to show a different progress bar when the case transferred out of ADA but has submitted hearing requirements already


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
