### PR TITLE
Notification should be sent on 'uploadHomeOfficeAppealResponse' event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -167,7 +167,7 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
             //eventsToHandle.add(Event.BUILD_CASE);
         }
         if (!isExAdaCaseWithHearingRequirementsSubmitted(callback)) {
-            eventsToHandle.add(Event.REQUEST_RESPONSE_REVIEW);
+            eventsToHandle.add(Event.UPLOAD_HOME_OFFICE_APPEAL_RESPONSE);
         }
         return eventsToHandle;
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6780


### Change description ###
* Send notification on the event "uploadHomeOfficeAppealResponse" for internal cases
* Replace the event "requestResponseReview" with "uploadHomeOfficeAppealResponse"


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
