### PR TITLE
RIA-6647 change date field to string

### DIFF
--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-api
 home: https://github.com/hmcts/ia-case-api
-version: 0.0.30
+version: 0.0.31
 description: Immigration & Asylum Case API
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.25"
+      version = "~> 3.33.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/util/MapValueExpander.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/util/MapValueExpander.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi.util;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -16,6 +17,7 @@ import uk.gov.hmcts.reform.iacaseapi.fixtures.DocumentManagementFilesFixture;
 public final class MapValueExpander {
 
     private static final Pattern TODAY_PATTERN = Pattern.compile("\\{\\$TODAY([+-]?\\d*?)}");
+    private static final Pattern TODAY_FULL_DATE_PATTERN = Pattern.compile("\\{\\$TODAY_FULL_DATE([+-]?\\d*?)}");
     private static final Pattern ENVIRONMENT_PROPERTY_PATTERN = Pattern.compile("\\{\\$([a-zA-Z0-9].+?)}");
     public static final Properties ENVIRONMENT_PROPERTIES = new Properties(System.getProperties());
 
@@ -62,6 +64,10 @@ public final class MapValueExpander {
                 value = expandToday(value);
             }
 
+            if (TODAY_FULL_DATE_PATTERN.matcher(value).find()) {
+                value = expandTodayFullDate(value);
+            }
+
             if (ENVIRONMENT_PROPERTY_PATTERN.matcher(value).find()) {
                 value = expandEnvironmentProperty(value);
             }
@@ -101,6 +107,40 @@ public final class MapValueExpander {
             String token = matcher.group(0);
 
             expandedValue = expandedValue.replace(token, now.toString());
+        }
+
+        return expandedValue;
+    }
+
+    private static String expandTodayFullDate(String value) {
+
+        Matcher matcher = TODAY_FULL_DATE_PATTERN.matcher(value);
+
+        String expandedValue = value;
+
+        while (matcher.find()) {
+
+            char plusOrMinus = '+';
+            int dayAdjustment = 0;
+
+            if (matcher.groupCount() == 1
+                && !matcher.group(1).isEmpty()) {
+
+                plusOrMinus = matcher.group(1).charAt(0);
+                dayAdjustment = Integer.valueOf(matcher.group(1).substring(1));
+            }
+
+            LocalDate now = LocalDate.now();
+
+            if (plusOrMinus == '+') {
+                now = now.plusDays(dayAdjustment);
+            } else {
+                now = now.minusDays(dayAdjustment);
+            }
+
+            String token = matcher.group(0);
+
+            expandedValue = expandedValue.replace(token, now.format(DateTimeFormatter.ofPattern("dd MMMM yyyy")));
         }
 
         return expandedValue;

--- a/src/functionalTest/resources/scenarios/RIA-1293-ftpa-appellant-out-of-time-flag-on-submit.json
+++ b/src/functionalTest/resources/scenarios/RIA-1293-ftpa-appellant-out-of-time-flag-on-submit.json
@@ -10,7 +10,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "ftpaApplicationDeadline": "{$TODAY-20}"
+          "ftpaApplicationDeadlineDate": "{$TODAY_FULL_DATE-20}"
         }
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-2581-ftpa-respondent-in-time-homeoffice-generic-submit.json
+++ b/src/functionalTest/resources/scenarios/RIA-2581-ftpa-respondent-in-time-homeoffice-generic-submit.json
@@ -10,7 +10,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "ftpaApplicationDeadline": "{$TODAY-20}",
+          "ftpaApplicationDeadlineDate": "{$TODAY_FULL_DATE-20}",
           "listCaseHearingCentre": "manchester",
           "ftpaRespondentDocuments": [],
           "ftpaRespondentOutOfTimeDocuments": [],

