### PR TITLE
RIA-6862 - Updating supplementary data handler to not be called for e…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AsylumSupplementaryDataFixingHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AsylumSupplementaryDataFixingHandler.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 import org.springframework.stereotype.Component;
@@ -12,8 +14,6 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallb
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.CcdSupplementaryUpdater;
-
-import static java.util.Objects.requireNonNull;
 
 @Component
 public class AsylumSupplementaryDataFixingHandler implements PreSubmitCallbackHandler<AsylumCase> {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AsylumSupplementaryDataFixingHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AsylumSupplementaryDataFixingHandler.java
@@ -5,12 +5,15 @@ import java.util.Map;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.CcdSupplementaryUpdater;
+
+import static java.util.Objects.requireNonNull;
 
 @Component
 public class AsylumSupplementaryDataFixingHandler implements PreSubmitCallbackHandler<AsylumCase> {
@@ -31,7 +34,11 @@ public class AsylumSupplementaryDataFixingHandler implements PreSubmitCallbackHa
             PreSubmitCallbackStage callbackStage,
             Callback<AsylumCase> callback
     ) {
-        return true;
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                && callback.getEvent() != Event.START_APPEAL;
     }
 
     @Override


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6862


### Change description ###
RIA-6862 - Updating supplementary data handler to not be called for every callback


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
