### PR TITLE
RIA-6856 makeAnApplicationTypes available for some internal ada cases

### DIFF
--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
     email: ImmigrationandAsylum@HMCTS.NET
 dependencies:
   - name: java
-    version: 4.0.3
+    version: 4.0.12
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -110,5 +110,6 @@
         <cve>CVE-2022-45143</cve>    
         <cve>CVE-2022-31197</cve>
         <cve>CVE-2022-45688</cve>
+        <cve>CVE-2023-24998</cve>
     </suppress>
 </suppressions>

--- a/src/functionalTest/resources/scenarios/RIA-6856-application-types-available-ada-internal-case-after-hearing-req.json
+++ b/src/functionalTest/resources/scenarios/RIA-6856-application-types-available-ada-internal-case-after-hearing-req.json
@@ -1,0 +1,67 @@
+{
+  "description": "RIA-6856: Admins make an application for internal ADA case after submitting hearing requirements",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 68562,
+      "eventId": "makeAnApplication",
+      "state": "caseBuilding",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isAdmin": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "appealType": "refusalOfEu",
+          "adaHearingRequirementsToReview": "Yes"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appealType": "refusalOfEu",
+        "isAdmin": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "adaHearingRequirementsToReview": "Yes",
+        "makeAnApplicationTypes": {
+          "value": {
+            "code": "JUDGE_REVIEW",
+            "label": "Judge's review of application decision"
+          },
+          "list_items": [
+            {
+              "code": "JUDGE_REVIEW",
+              "label": "Judge's review of application decision"
+            },
+            {
+              "code": "UPDATE_HEARING_REQUIREMENTS",
+              "label": "Update hearing requirements"
+            },
+            {
+              "code": "TIME_EXTENSION",
+              "label": "Time extension"
+            },
+            {
+              "code": "WITHDRAW",
+              "label": "Withdraw"
+            },
+            {
+              "code": "LINK_OR_UNLINK",
+              "label": "Link/unlink appeals"
+            },
+            {
+              "code": "OTHER",
+              "label": "Other"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+

--- a/src/functionalTest/resources/scenarios/RIA-6856-application-types-available-ada-internal-case-before-hearing-req.json
+++ b/src/functionalTest/resources/scenarios/RIA-6856-application-types-available-ada-internal-case-before-hearing-req.json
@@ -1,0 +1,69 @@
+{
+  "description": "RIA-6856: Admins make an application for internal ADA case before submitting hearing requirements",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "AdminOfficer",
+    "input": {
+      "id": 68561,
+      "eventId": "makeAnApplication",
+      "state": "awaitingRespondentEvidence",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isAdmin": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "appealType": "refusalOfEu"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appealType": "refusalOfEu",
+        "isAdmin": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "makeAnApplicationTypes": {
+          "value": {
+            "code": "ADJOURN",
+            "label": "Adjourn"
+          },
+          "list_items": [
+            {
+              "code": "ADJOURN",
+              "label": "Adjourn"
+            },
+            {
+              "code": "EXPEDITE",
+              "label": "Expedite"
+            },
+            {
+              "code": "JUDGE_REVIEW",
+              "label": "Judge's review of application decision"
+            },
+            {
+              "code": "TIME_EXTENSION",
+              "label": "Time extension"
+            },
+            {
+              "code": "WITHDRAW",
+              "label": "Withdraw"
+            },
+            {
+              "code": "LINK_OR_UNLINK",
+              "label": "Link/unlink appeals"
+            },
+            {
+              "code": "OTHER",
+              "label": "Other"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/MakeAnApplicationTypesProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/MakeAnApplicationTypesProvider.java
@@ -14,6 +14,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTyp
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.UPDATE_APPEAL_DETAILS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.UPDATE_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.WITHDRAW;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.AWAITING_RESPONDENT_EVIDENCE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.PENDING_PAYMENT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isInternalCase;
 
@@ -96,7 +97,17 @@ public class MakeAnApplicationTypesProvider {
 
             case PENDING_PAYMENT:
             case AWAITING_RESPONDENT_EVIDENCE:
-                if (hasRole(ROLE_ADMIN)
+            case CASE_BUILDING:
+            case AWAITING_REASONS_FOR_APPEAL:
+            case AWAITING_CLARIFYING_QUESTIONS_ANSWERS:
+            case AWAITING_CMA_REQUIREMENTS:
+            case CASE_UNDER_REVIEW:
+            case REASONS_FOR_APPEAL_SUBMITTED:
+            case RESPONDENT_REVIEW:
+            case SUBMIT_HEARING_REQUIREMENTS:
+
+                if (currentState == AWAITING_RESPONDENT_EVIDENCE
+                    && hasRole(ROLE_ADMIN)
                     && isInternalCase(asylumCase)
                     && isAcceleratedDetainedAppeal(asylumCase)) {
 
@@ -108,14 +119,7 @@ public class MakeAnApplicationTypesProvider {
                             UPDATE_HEARING_REQUIREMENTS.toString()));
                     }
                 }
-            case CASE_BUILDING:
-            case AWAITING_REASONS_FOR_APPEAL:
-            case AWAITING_CLARIFYING_QUESTIONS_ANSWERS:
-            case AWAITING_CMA_REQUIREMENTS:
-            case CASE_UNDER_REVIEW:
-            case REASONS_FOR_APPEAL_SUBMITTED:
-            case RESPONDENT_REVIEW:
-            case SUBMIT_HEARING_REQUIREMENTS:
+
                 if (hasRole(ROLE_LEGAL_REP) || hasHomeOfficeRole) {
                     values.add(new Value(JUDGE_REVIEW_LO.name(), JUDGE_REVIEW_LO.toString()));
                 } else {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/MakeAnApplicationTypesProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/MakeAnApplicationTypesProvider.java
@@ -1,7 +1,21 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.service;
 
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.*;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ADA_HEARING_REQUIREMENTS_TO_REVIEW;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.ADJOURN;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.EXPEDITE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.JUDGE_REVIEW;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.JUDGE_REVIEW_LO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.LINK_OR_UNLINK;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.OTHER;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.REINSTATE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.TIME_EXTENSION;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.TRANSFER;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.UPDATE_APPEAL_DETAILS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.UPDATE_HEARING_REQUIREMENTS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.MakeAnApplicationTypes.WITHDRAW;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.PENDING_PAYMENT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isInternalCase;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +32,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 @Service
 public class MakeAnApplicationTypesProvider {
 
+    private static final String ROLE_ADMIN = "caseworker-ia-admofficer";
     private static final String ROLE_LEGAL_REP = "caseworker-ia-legalrep-solicitor";
     private static final String ROLE_HO_APC = "caseworker-ia-homeofficeapc";
     private static final String ROLE_HO_LART = "caseworker-ia-homeofficelart";
@@ -81,6 +96,18 @@ public class MakeAnApplicationTypesProvider {
 
             case PENDING_PAYMENT:
             case AWAITING_RESPONDENT_EVIDENCE:
+                if (hasRole(ROLE_ADMIN)
+                    && isInternalCase(asylumCase)
+                    && isAcceleratedDetainedAppeal(asylumCase)) {
+
+                    values.add(new Value(ADJOURN.name(), ADJOURN.toString()));
+                    values.add(new Value(EXPEDITE.name(), EXPEDITE.toString()));
+
+                    if (hasSubmittedHearingRequirements(asylumCase)) {
+                        values.add(new Value(UPDATE_HEARING_REQUIREMENTS.name(),
+                            UPDATE_HEARING_REQUIREMENTS.toString()));
+                    }
+                }
             case CASE_BUILDING:
             case AWAITING_REASONS_FOR_APPEAL:
             case AWAITING_CLARIFYING_QUESTIONS_ANSWERS:
@@ -108,6 +135,14 @@ public class MakeAnApplicationTypesProvider {
                     }
                 }
 
+                if (hasRole(ROLE_ADMIN)
+                    && isInternalCase(asylumCase)
+                    && isAcceleratedDetainedAppeal(asylumCase)
+                    && hasSubmittedHearingRequirements(asylumCase)) {
+                    values.add(new Value(UPDATE_HEARING_REQUIREMENTS.name(),
+                        UPDATE_HEARING_REQUIREMENTS.toString()));
+                }
+
                 values.add(new Value(TIME_EXTENSION.name(), TIME_EXTENSION.toString()));
                 values.add(new Value(WITHDRAW.name(), WITHDRAW.toString()));
                 values.add(new Value(LINK_OR_UNLINK.name(), LINK_OR_UNLINK.toString()));
@@ -125,6 +160,14 @@ public class MakeAnApplicationTypesProvider {
                 if (hasRole(ROLE_LEGAL_REP)) {
                     values.add(new Value(UPDATE_APPEAL_DETAILS.name(),
                         UPDATE_APPEAL_DETAILS.toString()));
+                }
+
+                if (hasRole(ROLE_ADMIN)
+                    && isInternalCase(asylumCase)
+                    && isAcceleratedDetainedAppeal(asylumCase)
+                    && hasSubmittedHearingRequirements(asylumCase)) {
+                    values.add(new Value(UPDATE_HEARING_REQUIREMENTS.name(),
+                        UPDATE_HEARING_REQUIREMENTS.toString()));
                 }
 
                 values.add(new Value(TIME_EXTENSION.name(), TIME_EXTENSION.toString()));
@@ -154,6 +197,15 @@ public class MakeAnApplicationTypesProvider {
                             TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()));
                     }
                 }
+
+                if (hasRole(ROLE_ADMIN)
+                    && isInternalCase(asylumCase)
+                    && isAcceleratedDetainedAppeal(asylumCase)
+                    && hasSubmittedHearingRequirements(asylumCase)) {
+                    values.add(new Value(UPDATE_HEARING_REQUIREMENTS.name(),
+                        UPDATE_HEARING_REQUIREMENTS.toString()));
+                }
+
                 values.add(new Value(WITHDRAW.name(), WITHDRAW.toString()));
                 values.add(new Value(LINK_OR_UNLINK.name(), LINK_OR_UNLINK.toString()));
                 values.add(new Value(OTHER.name(), OTHER.toString()));
@@ -181,6 +233,15 @@ public class MakeAnApplicationTypesProvider {
                             TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString()));
                     }
                 }
+
+                if (hasRole(ROLE_ADMIN)
+                    && isInternalCase(asylumCase)
+                    && isAcceleratedDetainedAppeal(asylumCase)
+                    && hasSubmittedHearingRequirements(asylumCase)) {
+                    values.add(new Value(UPDATE_HEARING_REQUIREMENTS.name(),
+                        UPDATE_HEARING_REQUIREMENTS.toString()));
+                }
+
                 values.add(new Value(WITHDRAW.name(), WITHDRAW.toString()));
                 values.add(new Value(LINK_OR_UNLINK.name(), LINK_OR_UNLINK.toString()));
                 break;
@@ -213,6 +274,15 @@ public class MakeAnApplicationTypesProvider {
                     values.add(new Value(UPDATE_HEARING_REQUIREMENTS.name(),
                         UPDATE_HEARING_REQUIREMENTS.toString()));
                 }
+
+                if (hasRole(ROLE_ADMIN)
+                    && isInternalCase(asylumCase)
+                    && isAcceleratedDetainedAppeal(asylumCase)
+                    && hasSubmittedHearingRequirements(asylumCase)) {
+                    values.add(new Value(UPDATE_HEARING_REQUIREMENTS.name(),
+                        UPDATE_HEARING_REQUIREMENTS.toString()));
+                }
+
                 values.add(new Value(WITHDRAW.name(), WITHDRAW.toString()));
                 values.add(new Value(LINK_OR_UNLINK.name(), LINK_OR_UNLINK.toString()));
                 values.add(new Value(OTHER.name(), OTHER.toString()));
@@ -261,6 +331,12 @@ public class MakeAnApplicationTypesProvider {
 
     private boolean isAcceleratedDetainedAppeal(AsylumCase asylumCase) {
         return asylumCase.read(AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)
+            .orElse(YesOrNo.NO)
+            .equals(YesOrNo.YES);
+    }
+
+    private boolean hasSubmittedHearingRequirements(AsylumCase asylumCase) {
+        return asylumCase.read(ADA_HEARING_REQUIREMENTS_TO_REVIEW, YesOrNo.class)
             .orElse(YesOrNo.NO)
             .equals(YesOrNo.YES);
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6856](https://tools.hmcts.net/jira/browse/RIA-6856)


### Change description ###
- `Transfer` should not be available. It's only available for non ADA cases from the 'prepareForHearing' state onwards
- `Adjourn` and `Expedite` are available for internal ADA cases in the 'awaitingRespondentEvidence' state, and continue to be available for non-ADA cases after listing
- `Update hearing requirements` is available after 'submitHearingRequirements' is done

There's quite a bit of code repetition in this PR because I didn't feel like deviating too much from the grid that the `switch` block sets up, so it's easily understandable what each state is supposed to incorporate. I guess I could make it drier but it'd deform the straightforward approach of the `switch` block.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