--- a/src/functionalTest/resources/scenarios/RIA-2581-ftpa-respondent-out-of-time-flag-set-homeoffice-generic.json
+++ b/src/functionalTest/resources/scenarios/RIA-2581-ftpa-respondent-out-of-time-flag-set-homeoffice-generic.json
@@ -10,7 +10,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "ftpaApplicationDeadline": "{$TODAY-20}"
+          "ftpaApplicationDeadlineDate": "{$TODAY_FULL_DATE-20}"
         }
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-2581-ftpa-respondent-out-of-time-flag-set-homeoffice-pou.json
+++ b/src/functionalTest/resources/scenarios/RIA-2581-ftpa-respondent-out-of-time-flag-set-homeoffice-pou.json
@@ -10,7 +10,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "ftpaApplicationDeadline": "{$TODAY-20}"
+          "ftpaApplicationDeadlineDate": "{$TODAY_FULL_DATE-20}"
         }
       }
     }

--- a/src/functionalTest/resources/scenarios/RIA-3132-ftpa-reheard-appellant-flag-on.json
+++ b/src/functionalTest/resources/scenarios/RIA-3132-ftpa-reheard-appellant-flag-on.json
@@ -16,7 +16,7 @@
           "ftpaAppellantSubmitted": "Yes",
           "ftpaAppellantSubmissionOutOfTime": "No",
           "ftpaAppellantApplicationDate": "{$TODAY}",
-          "ftpaApplicationDeadline": "{$TODAY+1}",
+          "ftpaApplicationDeadlineDate": "{$TODAY_FULL_DATE+1}",
           "ftpaAppellantDocuments": [
             {
               "id": "1",

--- a/src/functionalTest/resources/scenarios/RIA-3132-ftpa-reheard-respondent-flag-on.json
+++ b/src/functionalTest/resources/scenarios/RIA-3132-ftpa-reheard-respondent-flag-on.json
@@ -15,7 +15,7 @@
           "caseFlagSetAsideReheardExists": "Yes",
           "ftpaRespondentSubmitted": "Yes",
           "ftpaRespondentSubmissionOutOfTime": "No",
-          "ftpaApplicationDeadline": "{$TODAY+1}",
+          "ftpaApplicationDeadlineDate": "{$TODAY_FULL_DATE+1}",
           "ftpaRespondentApplicationDate": "{$TODAY}",
           "ftpaRespondentDocuments": [
             {

--- a/src/functionalTest/resources/scenarios/RIA-3954-ftpa-appellant-in-time-flag-off-submit-ooc.json
+++ b/src/functionalTest/resources/scenarios/RIA-3954-ftpa-appellant-in-time-flag-off-submit-ooc.json
@@ -11,7 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "ftpaApplicationDeadline": "{$TODAY+28}",
+          "ftpaApplicationDeadlineDate": "{$TODAY_FULL_DATE+28}",
           "outOfCountryDecisionType":"refusalOfHumanRights"
         }
       }

--- a/src/functionalTest/resources/scenarios/RIA-3954-ftpa-appellant-out-of-time-flag-on-submit-ooc.json
+++ b/src/functionalTest/resources/scenarios/RIA-3954-ftpa-appellant-out-of-time-flag-on-submit-ooc.json
@@ -11,7 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "ftpaApplicationDeadline": "{$TODAY-29}",
+          "ftpaApplicationDeadlineDate": "{$TODAY_FULL_DATE-29}",
           "outOfCountryDecisionType":"refusalOfHumanRights"
         }
       }

--- a/src/functionalTest/resources/scenarios/RIA-3954-ftpa-respondent-in-time-flag-set-homeoffice-generic-ooc.json
+++ b/src/functionalTest/resources/scenarios/RIA-3954-ftpa-respondent-in-time-flag-set-homeoffice-generic-ooc.json
@@ -11,7 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "ftpaApplicationDeadline": "{$TODAY+28}",
+          "ftpaApplicationDeadlineDate": "{$TODAY_FULL_DATE+28}",
           "outOfCountryDecisionType":"refusalOfHumanRights"
         }
       }

