### PR TITLE
RIA-6848 Review Hearing Requirements error handling for judge non ADA

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparer.java
@@ -7,20 +7,29 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguage;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.UserDetailsHelper;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
 public class ReviewDraftHearingRequirementsPreparer implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final UserDetails userDetails;
+    private final UserDetailsHelper userDetailsHelper;
+
+    public ReviewDraftHearingRequirementsPreparer(
+        UserDetails userDetails, UserDetailsHelper userDetailsHelper
+    ) {
+        this.userDetails = userDetails;
+        this.userDetailsHelper = userDetailsHelper;
+    }
 
     public boolean canHandle(
         PreSubmitCallbackStage callbackStage,
@@ -52,6 +61,13 @@ public class ReviewDraftHearingRequirementsPreparer implements PreSubmitCallback
         final boolean exAdaWithSubmittedHearingRequirements =
             asylumCase.read(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class).orElse(YesOrNo.NO).equals(YesOrNo.YES)
             && asylumCase.read(ADA_HEARING_REQUIREMENTS_SUBMITTED, YesOrNo.class).orElse(YesOrNo.NO).equals(YesOrNo.YES);
+
+        // If Judge tries to trigger this for any non-ADA case, an error will be thrown on UI
+        if (isJudgeAndNonAdaAppeal(asylumCase)) {
+            final PreSubmitCallbackResponse<AsylumCase> asylumCasePreSubmitCallbackResponse = new PreSubmitCallbackResponse<>(asylumCase);
+            asylumCasePreSubmitCallbackResponse.addError("This option is not available. You can only review hearing requirements for accelerated detained appeals.");
+            return asylumCasePreSubmitCallbackResponse;
+        }
 
         if (!reviewedHearingRequirements.isPresent()) {
             final PreSubmitCallbackResponse<AsylumCase> asylumCasePreSubmitCallbackResponse = new PreSubmitCallbackResponse<>(asylumCase);
@@ -118,4 +134,12 @@ public class ReviewDraftHearingRequirementsPreparer implements PreSubmitCallback
             asylumCase.write(IS_EVIDENCE_FROM_OUTSIDE_UK_IN_COUNTRY, YesOrNo.NO);
         }
     }
+
+    private boolean isJudgeAndNonAdaAppeal(AsylumCase asylumCase) {
+
+        boolean isAcceleratedDetainedAppeal = HandlerUtils.isAcceleratedDetainedAppeal(asylumCase);
+
+        return userDetailsHelper.getLoggedInUserRoleLabel(userDetails).equals(UserRoleLabel.JUDGE) && !isAcceleratedDetainedAppeal;
+    }
+
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -383,6 +383,7 @@ security:
       - "markAddendumEvidenceAsReviewed"
       - "adaSuitabilityReview"
       - "transferOutOfAda"
+      - "reviewHearingRequirements"
     caseworker-ia-system:
       - "requestHearingRequirementsFeature"
       - "moveToPaymentPending"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparerTest.java
