### PR TITLE
RIA-6735 -

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealUserRoleAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealUserRoleAppender.java
@@ -36,7 +36,7 @@ public class AppealUserRoleAppender implements PreSubmitCallbackHandler<AsylumCa
 
         Event event = callback.getEvent();
 
-        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
+        return (callbackStage == PreSubmitCallbackStage.ABOUT_TO_START || callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT)
                 && List.of(START_APPEAL).contains(event);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -144,7 +144,7 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
 
     private List<Event> getInternalEventsToHandle() {
         List<Event> eventsToHandle = Lists.newArrayList(
-                Event.SUBMIT_APPEAL,
+                //Event.SUBMIT_APPEAL,
                 Event.EDIT_APPEAL_AFTER_SUBMIT,
                 Event.REQUEST_RESPONDENT_EVIDENCE
         );

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealUserRoleAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealUserRoleAppenderTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ADMIN;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.START_APPEAL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -92,7 +93,7 @@ class AppealUserRoleAppenderTest {
 
             for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
                 boolean canHandle = appealUserRoleAppender.canHandle(callbackStage, callback);
-                if (callbackStage == ABOUT_TO_START
+                if ((callbackStage == ABOUT_TO_START || callbackStage == ABOUT_TO_SUBMIT)
                         && callback.getEvent() == START_APPEAL) {
                     assertTrue(canHandle);
                 } else {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6735


### Change description ###
RIA-6735 - 

* Disabling internal case creation Submit appeal notifications
* Updating isAdmin flag to also be called on about to submit for startAppeal as it was not setting for LR journey cases.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
