### PR TITLE
RIA-6990 Fix CustodialDateValidator

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CustodialDateValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CustodialDateValidatorTest.java
@@ -8,8 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CUSTODIAL_SENTENCE_AO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
@@ -36,6 +35,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ExtendWith(MockitoExtension.class)
@@ -129,6 +129,8 @@ public class CustodialDateValidatorTest {
     })
     void should_error_when_date_is_not_future(Event event) {
         when(callback.getEvent()).thenReturn(event);
+        when(asylumCase.read(CUSTODIAL_SENTENCE, YesOrNo.class))
+                .thenReturn(Optional.of(YesOrNo.YES));
 
         when(asylumCase.read(DATE_CUSTODIAL_SENTENCE, CustodialSentenceDate.class))
             .thenReturn(Optional.of(custodialSentenceDate));


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6990


### Change description ###
Return as soon as client in custody == no
Return as soon as date is null (optional field)
Changed how dateCustodialSentence and dateCustodialSentenceAo are extracted/parsed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