--- a/src/functionalTest/resources/scenarios/RIA-3954-ftpa-respondent-out-of-time-flag-set-homeoffice-generic-ooc.json
+++ b/src/functionalTest/resources/scenarios/RIA-3954-ftpa-respondent-out-of-time-flag-set-homeoffice-generic-ooc.json
@@ -11,7 +11,7 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
-          "ftpaApplicationDeadline": "{$TODAY-29}",
+          "ftpaApplicationDeadlineDate": "{$TODAY_FULL_DATE-29}",
           "outOfCountryDecisionType":"refusalOfHumanRights"
         }
       }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -547,8 +547,8 @@ public enum AsylumCaseFieldDefinition {
     DECISION_AND_REASONS_AVAILABLE(
         "decisionAndReasonsAvailable", new TypeReference<YesOrNo>(){}),
 
-    FTPA_APPLICATION_DEADLINE(
-            "ftpaApplicationDeadline", new TypeReference<String>(){}),
+    FTPA_APPLICATION_DEADLINE_DATE(
+            "ftpaApplicationDeadlineDate", new TypeReference<String>(){}),
 
     APPEAL_SUBMISSION_INTERNAL_DATE(
             "appealSubmissionInternalDate", new TypeReference<String>(){}),

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/FtpaAppellantPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/FtpaAppellantPreparer.java
@@ -6,6 +6,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
@@ -78,7 +79,7 @@ public class FtpaAppellantPreparer implements PreSubmitCallbackHandler<AsylumCas
         }
 
         final Optional<String> ftpaApplicationDeadline =
-                asylumCase.read(AsylumCaseFieldDefinition.FTPA_APPLICATION_DEADLINE, String.class);
+                asylumCase.read(AsylumCaseFieldDefinition.FTPA_APPLICATION_DEADLINE_DATE, String.class);
 
         if (ftpaApplicationDeadline.isEmpty()) {
             // For in-flight cases
@@ -86,7 +87,8 @@ public class FtpaAppellantPreparer implements PreSubmitCallbackHandler<AsylumCas
             return new PreSubmitCallbackResponse<>(asylumCase);
         }
 
-        LocalDate ftpaApplicationDeadlineDate = LocalDate.parse(ftpaApplicationDeadline.get());
+        LocalDate ftpaApplicationDeadlineDate = LocalDate.parse(ftpaApplicationDeadline.get(),
+            DateTimeFormatter.ofPattern("d MMMM yyyy"));
 
         if (dateProvider.now().isAfter(ftpaApplicationDeadlineDate)) {
             asylumCase.write(FTPA_APPELLANT_SUBMISSION_OUT_OF_TIME, YES);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/FtpaRespondentPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/FtpaRespondentPreparer.java
@@ -6,6 +6,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
@@ -79,7 +80,7 @@ public class FtpaRespondentPreparer implements PreSubmitCallbackHandler<AsylumCa
         }
 
         final Optional<String> ftpaApplicationDeadline =
-                asylumCase.read(AsylumCaseFieldDefinition.FTPA_APPLICATION_DEADLINE, String.class);
+                asylumCase.read(AsylumCaseFieldDefinition.FTPA_APPLICATION_DEADLINE_DATE, String.class);
 
         if (ftpaApplicationDeadline.isEmpty()) {
             // For in-flight cases
@@ -87,7 +88,8 @@ public class FtpaRespondentPreparer implements PreSubmitCallbackHandler<AsylumCa
             return new PreSubmitCallbackResponse<>(asylumCase);
         }
 
-        LocalDate ftpaApplicationDeadlineDate = LocalDate.parse(ftpaApplicationDeadline.get());
+        LocalDate ftpaApplicationDeadlineDate = LocalDate.parse(ftpaApplicationDeadline.get(),
+            DateTimeFormatter.ofPattern("d MMMM yyyy"));
 
         if (dateProvider.now().isAfter(ftpaApplicationDeadlineDate)) {
             asylumCase.write(FTPA_RESPONDENT_SUBMISSION_OUT_OF_TIME, YES);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandler.java
@@ -7,6 +7,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import com.google.common.collect.Lists;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
@@ -145,7 +146,7 @@ public class GenerateDocumentHandler implements PreSubmitCallbackHandler<AsylumC
         LocalDate appealDate = dateProvider.now();
         asylumCase.write(APPEAL_DATE, appealDate.toString());
         asylumCase.write(APPEAL_DECISION_AVAILABLE, YesOrNo.YES);
-        asylumCase.write(FTPA_APPLICATION_DEADLINE, getFtpaApplicationDeadline(asylumCase, appealDate));
+        asylumCase.write(FTPA_APPLICATION_DEADLINE_DATE, getFtpaApplicationDeadline(asylumCase, appealDate));
     }
 
     private void changeEditListingApplicationsToCompleted(AsylumCase asylumCase) {
@@ -211,6 +212,6 @@ public class GenerateDocumentHandler implements PreSubmitCallbackHandler<AsylumC
             ftpaApplicationDeadline = appealDate.plusDays(ftpaAppealOutOfTimeDaysUk);
         }
 