@@ -20,9 +20,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguage;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
+import org.powermock.api.mockito.PowerMockito;
+import uk.gov.hmcts.reform.iacaseapi.domain.UserDetailsHelper;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
@@ -41,6 +41,10 @@ class ReviewDraftHearingRequirementsPreparerTest {
     @Mock
     private AsylumCase asylumCase;
     @Mock
+    private UserDetails userDetails;
+    @Mock
+    private UserDetailsHelper userDetailsHelper;
+    @Mock
     private List<IdValue<WitnessDetails>> witnessDetails;
     @Mock
     private List<IdValue<InterpreterLanguage>> interpreterLanguage;
@@ -50,7 +54,7 @@ class ReviewDraftHearingRequirementsPreparerTest {
     @BeforeEach
     public void setUp() {
         reviewDraftHearingRequirementsPreparer =
-            new ReviewDraftHearingRequirementsPreparer();
+            new ReviewDraftHearingRequirementsPreparer(userDetails, userDetailsHelper);
 
         when(callback.getEvent()).thenReturn(Event.REVIEW_HEARING_REQUIREMENTS);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
@@ -60,6 +64,7 @@ class ReviewDraftHearingRequirementsPreparerTest {
     @Test
     void should_review_hearing_requirements() {
         when(asylumCase.read(REVIEWED_HEARING_REQUIREMENTS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.TRIBUNAL_CASEWORKER);
 
         witnessDetails = Arrays.asList(
             new IdValue<>("1", new WitnessDetails("Witness1")),
@@ -94,6 +99,7 @@ class ReviewDraftHearingRequirementsPreparerTest {
     void should_set_outside_evidence_out_of_country_default_for_old_cases() {
         when(asylumCase.read(REVIEWED_HEARING_REQUIREMENTS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
         when(asylumCase.read(IS_EVIDENCE_FROM_OUTSIDE_UK_OOC)).thenReturn(null);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.TRIBUNAL_CASEWORKER);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             reviewDraftHearingRequirementsPreparer.handle(ABOUT_TO_START, callback);
@@ -112,6 +118,7 @@ class ReviewDraftHearingRequirementsPreparerTest {
     void should_set_outside_evidence_in_country_default_for_old_cases() {
         when(asylumCase.read(REVIEWED_HEARING_REQUIREMENTS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
         when(asylumCase.read(IS_EVIDENCE_FROM_OUTSIDE_UK_IN_COUNTRY)).thenReturn(null);
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.TRIBUNAL_CASEWORKER);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             reviewDraftHearingRequirementsPreparer.handle(ABOUT_TO_START, callback);
@@ -127,6 +134,7 @@ class ReviewDraftHearingRequirementsPreparerTest {
     @Test
     void should_return_error_on_review_flag_is_missing() {
         when(asylumCase.read(REVIEWED_HEARING_REQUIREMENTS, YesOrNo.class)).thenReturn(Optional.empty());
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.TRIBUNAL_CASEWORKER);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             reviewDraftHearingRequirementsPreparer.handle(ABOUT_TO_START, callback);
@@ -143,6 +151,7 @@ class ReviewDraftHearingRequirementsPreparerTest {
     @Test
     void should_return_error_on_reviewing_hearing_requirements_twice() {
         when(asylumCase.read(REVIEWED_HEARING_REQUIREMENTS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.TRIBUNAL_CASEWORKER);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             reviewDraftHearingRequirementsPreparer.handle(ABOUT_TO_START, callback);
@@ -161,6 +170,7 @@ class ReviewDraftHearingRequirementsPreparerTest {
         when(asylumCase.read(REVIEWED_HEARING_REQUIREMENTS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
         when(asylumCase.read(ADA_HEARING_REQUIREMENTS_SUBMITTED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(asylumCase.read(HAS_TRANSFERRED_OUT_OF_ADA, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.TRIBUNAL_CASEWORKER);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             reviewDraftHearingRequirementsPreparer.handle(ABOUT_TO_START, callback);
@@ -203,5 +213,55 @@ class ReviewDraftHearingRequirementsPreparerTest {
         assertThatThrownBy(() -> reviewDraftHearingRequirementsPreparer.handle(ABOUT_TO_START, null))
             .hasMessage("callback must not be null")
             .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void should_return_error_when_judge_tries_to_trigger_event_on_nonAda_case() {
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.JUDGE);
+        when(asylumCase.read(AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            reviewDraftHearingRequirementsPreparer.handle(ABOUT_TO_START, callback);
+
+        assertNotNull(callback);
+        assertEquals(asylumCase, callbackResponse.getData());
+        assertEquals("This option is not available. You can only review hearing requirements for accelerated detained appeals.",
+            callbackResponse.getErrors().iterator().next());
+
+    }
+
+    @Test
+    void judge_should_review_hearing_requirements_for_ada_case() {
+        when(asylumCase.read(REVIEWED_HEARING_REQUIREMENTS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.JUDGE);
+        when(asylumCase.read(AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        witnessDetails = Arrays.asList(
+            new IdValue<>("1", new WitnessDetails("Witness1")),
+            new IdValue<>("2", new WitnessDetails("Witness2"))
+        );
+
+        interpreterLanguage = Arrays.asList(
+            new IdValue<>("1", new InterpreterLanguage("Irish", "N/A"))
+        );
+
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnessDetails));
+        when(asylumCase.read(INTERPRETER_LANGUAGE)).thenReturn(Optional.of(interpreterLanguage));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            reviewDraftHearingRequirementsPreparer.handle(ABOUT_TO_START, callback);
+
+        assertNotNull(callback);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).read(WITNESS_DETAILS);
+        verify(asylumCase, times(1)).read(INTERPRETER_LANGUAGE);
+
+        verify(asylumCase, times(1)).write(
+            WITNESS_DETAILS_READONLY,
+            "Name\t\tWitness1\nName\t\tWitness2");
+        verify(asylumCase, times(1)).write(
+            INTERPRETER_LANGUAGE_READONLY,
+            "Language\t\tIrish\nDialect\t\t\tN/A\n");
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6848

### Change description ###

- Gave Judge event access in application.yaml for event: reviewHearingRequirements
- Handler changes for aboutToStart callback for above event to throw UI error when Judge tries to trigger this event for a non-ADA case. Otherwise handle same way as LO
- Refactored unit tests and new unit tests for coverage

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
