### PR TITLE
RIA-6585: Mark appeal as ADA event

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6585-mark-appeal-as-ada-in-appeal-submitted-state-admin.json
+++ b/src/functionalTest/resources/scenarios/RIA-6585-mark-appeal-as-ada-in-appeal-submitted-state-admin.json
@@ -1,0 +1,37 @@
+{
+  "description": "RIA-6585 Mark appeal as ADA in appeal submitted state Admin",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "eventId": "markAppealAsAda",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "harmondsworth",
+          "isAcceleratedDetainedAppeal": "No",
+          "appellantInDetention": "Yes",
+          "appealType": "protection",
+          "markAppealAsAdaExplanation": "Some explanation"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "hearingCentre": "harmondsworth",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "appellantInDetention": "Yes",
+        "appealType": "protection",
+        "reasonAppealMarkedAsAda": "Some explanation",
+        "dateMarkedAsAda": "{$TODAY}",
+        "adaSuffix": "_ada"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6585-mark-appeal-as-ada-in-appeal-submitted-state-tcw.json
+++ b/src/functionalTest/resources/scenarios/RIA-6585-mark-appeal-as-ada-in-appeal-submitted-state-tcw.json
@@ -1,0 +1,37 @@
+{
+  "description": "RIA-6585 Mark appeal as ADA in appeal submitted state TCW",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "markAppealAsAda",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "hearingCentre": "harmondsworth",
+          "isAcceleratedDetainedAppeal": "No",
+          "appellantInDetention": "Yes",
+          "appealType": "protection",
+          "markAppealAsAdaExplanation": "Some explanation"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "hearingCentre": "harmondsworth",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "appellantInDetention": "Yes",
+        "appealType": "protection",
+        "reasonAppealMarkedAsAda": "Some explanation",
+        "dateMarkedAsAda": "{$TODAY}",
+        "adaSuffix": "_ada"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1717,7 +1717,14 @@ public enum AsylumCaseFieldDefinition {
             "internalAppellantEmail", new TypeReference<String>(){}),
 
     INTERNAL_APPELLANT_MOBILE_NUMBER(
-            "internalAppellantMobileNumber", new TypeReference<String>(){});
+            "internalAppellantMobileNumber", new TypeReference<String>(){}),
+
+    DATE_MARKED_AS_ADA(
+            "dateMarkedAsAda", new TypeReference<String>(){}),
+    MARK_APPEAL_AS_ADA_EXPLANATION(
+        "markAppealAsAdaExplanation", new TypeReference<String>(){}),
+    REASON_APPEAL_MARKED_AS_ADA(
+        "reasonAppealMarkedAsAda", new TypeReference<String>(){});
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -117,6 +117,7 @@ public enum Event {
     END_APPEAL_AUTOMATICALLY("endAppealAutomatically"),
     GENERATE_SERVICE_REQUEST("generateServiceRequest"),
     TRANSFER_OUT_OF_ADA("transferOutOfAda"),
+    MARK_APPEAL_AS_ADA("markAppealAsAda"),
 
     PIP_ACTIVATION("pipActivation"),
     ADA_SUITABILITY_REVIEW("adaSuitabilityReview"),

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtils.java
@@ -45,4 +45,8 @@ public class HandlerUtils {
     public static boolean isAppellantInDetention(AsylumCase asylumCase) {
         return (asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).orElse(YesOrNo.NO) == YesOrNo.YES;
     }
+
+    public static String getAdaSuffix() {
+        return "_ada";
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/MarkAppealAsAdaConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/MarkAppealAsAdaConfirmation.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+@Component
+public class MarkAppealAsAdaConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    @Override
+    public boolean canHandle(
+            Callback<AsylumCase> callback
+    ) {
+
+        requireNonNull(callback, "callback must not be null");
+        return callback.getEvent() == Event.MARK_APPEAL_AS_ADA;
+    }
+
+    @Override
+    public PostSubmitCallbackResponse handle(
+            Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+                new PostSubmitCallbackResponse();
+
+        postSubmitResponse.setConfirmationHeader("# You have marked the appeal as ADA");
+        postSubmitResponse.setConfirmationBody(
+                "#### What happens next\n\nAll parties will be notified that the appeal has been marked an accelerated detained appeal."
+        );
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAppealAsAdaHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAppealAsAdaHandler.java
@@ -1,0 +1,77 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ADA_SUFFIX;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_MARKED_AS_ADA;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DETENTION_STATUS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.MARK_APPEAL_AS_ADA_EXPLANATION;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REASON_APPEAL_MARKED_AS_ADA;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.MARK_APPEAL_AS_ADA;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DetentionStatus;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class MarkAppealAsAdaHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final DateProvider dateProvider;
+
+    public MarkAppealAsAdaHandler(DateProvider dateProvider) {
+        this.dateProvider = dateProvider;
+    }
+
+    public boolean canHandle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                && callback.getEvent() == MARK_APPEAL_AS_ADA;
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback) {
+
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+                callback
+                        .getCaseDetails()
+                        .getCaseData();
+
+        if (HandlerUtils.isAppellantInDetention(asylumCase)
+            && !(HandlerUtils.isAcceleratedDetainedAppeal(asylumCase) || HandlerUtils.isAgeAssessmentAppeal(asylumCase))) {
+
+            String markAppealAsAdaReason = asylumCase.read(MARK_APPEAL_AS_ADA_EXPLANATION, String.class).orElse(null);
+
+            requireNonNull(markAppealAsAdaReason, "Explain why this appeal is being marked an accelerated detained appeal is required");
+
+            asylumCase.write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.YES);
+            asylumCase.write(DETENTION_STATUS, DetentionStatus.ACCELERATED);
+            asylumCase.write(DATE_MARKED_AS_ADA, dateProvider.now().toString());
+            asylumCase.write(REASON_APPEAL_MARKED_AS_ADA, markAppealAsAdaReason);
+            asylumCase.write(ADA_SUFFIX, HandlerUtils.getAdaSuffix());
+
+            asylumCase.clear(MARK_APPEAL_AS_ADA_EXPLANATION);
+        }
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ProgressBarAdaSuffixAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ProgressBarAdaSuffixAppender.java
@@ -2,8 +2,6 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ADA_SUFFIX;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
@@ -11,7 +9,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
@@ -40,12 +38,9 @@ public class ProgressBarAdaSuffixAppender implements PreSubmitCallbackHandler<As
 
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
-        asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)
-            .ifPresent(isAda -> {
-                if (isAda.equals(YES)) {
-                    asylumCase.write(ADA_SUFFIX, ADA_SUFFIX_STRING);
-                }
-            });
+        if (HandlerUtils.isAcceleratedDetainedAppeal(asylumCase)) {
+            asylumCase.write(ADA_SUFFIX, HandlerUtils.getAdaSuffix());
+        }
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -274,6 +274,7 @@ security:
       - "markAddendumEvidenceAsReviewed"
       - "markAppealPaid"
       - "transferOutOfAda"
+      - "markAppealAsAda"
     caseworker-ia-admofficer:
       - "startAppeal"
       - "listCma"
@@ -304,6 +305,7 @@ security:
       - "asyncStitchingComplete"
       - "markPaymentRequestSent"
       - "editAppealAfterSubmit"
+      - "markAppealAsAda"
     caseworker-ia-homeofficeapc:
       - "uploadHomeOfficeBundle"
       - "uploadAdditionalEvidenceHomeOffice"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -118,11 +118,12 @@ class EventTest {
         assertEquals("pipActivation", Event.PIP_ACTIVATION.toString());
         assertEquals("adaSuitabilityReview", Event.ADA_SUITABILITY_REVIEW.toString());
         assertEquals("transferOutOfAda", Event.TRANSFER_OUT_OF_ADA.toString());
+        assertEquals("markAppealAsAda", Event.MARK_APPEAL_AS_ADA.toString());
 
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(115, Event.values().length);
+        assertEquals(116, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/MarkAppealAsAdaConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/MarkAppealAsAdaConfirmationTest.java
@@ -1,0 +1,101 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class MarkAppealAsAdaConfirmationTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+
+    private MarkAppealAsAdaConfirmation markAppealAsAdaConfirmation = new MarkAppealAsAdaConfirmation();
+
+    @Test
+    void should_return_confirmation_for_transferring_out_of_ada() {
+
+        when(callback.getEvent()).thenReturn(Event.MARK_APPEAL_AS_ADA);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        PostSubmitCallbackResponse callbackResponse =
+            markAppealAsAdaConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        assertThat(
+                callbackResponse.getConfirmationHeader().get())
+                .contains("# You have marked the appeal as ADA");
+
+        assertThat(
+                callbackResponse.getConfirmationBody().get())
+                .contains("#### What happens next\n\nAll parties will be notified that the appeal has been marked an accelerated detained appeal.");
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> markAppealAsAdaConfirmation.handle(callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            boolean canHandle = markAppealAsAdaConfirmation.canHandle(callback);
+
+            if (event == Event.MARK_APPEAL_AS_ADA) {
+
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> markAppealAsAdaConfirmation.canHandle(null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> markAppealAsAdaConfirmation.handle(null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAppealAsAdaHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAppealAsAdaHandlerTest.java
@@ -1,0 +1,205 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DetentionStatus;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class MarkAppealAsAdaHandlerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private DateProvider dateProvider;
+    private MarkAppealAsAdaHandler markAppealAsAdaHandler;
+    private LocalDate date = LocalDate.now();
+    private static final String MARK_APPEAL_AS_ADA_REASON = "mark appeal as ada reason";
+    private static final String ADA_SUFFIX_VALUE = "_ada";
+
+    @BeforeEach
+    public void setup() {
+
+        when(dateProvider.now()).thenReturn(date);
+        markAppealAsAdaHandler = new MarkAppealAsAdaHandler(dateProvider);
+    }
+
+    @Test
+    void should_mark_appeal_as_ada_and_update_case_data() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.PA));
+        when(asylumCase.read(MARK_APPEAL_AS_ADA_EXPLANATION, String.class)).thenReturn(Optional.of(MARK_APPEAL_AS_ADA_REASON));
+        when(callback.getEvent()).thenReturn(Event.MARK_APPEAL_AS_ADA);
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            markAppealAsAdaHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase).write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.YES);
+        verify(asylumCase).write(DETENTION_STATUS, DetentionStatus.ACCELERATED);
+        verify(asylumCase).write(DATE_MARKED_AS_ADA, dateProvider.now().toString());
+        verify(asylumCase).write(REASON_APPEAL_MARKED_AS_ADA, MARK_APPEAL_AS_ADA_REASON);
+        verify(asylumCase).write(ADA_SUFFIX, ADA_SUFFIX_VALUE);
+        verify(asylumCase).clear(MARK_APPEAL_AS_ADA_EXPLANATION);
+    }
+
+    @Test
+    void should_not_mark_appeal_as_ada_when_aaa_appeal() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.AG));
+        when(asylumCase.read(MARK_APPEAL_AS_ADA_EXPLANATION, String.class)).thenReturn(Optional.of(MARK_APPEAL_AS_ADA_REASON));
+        when(callback.getEvent()).thenReturn(Event.MARK_APPEAL_AS_ADA);
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            markAppealAsAdaHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(0)).write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.YES);
+        verify(asylumCase, times(0)).write(DETENTION_STATUS, DetentionStatus.ACCELERATED);
+        verify(asylumCase, times(0)).write(DATE_MARKED_AS_ADA, dateProvider.now().toString());
+        verify(asylumCase, times(0)).write(REASON_APPEAL_MARKED_AS_ADA, MARK_APPEAL_AS_ADA_REASON);
+        verify(asylumCase, times(0)).write(ADA_SUFFIX, ADA_SUFFIX_VALUE);
+    }
+
+    @Test
+    void should_not_mark_appeal_as_ada_when_ada_appeal() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.PA));
+        when(asylumCase.read(MARK_APPEAL_AS_ADA_EXPLANATION, String.class)).thenReturn(Optional.of(MARK_APPEAL_AS_ADA_REASON));
+        when(callback.getEvent()).thenReturn(Event.MARK_APPEAL_AS_ADA);
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            markAppealAsAdaHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(0)).write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.YES);
+        verify(asylumCase, times(0)).write(DETENTION_STATUS, DetentionStatus.ACCELERATED);
+        verify(asylumCase, times(0)).write(DATE_MARKED_AS_ADA, dateProvider.now().toString());
+        verify(asylumCase, times(0)).write(REASON_APPEAL_MARKED_AS_ADA, MARK_APPEAL_AS_ADA_REASON);
+        verify(asylumCase, times(0)).write(ADA_SUFFIX, ADA_SUFFIX_VALUE);
+    }
+
+    @Test
+    void should_not_mark_appeal_as_ada_when_non_detained_appeal() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.PA));
+        when(asylumCase.read(MARK_APPEAL_AS_ADA_EXPLANATION, String.class)).thenReturn(Optional.of(MARK_APPEAL_AS_ADA_REASON));
+        when(callback.getEvent()).thenReturn(Event.MARK_APPEAL_AS_ADA);
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            markAppealAsAdaHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(0)).write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.YES);
+        verify(asylumCase, times(0)).write(DETENTION_STATUS, DetentionStatus.ACCELERATED);
+        verify(asylumCase, times(0)).write(DATE_MARKED_AS_ADA, dateProvider.now().toString());
+        verify(asylumCase, times(0)).write(REASON_APPEAL_MARKED_AS_ADA, MARK_APPEAL_AS_ADA_REASON);
+        verify(asylumCase, times(0)).write(ADA_SUFFIX, ADA_SUFFIX_VALUE);
+    }
+
+    @Test
+    void handling_should_throw_if_mark_appeal_as_ada_explanation_not_set() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.PA));
+        when(asylumCase.read(MARK_APPEAL_AS_ADA_EXPLANATION, String.class)).thenReturn(Optional.empty());
+        when(callback.getEvent()).thenReturn(Event.MARK_APPEAL_AS_ADA);
+
+        assertThatThrownBy(
+            () -> markAppealAsAdaHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Explain why this appeal is being marked an accelerated detained appeal is required")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        assertThatThrownBy(
+                () -> markAppealAsAdaHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = markAppealAsAdaHandler.canHandle(callbackStage, callback);
+                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                        && ((callback.getEvent() == Event.MARK_APPEAL_AS_ADA))) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> markAppealAsAdaHandler.canHandle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(
+                () -> markAppealAsAdaHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> markAppealAsAdaHandler.handle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> markAppealAsAdaHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6585


### Change description ###
* Include the new event 'markAppealAsAda' in the events enum
* Give relevant roles access to the event
* Create a pre-submit callback handler to mark appeal as ADA
* Create a post-submit callback handler to set the successful event confirmation message
* Some refactorings
* Functional/unit tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
