### PR TITLE
Ria 6906 mark appeal as detained

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -114,5 +114,6 @@
         <cve>CVE-2022-1471</cve>
         <cve>CVE-2023-28708</cve>
         <cve>CVE-2023-20861</cve>
+        <cve>CVE-2023-20860</cve>
     </suppress>
 </suppressions>

--- a/src/functionalTest/resources/scenarios/RIA-6906-mark-appeal-as-detained.json
+++ b/src/functionalTest/resources/scenarios/RIA-6906-mark-appeal-as-detained.json
@@ -35,7 +35,10 @@
         },
         "dateCustodialSentence": {
           "custodialDate": "2023-03-28"
-        }
+        },
+        "appellantHasFixedAddress": null,
+        "contactPreference": null,
+        "mobileNumber": null
       }
     }
   }

--- a/src/functionalTest/resources/scenarios/RIA-6906-mark-appeal-as-detained.json
+++ b/src/functionalTest/resources/scenarios/RIA-6906-mark-appeal-as-detained.json
@@ -1,0 +1,42 @@
+{
+  "description": "RIA-6906 Mark appeal as detained",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "eventId": "markAppealAsDetained",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "appealType": "refusalOfEu",
+          "appellantInDetention": "No",
+          "prisonNOMSNumberAo": {
+            "prison": "nomsNumber"
+          },
+          "dateCustodialSentenceAo": {
+            "custodialDate": "2023-03-28"
+          }
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appealType": "refusalOfEu",
+        "appellantInDetention": "Yes",
+        "detentionStatus": "detained",
+        "prisonNOMSNumber": {
+          "prison": "nomsNumber"
+        },
+        "dateCustodialSentence": {
+          "custodialDate": "2023-03-28"
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1630,7 +1630,10 @@ public enum AsylumCaseFieldDefinition {
         "detentionFacility", new TypeReference<String>(){}),
 
     PRISON_NOMS(
-        "prisonNOMSNumber", new TypeReference<String>(){}),
+        "prisonNOMSNumber", new TypeReference<PrisonNomsNumber>(){}),
+
+    PRISON_NOMS_AO(
+        "prisonNOMSNumberAo", new TypeReference<PrisonNomsNumber>(){}),
 
     IRC_NAME(
         "ircName", new TypeReference<String>(){}),
@@ -1646,6 +1649,9 @@ public enum AsylumCaseFieldDefinition {
 
     DATE_CUSTODIAL_SENTENCE(
         "dateCustodialSentence", new TypeReference<CustodialSentenceDate>(){}),
+
+    DATE_CUSTODIAL_SENTENCE_AO(
+        "dateCustodialSentenceAo", new TypeReference<CustodialSentenceDate>(){}),
 
     BAIL_APPLICATION_NUMBER(
              "bailApplicationNumber", new TypeReference<String>(){}),

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/PrisonNomsNumber.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/PrisonNomsNumber.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+@Getter
+@AllArgsConstructor
+public class PrisonNomsNumber {
+
+    private String prison;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -121,6 +121,7 @@ public enum Event {
     PIP_ACTIVATION("pipActivation"),
     ADA_SUITABILITY_REVIEW("adaSuitabilityReview"),
     REMOVE_DETAINED_STATUS("removeDetainedStatus"),
+    MARK_APPEAL_AS_DETAINED("markAppealAsDetained"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/MarkAppealAsDetainedConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/MarkAppealAsDetainedConfirmation.java
@@ -35,7 +35,7 @@ public class MarkAppealAsDetainedConfirmation implements PostSubmitCallbackHandl
         postSubmitResponse.setConfirmationHeader("# You have marked the appeal as detained");
         postSubmitResponse.setConfirmationBody(
             "#### What happens next\n\nAll parties will be notified that the appeal has been marked an detained.\n\n"
-            + "You should notify the hearing center, if necessary."
+            + "You should update the hearing center, if necessary."
         );
 
         return postSubmitResponse;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/MarkAppealAsDetainedConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/MarkAppealAsDetainedConfirmation.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+@Component
+public class MarkAppealAsDetainedConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    @Override
+    public boolean canHandle(
+        Callback<AsylumCase> callback
+    ) {
+
+        requireNonNull(callback, "callback must not be null");
+        return callback.getEvent() == Event.MARK_APPEAL_AS_DETAINED;
+    }
+
+    @Override
+    public PostSubmitCallbackResponse handle(
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+
+        postSubmitResponse.setConfirmationHeader("# You have marked the appeal as detained");
+        postSubmitResponse.setConfirmationBody(
+            "#### What happens next\n\nAll parties will be notified that the appeal has been marked an detained.\n\n"
+            + "You should notify the hearing center, if necessary."
+        );
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/BailApplicationNumberHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/BailApplicationNumberHandler.java
@@ -32,7 +32,8 @@ public class BailApplicationNumberHandler implements PreSubmitCallbackHandler<As
         return callbackStage == PreSubmitCallbackStage.MID_EVENT
                && (callback.getEvent() == Event.START_APPEAL
                || callback.getEvent() == Event.EDIT_APPEAL
-               || callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT)
+               || callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT
+               || callback.getEvent() == Event.MARK_APPEAL_AS_DETAINED)
                && callback.getPageId().equals(HAS_PENDING_BAIL_APPLICATIONS.value());
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionStatusHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionStatusHandler.java
@@ -29,7 +29,8 @@ public class DetentionStatusHandler implements PreSubmitCallbackHandler<AsylumCa
 
         return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                && (callback.getEvent() == Event.START_APPEAL
-               || callback.getEvent() == Event.EDIT_APPEAL);
+               || callback.getEvent() == Event.EDIT_APPEAL
+               || callback.getEvent() == Event.MARK_APPEAL_AS_DETAINED);
     }
 
     @Override
@@ -57,6 +58,10 @@ public class DetentionStatusHandler implements PreSubmitCallbackHandler<AsylumCa
             } else if (appellantInDetention.equals(Optional.of(YesOrNo.YES)) && isAcceleratedDetainedAppeal.equals(Optional.of(YesOrNo.NO))) {
                 asylumCase.write(DETENTION_STATUS, DetentionStatus.DETAINED);
             }
+        }
+
+        if (callback.getEvent().equals(Event.MARK_APPEAL_AS_DETAINED)) {
+            asylumCase.write(DETENTION_STATUS, DetentionStatus.DETAINED);
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAppealAsDetainedHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAppealAsDetainedHandler.java
@@ -1,11 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_IN_DETENTION;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE_AO;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PRISON_NOMS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PRISON_NOMS_AO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.MARK_APPEAL_AS_DETAINED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
@@ -51,6 +47,13 @@ public class MarkAppealAsDetainedHandler implements PreSubmitCallbackHandler<Asy
 
         asylumCase.read(DATE_CUSTODIAL_SENTENCE_AO, CustodialSentenceDate.class)
             .ifPresent(dateAo -> asylumCase.write(DATE_CUSTODIAL_SENTENCE, dateAo));
+
+        // clearing non-detention related fields
+        asylumCase.clear(APPELLANT_HAS_FIXED_ADDRESS);
+        asylumCase.clear(APPELLANT_ADDRESS);
+        asylumCase.clear(CONTACT_PREFERENCE);
+        asylumCase.clear(EMAIL);
+        asylumCase.clear(MOBILE_NUMBER);
 
         asylumCase.write(APPELLANT_IN_DETENTION, YES);
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAppealAsDetainedHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAppealAsDetainedHandler.java
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_IN_DETENTION;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE_AO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PRISON_NOMS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PRISON_NOMS_AO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.MARK_APPEAL_AS_DETAINED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CustodialSentenceDate;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.PrisonNomsNumber;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class MarkAppealAsDetainedHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+               && callback.getEvent() == MARK_APPEAL_AS_DETAINED;
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback) {
+
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        asylumCase.read(PRISON_NOMS_AO, PrisonNomsNumber.class)
+            .ifPresent(prisonNomsAo -> asylumCase.write(PRISON_NOMS, prisonNomsAo));
+
+        asylumCase.read(DATE_CUSTODIAL_SENTENCE_AO, CustodialSentenceDate.class)
+            .ifPresent(dateAo -> asylumCase.write(DATE_CUSTODIAL_SENTENCE, dateAo));
+
+        asylumCase.write(APPELLANT_IN_DETENTION, YES);
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -278,11 +278,8 @@ security:
       - "markAppealPaid"
       - "transferOutOfAda"
       - "markAppealAsAda"
-<<<<<<< HEAD
       - "removeDetainedStatus"
-=======
       - "markAppealAsDetained"
->>>>>>> d41d233c (RIA-6906 MarkAppealAsDetained event, pre- and post-submit handlers, PrisonNomsNumber entity)
     caseworker-ia-admofficer:
       - "startAppeal"
       - "submitAppeal"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -278,7 +278,11 @@ security:
       - "markAppealPaid"
       - "transferOutOfAda"
       - "markAppealAsAda"
+<<<<<<< HEAD
       - "removeDetainedStatus"
+=======
+      - "markAppealAsDetained"
+>>>>>>> d41d233c (RIA-6906 MarkAppealAsDetained event, pre- and post-submit handlers, PrisonNomsNumber entity)
     caseworker-ia-admofficer:
       - "startAppeal"
       - "submitAppeal"
@@ -320,6 +324,7 @@ security:
       - "editAppealAfterSubmit"
       - "markAppealAsAda"
       - "removeDetainedStatus"
+      - "markAppealAsDetained"
     caseworker-ia-homeofficeapc:
       - "uploadHomeOfficeBundle"
       - "uploadAdditionalEvidenceHomeOffice"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinitionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinitionTest.java
@@ -5,6 +5,7 @@ import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ATTENDING_TCW;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PRISON_NOMS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PRISON_NOMS_AO;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -12,7 +13,11 @@ import org.junit.jupiter.api.Test;
 
 class AsylumCaseFieldDefinitionTest {
 
-    List<AsylumCaseFieldDefinition> exceptions = List.of(new AsylumCaseFieldDefinition[]{ATTENDING_TCW, PRISON_NOMS});
+    List<AsylumCaseFieldDefinition> exceptions = List.of(new AsylumCaseFieldDefinition[]{
+        ATTENDING_TCW,
+        PRISON_NOMS,
+        PRISON_NOMS_AO
+    });
 
     @Test
     void mapped_to_equivalent_field_name() {

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -120,7 +120,7 @@ class EventTest {
         assertEquals("transferOutOfAda", Event.TRANSFER_OUT_OF_ADA.toString());
         assertEquals("markAppealAsAda", Event.MARK_APPEAL_AS_ADA.toString());
         assertEquals("removeDetainedStatus", Event.REMOVE_DETAINED_STATUS.toString());
-
+        assertEquals("markAppealAsDetained", Event.MARK_APPEAL_AS_DETAINED.toString());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -125,6 +125,6 @@ class EventTest {
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(117, Event.values().length);
+        assertEquals(118, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/MarkAppealAsDetainedConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/MarkAppealAsDetainedConfirmationTest.java
@@ -1,0 +1,92 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class MarkAppealAsDetainedConfirmationTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+
+    private MarkAppealAsDetainedConfirmation markAppealAsDetainedConfirmation = new MarkAppealAsDetainedConfirmation();
+
+    @Test
+    void should_return_confirmation() {
+
+        when(callback.getEvent()).thenReturn(Event.MARK_APPEAL_AS_DETAINED);
+
+        PostSubmitCallbackResponse callbackResponse =
+            markAppealAsDetainedConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        assertThat(
+            callbackResponse.getConfirmationHeader().get())
+            .contains("# You have marked the appeal as detained");
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get())
+            .contains("#### What happens next\n\nAll parties will be notified that "
+                      + "the appeal has been marked an detained.\n\n"
+                      + "You should notify the hearing center, if necessary.");
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> markAppealAsDetainedConfirmation.handle(callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            boolean canHandle = markAppealAsDetainedConfirmation.canHandle(callback);
+
+            if (event == Event.MARK_APPEAL_AS_DETAINED) {
+
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> markAppealAsDetainedConfirmation.canHandle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> markAppealAsDetainedConfirmation.handle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}
+

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/MarkAppealAsDetainedConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/MarkAppealAsDetainedConfirmationTest.java
@@ -46,7 +46,7 @@ class MarkAppealAsDetainedConfirmationTest {
             callbackResponse.getConfirmationBody().get())
             .contains("#### What happens next\n\nAll parties will be notified that "
                       + "the appeal has been marked an detained.\n\n"
-                      + "You should notify the hearing center, if necessary.");
+                      + "You should update the hearing center, if necessary.");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/BailApplicationNumberHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/BailApplicationNumberHandlerTest.java
@@ -122,7 +122,8 @@ public class BailApplicationNumberHandlerTest {
                 if (callbackStage == PreSubmitCallbackStage.MID_EVENT
                     && (callback.getEvent() == Event.START_APPEAL
                     || callback.getEvent() == Event.EDIT_APPEAL
-                    || callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT)
+                    || callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT
+                    || callback.getEvent() == Event.MARK_APPEAL_AS_DETAINED)
                     && callback.getPageId().equals(HAS_PENDING_BAIL_APPLICATIONS.value())) {
 
                     assertTrue(canHandle);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CustodialDateValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CustodialDateValidatorTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE_AO;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
@@ -131,6 +132,8 @@ public class CustodialDateValidatorTest {
 
         when(asylumCase.read(DATE_CUSTODIAL_SENTENCE, CustodialSentenceDate.class))
             .thenReturn(Optional.of(custodialSentenceDate));
+        when(asylumCase.read(DATE_CUSTODIAL_SENTENCE_AO, CustodialSentenceDate.class))
+            .thenReturn(Optional.of(custodialSentenceDate));
 
         String yesterday = now.minusDays(1).toString();
         when(custodialSentenceDate.getCustodialDate()).thenReturn(yesterday);
@@ -144,10 +147,8 @@ public class CustodialDateValidatorTest {
 
         if (event.equals(Event.MARK_APPEAL_AS_DETAINED)) {
             assertThat(errors).hasSize(1).containsOnly(CALLBACK_ERROR_MESSAGE_AO);
-
         } else {
             assertThat(errors).hasSize(1).containsOnly(CALLBACK_ERROR_MESSAGE_LR);
-
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionStatusHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionStatusHandlerTest.java
@@ -97,7 +97,9 @@ class DetentionStatusHandlerTest {
             for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
                 boolean canHandle = detentionStatusHandler.canHandle(callbackStage, callback);
                 if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-                    && ((callback.getEvent() == Event.START_APPEAL || callback.getEvent() == Event.EDIT_APPEAL))) {
+                    && ((callback.getEvent() == Event.START_APPEAL
+                         || callback.getEvent() == Event.EDIT_APPEAL
+                         || callback.getEvent() == Event.MARK_APPEAL_AS_DETAINED))) {
                     assertTrue(canHandle);
                 } else {
                     assertFalse(canHandle);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionStatusHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetentionStatusHandlerTest.java
@@ -67,6 +67,19 @@ class DetentionStatusHandlerTest {
     }
 
     @Test
+    void should_mark_appeal_as_detained() {
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.MARK_APPEAL_AS_DETAINED);
+
+        detentionStatusHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        verify(asylumCase, times(1)).write(AsylumCaseFieldDefinition.DETENTION_STATUS, DetentionStatus.DETAINED);
+
+    }
+
+    @Test
     void handling_should_throw_if_cannot_actually_handle() {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAppealAsDetainedHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAppealAsDetainedHandlerTest.java
@@ -7,11 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_IN_DETENTION;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE_AO;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PRISON_NOMS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PRISON_NOMS_AO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import java.util.Optional;
@@ -73,6 +69,12 @@ class MarkAppealAsDetainedHandlerTest {
         verify(asylumCase).write(PRISON_NOMS, prisonNomsNumber);
         verify(asylumCase).write(DATE_CUSTODIAL_SENTENCE, custodialSentenceDate);
         verify(asylumCase).write(APPELLANT_IN_DETENTION, YES);
+        verify(asylumCase).clear(APPELLANT_HAS_FIXED_ADDRESS);
+        verify(asylumCase).clear(APPELLANT_ADDRESS);
+        verify(asylumCase).clear(CONTACT_PREFERENCE);
+        verify(asylumCase).clear(EMAIL);
+        verify(asylumCase).clear(MOBILE_NUMBER);
+
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAppealAsDetainedHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAppealAsDetainedHandlerTest.java
@@ -1,0 +1,115 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_IN_DETENTION;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE_AO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PRISON_NOMS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PRISON_NOMS_AO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CustodialSentenceDate;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.PrisonNomsNumber;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class MarkAppealAsDetainedHandlerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private CustodialSentenceDate custodialSentenceDate;
+    @Mock
+    private PrisonNomsNumber prisonNomsNumber;
+
+    private MarkAppealAsDetainedHandler markAppealAsDetainedHandler;
+
+    @BeforeEach
+    public void setup() {
+
+        markAppealAsDetainedHandler = new MarkAppealAsDetainedHandler();
+    }
+
+    @Test
+    void should_mark_appeal_as_detained_and_update_case_data() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.MARK_APPEAL_AS_DETAINED);
+
+        when(asylumCase.read(PRISON_NOMS_AO, PrisonNomsNumber.class)).thenReturn(Optional.of(prisonNomsNumber));
+        when(asylumCase.read(DATE_CUSTODIAL_SENTENCE_AO, CustodialSentenceDate.class))
+            .thenReturn(Optional.of(custodialSentenceDate));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            markAppealAsDetainedHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase).write(PRISON_NOMS, prisonNomsNumber);
+        verify(asylumCase).write(DATE_CUSTODIAL_SENTENCE, custodialSentenceDate);
+        verify(asylumCase).write(APPELLANT_IN_DETENTION, YES);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = markAppealAsDetainedHandler.canHandle(callbackStage, callback);
+                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                        && callback.getEvent() == Event.MARK_APPEAL_AS_DETAINED) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> markAppealAsDetainedHandler.canHandle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(
+                () -> markAppealAsDetainedHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> markAppealAsDetainedHandler.handle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> markAppealAsDetainedHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-6906](https://tools.hmcts.net/jira/browse/RIA-6906)


### Change description ###
- added `PrisonNomsNumber` entity which didn't use to exist
- new event **markAppealAsDetained** with handler which maps `prisonNomsNumberAo` and `dateCustodialSentenceAo` to `prisonNomsNumber` and `dateCustodialSentence` before the end of the event
- made `DetentionStatusHandler` set detention status to "detained" when the event is `markAppealAsDetained`
- made `BailApplicationNumberHandler` and `CustodialDateValidator` use validation during the new event too
- made valid


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
