### PR TITLE
RIA-6662 Changes necessary for progress bar conversion to non-ADA

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1713,6 +1713,9 @@ public enum AsylumCaseFieldDefinition {
     ADA_SUFFIX(
         "adaSuffix", new TypeReference<String>(){}),
 
+    HEARING_REQ_SUFFIX(
+        "hearingReqSuffix", new TypeReference<String>(){}),
+
     INTERNAL_APPELLANT_EMAIL(
             "internalAppellantEmail", new TypeReference<String>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtils.java
@@ -58,4 +58,8 @@ public class HandlerUtils {
     public static boolean isAppealPaid(AsylumCase asylumCase) {
         return asylumCase.read(PAYMENT_STATUS, PaymentStatus.class).orElse(null) == PaymentStatus.PAID;
     }
+
+    public static String getAfterHearingReqSuffix() {
+        return "_afterHearingReq";
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -67,11 +68,11 @@ public class DraftHearingRequirementsHandler implements PreSubmitCallbackHandler
 
         asylumCase.write(WITNESS_COUNT, witnessDetails.size());
 
-        asylumCase.write(SUBMIT_HEARING_REQUIREMENTS_AVAILABLE, YesOrNo.YES);
+        asylumCase.write(SUBMIT_HEARING_REQUIREMENTS_AVAILABLE, YES);
 
         asylumCase.write(REVIEWED_HEARING_REQUIREMENTS, YesOrNo.NO);
 
-        if (asylumCase.read(CASE_FLAG_SET_ASIDE_REHEARD_EXISTS, YesOrNo.class).map(flag -> flag.equals(YesOrNo.YES)).orElse(false)
+        if (asylumCase.read(CASE_FLAG_SET_ASIDE_REHEARD_EXISTS, YesOrNo.class).map(flag -> flag.equals(YES)).orElse(false)
             && featureToggler.getValue("reheard-feature", false)) {
 
             Optional<List<IdValue<DocumentWithMetadata>>> maybeHearingRequirements =
@@ -103,19 +104,27 @@ public class DraftHearingRequirementsHandler implements PreSubmitCallbackHandler
             asylumCase.clear(ADDITIONAL_TRIBUNAL_RESPONSE);
             asylumCase.clear(HEARING_REQUIREMENTS);
         } else {
-            asylumCase.write(CURRENT_HEARING_DETAILS_VISIBLE, YesOrNo.YES);
+            asylumCase.write(CURRENT_HEARING_DETAILS_VISIBLE, YES);
         }
 
         boolean isAcceleratedDetainedAppeal = HandlerUtils.isAcceleratedDetainedAppeal(asylumCase);
 
         if (isAcceleratedDetainedAppeal) {
             asylumCase.clear(ADA_HEARING_REQUIREMENTS_SUBMITTABLE);
-            asylumCase.write(ADA_HEARING_REQUIREMENTS_TO_REVIEW, YesOrNo.YES);
+            asylumCase.write(ADA_HEARING_REQUIREMENTS_TO_REVIEW, YES);
 
             // This flag is set so that when it is transferred out of ADA into normal detained flow,
             // it is used in CaseEvent definition to move into correct state if HR are submitted or not.
-            asylumCase.write(ADA_HEARING_REQUIREMENTS_SUBMITTED, YesOrNo.YES);
+            asylumCase.write(ADA_HEARING_REQUIREMENTS_SUBMITTED, YES);
 
+        }
+
+        boolean appealTransferredOutOfAda = asylumCase.read(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class)
+            .map(yesOrNo -> yesOrNo.equals(YES))
+            .orElse(false);
+
+        if (appealTransferredOutOfAda) {
+            asylumCase.write(ADA_EDIT_LISTING_AVAILABLE, YES);
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
@@ -119,14 +119,6 @@ public class DraftHearingRequirementsHandler implements PreSubmitCallbackHandler
 
         }
 
-        boolean appealTransferredOutOfAda = asylumCase.read(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class)
-            .map(yesOrNo -> yesOrNo.equals(YES))
-            .orElse(false);
-
-        if (appealTransferredOutOfAda) {
-            asylumCase.write(ADA_EDIT_LISTING_AVAILABLE, YES);
-        }
-
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListCasePreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListCasePreparer.java
@@ -71,6 +71,24 @@ public class ListCasePreparer implements PreSubmitCallbackHandler<AsylumCase> {
             });
         }
 
+        boolean hasTransferredOutOfAda = asylumCase.read(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class)
+            .map(field -> field.equals(YesOrNo.YES))
+            .orElse(false);
+
+        boolean listCaseWasTriggeredInAdaJourney = asylumCase.read(CURRENT_HEARING_DETAILS_VISIBLE, YesOrNo.class)
+            .map(field -> field.equals(YesOrNo.YES))
+            .orElse(false);
+
+        if (callback.getEvent().equals(Event.LIST_CASE)
+            && hasTransferredOutOfAda
+            && listCaseWasTriggeredInAdaJourney) {
+            // direct user to use EDIT_CASE_LISTING instead of LIST_CASE if the appeal was transferred out of ADA after listing
+
+            PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
+            response.addError("Case was listed before being transferred out of ADA. Edit case listing instead.");
+            return response;
+        }
+
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsHandler.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ADA_HEARING_REQUIREMENTS_TO_REVIEW;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
@@ -61,6 +62,14 @@ public class ReviewDraftHearingRequirementsHandler implements PreSubmitCallbackH
             asylumCase.write(ADA_HEARING_REQUIREMENTS_TO_REVIEW, YesOrNo.NO);
             //Set flag to Yes to enable updateHearingRequirementsEvent for ada cases
             asylumCase.write(ADA_HEARING_REQUIREMENTS_UPDATABLE, YesOrNo.YES);
+        }
+
+        boolean appealTransferredOutOfAda = asylumCase.read(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class)
+            .map(yesOrNo -> yesOrNo.equals(YES))
+            .orElse(false);
+
+        if (appealTransferredOutOfAda) {
+            asylumCase.write(ADA_EDIT_LISTING_AVAILABLE, YES);
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandler.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 
 import java.util.Optional;
 import org.springframework.stereotype.Component;
@@ -53,10 +54,18 @@ public class TransferOutOfAdaHandler implements PreSubmitCallbackHandler<AsylumC
 
         if (isAcceleratedDetainedAppeal.equals(Optional.of(YesOrNo.YES))) {
 
-            asylumCase.write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.NO);
+            asylumCase.write(IS_ACCELERATED_DETAINED_APPEAL, NO);
             asylumCase.write(DETENTION_STATUS, DetentionStatus.DETAINED);
             asylumCase.write(TRANSFER_OUT_OF_ADA_DATE, dateProvider.now().toString());
             asylumCase.write(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.YES);
+
+            asylumCase.write(LISTING_AVAILABLE_FOR_ADA, NO);
+
+            asylumCase.write(ADA_HEARING_ADJUSTMENTS_UPDATABLE, NO);
+            asylumCase.write(ADA_HEARING_REQUIREMENTS_UPDATABLE, NO);
+            asylumCase.write(ADA_HEARING_REQUIREMENTS_TO_REVIEW, NO);
+            asylumCase.write(ADA_HEARING_REQUIREMENTS_SUBMITTABLE, NO);
+            asylumCase.write(ADA_EDIT_LISTING_AVAILABLE, NO);
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandlerTest.java
@@ -209,6 +209,18 @@ class DraftHearingRequirementsHandlerTest {
     }
 
     @Test
+    void should_set_flag_for_editing_listing_if_transferring_out_of_ada() {
+
+        when(asylumCase.read(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            draftHearingRequirementsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        verify(asylumCase, times(1))
+            .write(eq(ADA_EDIT_LISTING_AVAILABLE), eq(YesOrNo.YES));
+    }
+
+    @Test
     void should_set_hearing_requirements_submitted_flag_to_yes_for_ada_cases() {
 
         when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandlerTest.java
@@ -209,18 +209,6 @@ class DraftHearingRequirementsHandlerTest {
     }
 
     @Test
-    void should_set_flag_for_editing_listing_if_transferring_out_of_ada() {
-
-        when(asylumCase.read(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
-
-        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-            draftHearingRequirementsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
-
-        verify(asylumCase, times(1))
-            .write(eq(ADA_EDIT_LISTING_AVAILABLE), eq(YesOrNo.YES));
-    }
-
-    @Test
     void should_set_hearing_requirements_submitted_flag_to_yes_for_ada_cases() {
 
         when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListCasePreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListCasePreparerTest.java
@@ -194,6 +194,23 @@ class ListCasePreparerTest {
     }
 
     @Test
+    void should_set_error_when_transferred_out_of_ada_after_listing() {
+
+        when(asylumCase.read(AsylumCaseFieldDefinition.HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class))
+            .thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(AsylumCaseFieldDefinition.CURRENT_HEARING_DETAILS_VISIBLE, YesOrNo.class))
+            .thenReturn(Optional.of(YesOrNo.YES));
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            listCasePreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+        Assertions.assertThat(callbackResponse.getErrors()).hasSize(1);
+        Assertions.assertThat(callbackResponse.getErrors()).containsExactlyInAnyOrder(
+            "Case was listed before being transferred out of ADA. Edit case listing instead.");
+    }
+
+    @Test
     void should_work_for_old_flow_when_requirements_not_captured() {
 
         when(asylumCase.read(AsylumCaseFieldDefinition.HEARING_CENTRE))

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/TransferOutOfAdaHandlerTest.java
@@ -65,6 +65,13 @@ class TransferOutOfAdaHandlerTest {
         verify(asylumCase).write(DETENTION_STATUS, DetentionStatus.DETAINED);
         verify(asylumCase).write(TRANSFER_OUT_OF_ADA_DATE, dateProvider.now().toString());
         verify(asylumCase).write(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.YES);
+
+        verify(asylumCase).write(LISTING_AVAILABLE_FOR_ADA, YesOrNo.NO);
+        verify(asylumCase).write(ADA_HEARING_ADJUSTMENTS_UPDATABLE, YesOrNo.NO);
+        verify(asylumCase).write(ADA_HEARING_REQUIREMENTS_UPDATABLE, YesOrNo.NO);
+        verify(asylumCase).write(ADA_HEARING_REQUIREMENTS_TO_REVIEW, YesOrNo.NO);
+        verify(asylumCase).write(ADA_HEARING_REQUIREMENTS_SUBMITTABLE, YesOrNo.NO);
+        verify(asylumCase).write(ADA_EDIT_LISTING_AVAILABLE, YesOrNo.NO);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6662](https://tools.hmcts.net/jira/browse/RIA-6662)


### Change description ###
- Six flag fields from the ADA journey reset to `NO`
- `adaSuffix` gets set to `"_ada"` when case is ADA and set to `""` when case transfers out of ADA

The below are changes to the logic I've made to allow myself to progress the case, but I have no acceptance criteria to go by:
- Added UI error to prevent user from triggering `LIST_CASE` after the case has been listed (redirecting the user to use `EDIT_CASE_LISTING` instead
- Added logic to enable `EDIT_CASE_LISTING` after CW review of hearing requirements when transferred out of ADA
- Added flag suffix to show a different progress bar when the case transferred out of ADA but has submitted hearing requirements already


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
