### PR TITLE
RIA-6733: Make 'Mark appeal as paid' event available for internal cases

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6733-mark-hu-appeal-as-paid-admin-officer.json
+++ b/src/functionalTest/resources/scenarios/RIA-6733-mark-hu-appeal-as-paid-admin-officer.json
@@ -1,0 +1,57 @@
+{
+  "description": "RIA-6733 Mark EA/HU appeal as paid Case Officer",
+  "enabled": "true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 6733,
+      "eventId": "markAppealPaid",
+      "state": "pendingPayment",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "appealReferenceNumber": "HU/50001/2020",
+          "appealType": "refusalOfHumanRights",
+          "appealGroundsProtection": {
+            "values": [
+              "protectionHumanRights"
+            ]
+          },
+          "paymentStatus": "Payment pending",
+          "eaHuAppealTypePaymentOption": "payOffline",
+          "paidDate": "2021-06-07",
+          "feeAmountGbp": "8000",
+          "paidAmount": "8000",
+          "hearingDecisionSelected": "Decision without a hearing. The fee for this type of appeal is £80",
+          "decisionHearingFeeOption": "decisionWithoutHearing",
+          "additionalPaymentInfo": "Payment for the appeal is now complete",
+          "legalRepresentativeDocuments": []
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appealReferenceNumber": "HU/50001/2020",
+        "appealType": "refusalOfHumanRights",
+        "appealGroundsProtection": {
+          "values": [
+            "protectionHumanRights"
+          ]
+        },
+        "submissionOutOfTime": "No",
+        "feeAmountGbp": "8000",
+        "paidDate": "2021-06-07",
+        "paymentDate": "7 Jun 2021",
+        "paymentStatus": "Paid",
+        "additionalPaymentInfo": "Payment for the appeal is now complete",
+        "currentCaseStateVisibleToCaseOfficer": "appealSubmitted"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-6733-mark-pa-appeal-as-paid-case-officer.json
+++ b/src/functionalTest/resources/scenarios/RIA-6733-mark-pa-appeal-as-paid-case-officer.json
@@ -1,0 +1,43 @@
+{
+  "description": "RIA-6733 Mark PA appeal as paid Case Officer",
+  "enabled": "true",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 6733,
+      "eventId": "markAppealPaid",
+      "state": "pendingPayment",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "paymentStatus": "Payment pending",
+          "eaHuAppealTypePaymentOption": "payOffline",
+          "paidDate": "2021-06-07",
+          "feeAmountGbp": "8000",
+          "paidAmount": "8000",
+          "hearingDecisionSelected": "Decision without a hearing. The fee for this type of appeal is £80",
+          "decisionHearingFeeOption": "decisionWithoutHearing",
+          "additionalPaymentInfo": "Payment for the appeal is now complete",
+          "legalRepresentativeDocuments": []
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "submissionOutOfTime": "No",
+        "feeAmountGbp": "8000",
+        "paidDate": "2021-06-07",
+        "paymentDate": "7 Jun 2021",
+        "paymentStatus": "Paid",
+        "additionalPaymentInfo": "Payment for the appeal is now complete",
+        "currentCaseStateVisibleToCaseOfficer": "appealSubmitted"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtils.java
@@ -5,6 +5,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.PaymentStatus;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 
 public class HandlerUtils {
@@ -52,5 +53,9 @@ public class HandlerUtils {
 
     public static String getAdaSuffix() {
         return "_ada";
+    }
+
+    public static boolean isAppealPaid(AsylumCase asylumCase) {
+        return asylumCase.read(PAYMENT_STATUS, PaymentStatus.class).orElse(null) == PaymentStatus.PAID;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/MarkPaymentPaidPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/MarkPaymentPaidPreparer.java
@@ -10,17 +10,14 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionDecision;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionType;
+import uk.gov.hmcts.reform.iacaseapi.domain.UserDetailsHelper;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.PaymentStatus;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
@@ -29,11 +26,16 @@ public class MarkPaymentPaidPreparer implements PreSubmitCallbackHandler<AsylumC
     private static final String NOT_AVAILABLE_LABEL = "You cannot mark this appeal as paid";
 
     private final boolean isFeePaymentEnabled;
+    private final UserDetails userDetails;
+    private final UserDetailsHelper userDetailsHelper;
 
     public MarkPaymentPaidPreparer(
-        @Value("${featureFlag.isfeePaymentEnabled}") boolean isFeePaymentEnabled
+        @Value("${featureFlag.isfeePaymentEnabled}") boolean isFeePaymentEnabled,
+        UserDetails userDetails, UserDetailsHelper userDetailsHelper
     ) {
         this.isFeePaymentEnabled = isFeePaymentEnabled;
+        this.userDetails = userDetails;
+        this.userDetailsHelper = userDetailsHelper;
     }
 
     public boolean canHandle(
@@ -59,19 +61,17 @@ public class MarkPaymentPaidPreparer implements PreSubmitCallbackHandler<AsylumC
         final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
         final PreSubmitCallbackResponse<AsylumCase> callbackResponse = new PreSubmitCallbackResponse<>(asylumCase);
 
-        Optional<PaymentStatus> optPaymentStatus = asylumCase.read(PAYMENT_STATUS, PaymentStatus.class);
-        if (optPaymentStatus.isPresent() && optPaymentStatus.get() == PaymentStatus.PAID) {
+        if (isTribunalCaseworker() && !internalDetainedCase(asylumCase)) {
+            callbackResponse.addError("You don't have required access to perform this task");
+            return callbackResponse;
+        }
 
+        if (HandlerUtils.isAppealPaid(asylumCase)) {
             callbackResponse.addError("The fee for this appeal has already been paid.");
         }
 
         AppealType appealType = asylumCase.read(APPEAL_TYPE, AppealType.class)
             .orElseThrow(() -> new IllegalStateException("Appeal type is not present"));
-
-        boolean isAipJourney = callback.getCaseDetails().getCaseData()
-            .read(AsylumCaseFieldDefinition.JOURNEY_TYPE, JourneyType.class)
-            .map(journeyType -> journeyType == JourneyType.AIP)
-            .orElse(false);
 
         switch (appealType) {
             case EA:
@@ -79,45 +79,49 @@ public class MarkPaymentPaidPreparer implements PreSubmitCallbackHandler<AsylumC
             case PA:
             case AG:
             case EU:
-                Optional<RemissionType> remissionType = asylumCase.read(REMISSION_TYPE, RemissionType.class);
-                Optional<RemissionType> lateRemissionType = asylumCase.read(LATE_REMISSION_TYPE, RemissionType.class);
+                if (internalDetainedCase(asylumCase)) {
+                    return callbackResponse;
+                } else {
+                    Optional<RemissionType> remissionType = asylumCase.read(REMISSION_TYPE, RemissionType.class);
+                    Optional<RemissionType> lateRemissionType = asylumCase.read(LATE_REMISSION_TYPE, RemissionType.class);
 
-                Optional<RemissionDecision> remissionDecision = asylumCase.read(REMISSION_DECISION, RemissionDecision.class);
+                    Optional<RemissionDecision> remissionDecision = asylumCase.read(REMISSION_DECISION, RemissionDecision.class);
 
-                Optional<String> paPaymentType = asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class);
-                Optional<PaymentStatus> paymentStatus = asylumCase.read(PAYMENT_STATUS, PaymentStatus.class);
-                Optional<String> eaHuPaymentType = asylumCase.read(EA_HU_APPEAL_TYPE_PAYMENT_OPTION, String.class);
-                boolean isEaHuEuAg = List.of(EA, HU, EU, AG).contains(appealType);
-                // old cases
-                if ((appealType == PA && remissionType.isEmpty() && paPaymentType.isEmpty())
+                    Optional<String> paPaymentType = asylumCase.read(PA_APPEAL_TYPE_PAYMENT_OPTION, String.class);
+                    Optional<PaymentStatus> paymentStatus = asylumCase.read(PAYMENT_STATUS, PaymentStatus.class);
+                    Optional<String> eaHuPaymentType = asylumCase.read(EA_HU_APPEAL_TYPE_PAYMENT_OPTION, String.class);
+                    boolean isEaHuEuAg = List.of(EA, HU, EU, AG).contains(appealType);
+                    // old cases
+                    if ((appealType == PA && remissionType.isEmpty() && paPaymentType.isEmpty())
                         || (isEaHuEuAg && remissionType.isEmpty()
                         && eaHuPaymentType.isEmpty())) {
-                    callbackResponse.addError(NOT_AVAILABLE_LABEL);
-                }
-                if (isEaHuEuAg && (remissionType.isEmpty() || remissionType.get() == NO_REMISSION)
+                        callbackResponse.addError(NOT_AVAILABLE_LABEL);
+                    }
+                    if (isEaHuEuAg && (remissionType.isEmpty() || remissionType.get() == NO_REMISSION)
                         && eaHuPaymentType.isPresent() && eaHuPaymentType.get().equals("payNow")
                         && paymentStatus.isPresent() && paymentStatus.get() == PaymentStatus.PAID) {
-                    callbackResponse.addError(NOT_AVAILABLE_LABEL);
+                        callbackResponse.addError(NOT_AVAILABLE_LABEL);
+                    }
+
+                    if (appealType == PA && remissionType.isPresent()
+                        && remissionType.get() == NO_REMISSION
+                        && HandlerUtils.isAipJourney(asylumCase)) {
+                        paPaymentType
+                            .filter(option -> option.equals("payLater"))
+                            .ifPresent(s ->
+                                callbackResponse.addError(NOT_AVAILABLE_LABEL)
+                            );
+                    } else if ((remissionType.isPresent() && remissionType.get() != NO_REMISSION && !remissionDecision.isPresent())
+                        || (lateRemissionType.isPresent() && !remissionDecision.isPresent())) {
+
+                        callbackResponse.addError("You cannot mark this appeal as paid because the remission decision has not been recorded.");
+                    } else if (isRemissionDecisionExistsAndApproved(remissionDecision)) {
+
+                        callbackResponse.addError("You cannot mark this appeal as paid because a full remission has been approved.");
+                    }
+                    break;
+
                 }
-
-                if (appealType == PA && remissionType.isPresent()
-                    && remissionType.get() == NO_REMISSION
-                    && isAipJourney) {
-                    paPaymentType
-                        .filter(option -> option.equals("payLater"))
-                        .ifPresent(s ->
-                            callbackResponse.addError(NOT_AVAILABLE_LABEL)
-                        );
-                } else if ((remissionType.isPresent() && remissionType.get() != NO_REMISSION && !remissionDecision.isPresent())
-                           || (lateRemissionType.isPresent() && !remissionDecision.isPresent())) {
-
-                    callbackResponse.addError("You cannot mark this appeal as paid because the remission decision has not been recorded.");
-                } else if (isRemissionDecisionExistsAndApproved(remissionDecision)) {
-
-                    callbackResponse.addError("You cannot mark this appeal as paid because a full remission has been approved.");
-                }
-                break;
-
             case RP:
             case DC:
                 callbackResponse.addError("Payment is not required for this type of appeal.");
@@ -135,6 +139,14 @@ public class MarkPaymentPaidPreparer implements PreSubmitCallbackHandler<AsylumC
     ) {
 
         return remissionDecision.isPresent()
-               && remissionDecision.get() == APPROVED;
+            && remissionDecision.get() == APPROVED;
+    }
+
+    private boolean internalDetainedCase(AsylumCase asylumCase) {
+        return HandlerUtils.isInternalCase(asylumCase) && HandlerUtils.isAppellantInDetention(asylumCase);
+    }
+
+    private boolean isTribunalCaseworker() {
+        return userDetailsHelper.getLoggedInUserRoleLabel(userDetails).equals(UserRoleLabel.TRIBUNAL_CASEWORKER);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtilsTest.java
@@ -2,8 +2,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.JOURNEY_TYPE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -15,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 
 @ExtendWith(MockitoExtension.class)
 class HandlerUtilsTest {
@@ -65,5 +65,17 @@ class HandlerUtilsTest {
     void given_aaa_test_should_pass() {
         when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.AG));
         assertTrue(HandlerUtils.isAgeAssessmentAppeal(asylumCase));
+    }
+
+    @Test
+    void isInternalCase_should_return_true() {
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        assertTrue(HandlerUtils.isInternalCase(asylumCase));
+    }
+
+    @Test
+    void isInternalCase_should_return_false() {
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        assertFalse(HandlerUtils.isInternalCase(asylumCase));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6733


### Change description ###
* Some refactoring to clean up code and make it readable
* Allow all internal detained cases ('isAdmin'= true and 'appellantInDetention'=true) in 'paymentPending' state to be marked as paid both by Admins and Caseworkers
* For non-internal cases, only Admins are allowed to 'mark appeal as paid' Caseworkers are not allowed
* Unit/Functional tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
