### PR TITLE
RIA-6907 Remove detained status event handlers and tests

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-6907-remove-detained-status.json
+++ b/src/functionalTest/resources/scenarios/RIA-6907-remove-detained-status.json
@@ -1,0 +1,39 @@
+{
+  "description": "RIA-6907 Remove detained status",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "eventId": "removeDetainedStatus",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "detentionFacility": "prison",
+          "prisonName": "Birmingham",
+          "prisonNOMSNumber": {
+            "prison": "123456"
+          },
+          "custodialSentence": "No",
+          "hasPendingBailApplications": "No"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "No",
+        "detentionFacility": null,
+        "prisonName": null,
+        "prisonNOMSNumber": null,
+        "custodialSentence": null,
+        "hasPendingBailApplications": null
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -118,9 +118,10 @@ public enum Event {
     GENERATE_SERVICE_REQUEST("generateServiceRequest"),
     TRANSFER_OUT_OF_ADA("transferOutOfAda"),
     MARK_APPEAL_AS_ADA("markAppealAsAda"),
-
     PIP_ACTIVATION("pipActivation"),
     ADA_SUITABILITY_REVIEW("adaSuitabilityReview"),
+    REMOVE_DETAINED_STATUS("removeDetainedStatus"),
+
     @JsonEnumDefaultValue
     UNKNOWN("unknown");
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/RemoveDetainedStatusConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/RemoveDetainedStatusConfirmation.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+@Component
+public class RemoveDetainedStatusConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    @Override
+    public boolean canHandle(
+        Callback<AsylumCase> callback
+    ) {
+
+        requireNonNull(callback, "callback must not be null");
+        return callback.getEvent() == Event.REMOVE_DETAINED_STATUS;
+    }
+
+    @Override
+    public PostSubmitCallbackResponse handle(
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+
+        postSubmitResponse.setConfirmationHeader("# You have removed the detained status from this appeal");
+        postSubmitResponse.setConfirmationBody(
+            "#### What happens next\n\n"
+            + "All parties will be notified that the appellant's detention status has been updated.\n\n"
+            + "You should update the hearing centre, if necessary."
+        );
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RemoveDetainedStatusHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RemoveDetainedStatusHandler.java
@@ -1,0 +1,78 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DETENTION_STATUS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.REMOVE_DETAINED_STATUS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Slf4j
+@Component
+public class RemoveDetainedStatusHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+               && callback.getEvent() == REMOVE_DETAINED_STATUS;
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback) {
+
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        Optional<YesOrNo> appellantInDetention = asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class);
+
+        if (appellantInDetention.isPresent() && appellantInDetention.equals(Optional.of(YES))) {
+
+            clearDetentionRelatedFields(asylumCase);
+
+            asylumCase.write(APPELLANT_IN_DETENTION, NO);
+
+        }
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    private void clearDetentionRelatedFields(AsylumCase asylumCase) {
+
+        log.info("Event: Remove Detained status - Clearing Detention related fields");
+        asylumCase.clear(DETENTION_FACILITY);
+        asylumCase.clear(IRC_NAME);
+        asylumCase.clear(PRISON_NAME);
+        asylumCase.clear(OTHER_DETENTION_FACILITY_NAME);
+        asylumCase.clear(PRISON_NOMS);
+        asylumCase.clear(CUSTODIAL_SENTENCE);
+        asylumCase.clear(DATE_CUSTODIAL_SENTENCE);
+        asylumCase.clear(HAS_PENDING_BAIL_APPLICATIONS);
+        asylumCase.clear(BAIL_APPLICATION_NUMBER);
+        asylumCase.clear(REMOVAL_ORDER_OPTIONS);
+        asylumCase.clear(REMOVAL_ORDER_DATE);
+        asylumCase.clear(DETENTION_STATUS);
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -278,6 +278,7 @@ security:
       - "markAppealPaid"
       - "transferOutOfAda"
       - "markAppealAsAda"
+      - "removeDetainedStatus"
     caseworker-ia-admofficer:
       - "startAppeal"
       - "submitAppeal"
@@ -318,6 +319,7 @@ security:
       - "markPaymentRequestSent"
       - "editAppealAfterSubmit"
       - "markAppealAsAda"
+      - "removeDetainedStatus"
     caseworker-ia-homeofficeapc:
       - "uploadHomeOfficeBundle"
       - "uploadAdditionalEvidenceHomeOffice"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -119,11 +119,12 @@ class EventTest {
         assertEquals("adaSuitabilityReview", Event.ADA_SUITABILITY_REVIEW.toString());
         assertEquals("transferOutOfAda", Event.TRANSFER_OUT_OF_ADA.toString());
         assertEquals("markAppealAsAda", Event.MARK_APPEAL_AS_ADA.toString());
+        assertEquals("removeDetainedStatus", Event.REMOVE_DETAINED_STATUS.toString());
 
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(116, Event.values().length);
+        assertEquals(117, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/RemoveDetainedStatusConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/RemoveDetainedStatusConfirmationTest.java
@@ -1,0 +1,103 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class RemoveDetainedStatusConfirmationTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+
+    private RemoveDetainedStatusConfirmation removeDetainedStatusConfirmation = new RemoveDetainedStatusConfirmation();
+
+    @Test
+    void should_return_confirmation_for_removing_detained_status() {
+
+        when(callback.getEvent()).thenReturn(Event.REMOVE_DETAINED_STATUS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        PostSubmitCallbackResponse callbackResponse =
+            removeDetainedStatusConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        assertThat(
+            callbackResponse.getConfirmationHeader().get())
+            .contains("# You have removed the detained status from this appeal");
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get())
+            .contains("#### What happens next\n\n"
+                      + "All parties will be notified that the appellant's detention status has been updated.\n\n"
+                      + "You should update the hearing centre, if necessary.");
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> removeDetainedStatusConfirmation.handle(callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            boolean canHandle = removeDetainedStatusConfirmation.canHandle(callback);
+
+            if (event == Event.REMOVE_DETAINED_STATUS) {
+
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> removeDetainedStatusConfirmation.canHandle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> removeDetainedStatusConfirmation.handle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RemoveDetainedStatusHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RemoveDetainedStatusHandlerTest.java
@@ -1,0 +1,118 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class RemoveDetainedStatusHandlerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    private RemoveDetainedStatusHandler removeDetainedStatusHandler;
+
+    @BeforeEach
+    public void setup() {
+        removeDetainedStatusHandler = new RemoveDetainedStatusHandler();
+    }
+
+    @Test
+    void should_remove_detained_status_for_a_non_ada_detained_case() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(callback.getEvent()).thenReturn(Event.REMOVE_DETAINED_STATUS);
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            removeDetainedStatusHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase).write(APPELLANT_IN_DETENTION, YesOrNo.NO);
+        verify(asylumCase).clear(DETENTION_FACILITY);
+        verify(asylumCase).clear(IRC_NAME);
+        verify(asylumCase).clear(PRISON_NAME);
+        verify(asylumCase).clear(OTHER_DETENTION_FACILITY_NAME);
+        verify(asylumCase).clear(PRISON_NOMS);
+        verify(asylumCase).clear(CUSTODIAL_SENTENCE);
+        verify(asylumCase).clear(DATE_CUSTODIAL_SENTENCE);
+        verify(asylumCase).clear(HAS_PENDING_BAIL_APPLICATIONS);
+        verify(asylumCase).clear(BAIL_APPLICATION_NUMBER);
+        verify(asylumCase).clear(REMOVAL_ORDER_OPTIONS);
+        verify(asylumCase).clear(REMOVAL_ORDER_DATE);
+        verify(asylumCase).clear(DETENTION_STATUS);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        assertThatThrownBy(
+            () -> removeDetainedStatusHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = removeDetainedStatusHandler.canHandle(callbackStage, callback);
+                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                    && ((callback.getEvent() == Event.REMOVE_DETAINED_STATUS))) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> removeDetainedStatusHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(
+            () -> removeDetainedStatusHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> removeDetainedStatusHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> removeDetainedStatusHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6907

### Change description ###

- Handler for 'Remove detained status' event to write the field 'appellantInDetention' to 'No' and clear all detention-related fields from case data
- New event ID added
- Event authorisations added for Admin Officer and Legal Officer
- Confirmation screen for the 'Remove detained status' event
- Units tests and functional test

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