-        return ftpaApplicationDeadline.toString();
+        return ftpaApplicationDeadline.format(DateTimeFormatter.ofPattern("d MMMM yyyy"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/FtpaAppellantPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/FtpaAppellantPreparerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,7 +74,8 @@ class FtpaAppellantPreparerTest {
         when(asylumCase.read(OUT_OF_COUNTRY_DECISION_TYPE, OutOfCountryDecisionType.class))
                 .thenReturn(Optional.of(OutOfCountryDecisionType.REMOVAL_OF_CLIENT));
 
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.of(FTPA_DUE_DATE_UK.toString()));
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.of(FTPA_DUE_DATE_UK
+            .format(DateTimeFormatter.ofPattern("d MMMM yyyy"))));
 
         ftpaAppellantPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
 
@@ -88,7 +90,8 @@ class FtpaAppellantPreparerTest {
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_APPELLANT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(dateProvider.now()).thenReturn(LocalDate.now());
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.of(FTPA_DUE_DATE_OOC.toString()));
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.of(FTPA_DUE_DATE_OOC
+            .format(DateTimeFormatter.ofPattern("d MMMM yyyy"))));
 
         ftpaAppellantPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
 
@@ -102,7 +105,7 @@ class FtpaAppellantPreparerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_APPELLANT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(APPEAL_DATE, String.class)).thenReturn(Optional.empty());
 
         RequiredFieldMissingException thrown = assertThrows(
@@ -126,7 +129,7 @@ class FtpaAppellantPreparerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_APPELLANT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(APPEAL_DATE, String.class)).thenReturn(Optional.of("2023-01-01"));
         when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.empty());
 
@@ -153,7 +156,8 @@ class FtpaAppellantPreparerTest {
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_APPELLANT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(dateProvider.now()).thenReturn(LocalDate.now());
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.of(MISSED_FTPA_SUBMISSION_DATE.toString()));
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.of(MISSED_FTPA_SUBMISSION_DATE
+            .format(DateTimeFormatter.ofPattern("d MMMM yyyy"))));
 
         ftpaAppellantPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
 
@@ -168,7 +172,8 @@ class FtpaAppellantPreparerTest {
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_APPELLANT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(dateProvider.now()).thenReturn(LocalDate.now());
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.of(MISSED_FTPA_SUBMISSION_DATE.toString()));
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.of(MISSED_FTPA_SUBMISSION_DATE
+            .format(DateTimeFormatter.ofPattern("d MMMM yyyy"))));
 
         ftpaAppellantPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
 
@@ -209,8 +214,9 @@ class FtpaAppellantPreparerTest {
         when(asylumCase.read(CASE_FLAG_SET_ASIDE_REHEARD_EXISTS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 
         when(dateProvider.now()).thenReturn(LocalDate.now());
-        final String ftpaApplicationDeadline = dateProvider.now().minusDays(15).toString();
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.of(ftpaApplicationDeadline));
+        final String ftpaApplicationDeadline = dateProvider.now().minusDays(15)
+            .format(DateTimeFormatter.ofPattern("d MMMM yyyy"));
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.of(ftpaApplicationDeadline));
 
         final PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             ftpaAppellantPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
@@ -325,7 +331,7 @@ class FtpaAppellantPreparerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_APPELLANT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(APPEAL_DATE, String.class)).thenReturn(Optional.of(input));
         when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
         when(dateProvider.now()).thenReturn(LocalDate.parse(IN_FLIGHT_CASES_FTPA_OUT_OF_TIME_DATE_TO_COMPARE));
