### PR TITLE
RIA-6836 Validation error for internal case non in detention

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6836-appellant-not-in-detention-internal-case-valitation.json
+++ b/src/functionalTest/resources/scenarios/RIA-6836-appellant-not-in-detention-internal-case-valitation.json
@@ -1,0 +1,30 @@
+{
+  "description": "RIA-6836 Validation error for appellant not in detention during internal case creation",
+   "request": {
+    "uri": "/asylum/ccdMidEvent?pageId=detention",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 6836,
+      "eventId": "startAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "isAdmin": "Yes",
+          "appellantInDetention": "No"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": ["The option is currently unavailable"],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "appellantInDetention": "No"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionValidator.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.EDIT_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.EDIT_APPEAL_AFTER_SUBMIT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.START_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isAppellantInDetention;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isInternalCase;
+
+import java.util.Objects;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class DetentionValidator  implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private static final String DETENTION_PAGE_ID = "detention";
+    private static final String OPTION_UNAVAILABLE_ERROR = "The option is currently unavailable";
+
+    @Override
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == MID_EVENT
+               && Objects.equals(callback.getPageId(), DETENTION_PAGE_ID)
+               && Set.of(START_APPEAL,
+                EDIT_APPEAL,
+                EDIT_APPEAL_AFTER_SUBMIT).contains(callback.getEvent());
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback) {
+
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
+
+        if (!isAppellantInDetention(asylumCase) && isInternalCase(asylumCase)) {
+            response.addError(OPTION_UNAVAILABLE_ERROR);
+        }
+
+        return response;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionValidatorTest.java
@@ -1,0 +1,149 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.EDIT_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.EDIT_APPEAL_AFTER_SUBMIT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.START_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class DetentionValidatorTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+
+    private final DetentionValidator detentionValidator = new DetentionValidator();
+
+    @BeforeEach
+    void setup() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getPageId()).thenReturn("detention");
+    }
+
+    @Test
+    void should_add_error_to_asylum_case_if_admin_starts_non_detained_appeal() {
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        when(asylumCase.read(AsylumCaseFieldDefinition.APPELLANT_IN_DETENTION, YesOrNo.class))
+            .thenReturn(Optional.of(NO));
+        when(asylumCase.read(AsylumCaseFieldDefinition.IS_ADMIN, YesOrNo.class))
+            .thenReturn(Optional.of(YES));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse = detentionValidator
+            .handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).isNotEmpty();
+        assertEquals(1, errors.size());
+        assertTrue(errors.contains("The option is currently unavailable"));
+    }
+
+    private static Stream<Arguments> noErrorScenarios() {
+        // isAdmin, appellantInDetention
+        return Stream.of(
+            Arguments.of(NO, NO),
+            Arguments.of(YES, YES),
+            Arguments.of(NO, YES)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("noErrorScenarios")
+    void should_not_add_error_to_asylum_case_if_admin_starts_non_detained_appeal(YesOrNo isAdmin, YesOrNo appellantInDetention) {
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        when(asylumCase.read(AsylumCaseFieldDefinition.APPELLANT_IN_DETENTION, YesOrNo.class))
+            .thenReturn(Optional.of(appellantInDetention));
+        when(asylumCase.read(AsylumCaseFieldDefinition.IS_ADMIN, YesOrNo.class))
+            .thenReturn(Optional.of(isAdmin));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse = detentionValidator
+            .handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        final Set<String> errors = callbackResponse.getErrors();
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        assertThatThrownBy(
+            () -> detentionValidator.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = detentionValidator.canHandle(callbackStage, callback);
+                if (callbackStage == PreSubmitCallbackStage.MID_EVENT
+                    && Set.of(START_APPEAL,
+                    EDIT_APPEAL,
+                    EDIT_APPEAL_AFTER_SUBMIT).contains(callback.getEvent())) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> detentionValidator.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(
+            () -> detentionValidator.canHandle(PreSubmitCallbackStage.MID_EVENT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> detentionValidator.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> detentionValidator.handle(PreSubmitCallbackStage.MID_EVENT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6836](https://tools.hmcts.net/jira/browse/RIA-6836)


### Change description ###
- Added UI error for an internal case when `appellantInDetention` is selected to be `NO`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