@@ -350,7 +356,7 @@ class FtpaAppellantPreparerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_APPELLANT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(APPEAL_DATE, String.class)).thenReturn(Optional.of(input));
         when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
         when(dateProvider.now()).thenReturn(LocalDate.parse(IN_FLIGHT_CASES_FTPA_OUT_OF_TIME_DATE_TO_COMPARE));

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/FtpaRespondentPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/FtpaRespondentPreparerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -72,7 +73,8 @@ class FtpaRespondentPreparerTest {
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_RESPONDENT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(dateProvider.now()).thenReturn(LocalDate.now());
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.of(FTPA_DUE_DATE_UK.toString()));
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.of(FTPA_DUE_DATE_UK
+            .format(DateTimeFormatter.ofPattern("d MMMM yyyy"))));
 
         ftpaRespondentPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
 
@@ -86,7 +88,8 @@ class FtpaRespondentPreparerTest {
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_RESPONDENT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(dateProvider.now()).thenReturn(LocalDate.now());
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.of(FTPA_DUE_DATE_OOC.toString()));
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.of(FTPA_DUE_DATE_OOC
+            .format(DateTimeFormatter.ofPattern("d MMMM yyyy"))));
 
         ftpaRespondentPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
 
@@ -99,7 +102,7 @@ class FtpaRespondentPreparerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_RESPONDENT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(APPEAL_DATE, String.class)).thenReturn(Optional.empty());
 
         RequiredFieldMissingException thrown = assertThrows(
@@ -124,7 +127,7 @@ class FtpaRespondentPreparerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_RESPONDENT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(APPEAL_DATE, String.class)).thenReturn(Optional.of("2023-01-01"));
         when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.empty());
 
@@ -152,7 +155,8 @@ class FtpaRespondentPreparerTest {
         when(dateProvider.now()).thenReturn(LocalDate.now());
         when(asylumCase.read(OUT_OF_COUNTRY_DECISION_TYPE, OutOfCountryDecisionType.class))
                 .thenReturn(Optional.of(OutOfCountryDecisionType.REMOVAL_OF_CLIENT));
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.of(MISSED_FTPA_SUBMISSION_DATE.toString()));
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.of(MISSED_FTPA_SUBMISSION_DATE
+            .format(DateTimeFormatter.ofPattern("d MMMM yyyy"))));
 
         ftpaRespondentPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
 
@@ -166,7 +170,8 @@ class FtpaRespondentPreparerTest {
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(dateProvider.now()).thenReturn(LocalDate.now());
 
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.of(MISSED_FTPA_SUBMISSION_DATE.toString()));
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.of(MISSED_FTPA_SUBMISSION_DATE
+            .format(DateTimeFormatter.ofPattern("d MMMM yyyy"))));
 
         ftpaRespondentPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
 
@@ -207,8 +212,8 @@ class FtpaRespondentPreparerTest {
         when(asylumCase.read(CASE_FLAG_SET_ASIDE_REHEARD_EXISTS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 
         when(dateProvider.now()).thenReturn(LocalDate.now());
-        final String ftpaApplicationDeadline = dateProvider.now().minusDays(15).toString();
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.of(ftpaApplicationDeadline));
+        final String ftpaApplicationDeadline = dateProvider.now().minusDays(15).format(DateTimeFormatter.ofPattern("d MMMM yyyy"));
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.of(ftpaApplicationDeadline));
 
         final PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             ftpaRespondentPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
@@ -323,7 +328,7 @@ class FtpaRespondentPreparerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_RESPONDENT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(APPEAL_DATE, String.class)).thenReturn(Optional.of(input));
         when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
         when(dateProvider.now()).thenReturn(LocalDate.parse(IN_FLIGHT_CASES_FTPA_OUT_OF_TIME_DATE_TO_COMPARE));
@@ -348,7 +353,7 @@ class FtpaRespondentPreparerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getEvent()).thenReturn(Event.APPLY_FOR_FTPA_RESPONDENT);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(asylumCase.read(FTPA_APPLICATION_DEADLINE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(FTPA_APPLICATION_DEADLINE_DATE, String.class)).thenReturn(Optional.empty());
         when(asylumCase.read(APPEAL_DATE, String.class)).thenReturn(Optional.of(input));
         when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
         when(dateProvider.now()).thenReturn(LocalDate.parse(IN_FLIGHT_CASES_FTPA_OUT_OF_TIME_DATE_TO_COMPARE));

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandlerTest.java
@@ -12,6 +12,7 @@ import com.google.common.collect.ImmutableSet;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -181,7 +182,8 @@ class GenerateDocumentHandlerTest {
             if (event.equals(SEND_DECISION_AND_REASONS)) {
                 verify(expectedUpdatedCase).write(APPEAL_DECISION, "Allowed");
                 verify(expectedUpdatedCase).write(APPEAL_DATE, FAKE_APPEAL_DATE.toString());
-                verify(expectedUpdatedCase).write(FTPA_APPLICATION_DEADLINE,EXPECTED_FTPA_DEADLINE_UK.toString());
+                verify(expectedUpdatedCase).write(FTPA_APPLICATION_DEADLINE_DATE,
+                    EXPECTED_FTPA_DEADLINE_UK.format(DateTimeFormatter.ofPattern("d MMMM yyyy")));
             }
 
             reset(callback);
@@ -437,7 +439,8 @@ class GenerateDocumentHandlerTest {
         assertEquals(expectedUpdatedCase, callbackResponse.getData());
         verify(documentGenerator, times(1)).generate(callback);
 
-        verify(expectedUpdatedCase).write(FTPA_APPLICATION_DEADLINE, EXPECTED_FTPA_DEADLINE_ADA.toString());
+        verify(expectedUpdatedCase).write(FTPA_APPLICATION_DEADLINE_DATE,
+            EXPECTED_FTPA_DEADLINE_ADA.format(DateTimeFormatter.ofPattern("d MMMM yyyy")));
     }
 
     @Test
@@ -457,7 +460,8 @@ class GenerateDocumentHandlerTest {
         assertEquals(expectedUpdatedCase, callbackResponse.getData());
         verify(documentGenerator, times(1)).generate(callback);
 
-        verify(expectedUpdatedCase).write(FTPA_APPLICATION_DEADLINE, EXPECTED_FTPA_DEADLINE_OOC.toString());
+        verify(expectedUpdatedCase).write(FTPA_APPLICATION_DEADLINE_DATE,
+            EXPECTED_FTPA_DEADLINE_OOC.format(DateTimeFormatter.ofPattern("d MMMM yyyy")));
     }
 
     @Test
@@ -474,7 +478,8 @@ class GenerateDocumentHandlerTest {
         assertEquals(expectedUpdatedCase, callbackResponse.getData());
         verify(documentGenerator, times(1)).generate(callback);
 
-        verify(expectedUpdatedCase).write(FTPA_APPLICATION_DEADLINE, EXPECTED_FTPA_DEADLINE_UK.toString());
+        verify(expectedUpdatedCase).write(FTPA_APPLICATION_DEADLINE_DATE,
+            EXPECTED_FTPA_DEADLINE_UK.format(DateTimeFormatter.ofPattern("d MMMM yyyy")));
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6647](https://tools.hmcts.net/jira/browse/RIA-6647)


### Change description ###
- Migrated `ftpaApplicationDeadline` (Date field) to `ftpaApplicationDeadlineDate` (String field) in order to format the date in full (15 March 2023). A Date field will always show as 15 Mar 2023 on the frontend, DATETIMEDISPLAY does not work in ccd.
- Changed functional tests and added the functionality of passing a String date in full dynamically to the tests. Just like `${TODAY}` will evaluate to `"2023-03-15"`, `${TODAY_FULL_DATE}` will evaluate to `"15 March 2023"`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
