### PR TITLE
RIA-6586 Fixing typo in confirmation text

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/TransferOutOfAdaConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/TransferOutOfAdaConfirmation.java
@@ -36,7 +36,7 @@ public class TransferOutOfAdaConfirmation implements PostSubmitCallbackHandler<A
         postSubmitResponse.setConfirmationBody(
                 "#### What happens next\n\n"
                         + "All parties will be notified that this is no longer an accelerated detained appeal.\n\n"
-                        + "A Legal Officer will review the case and decide next steps."
+                        + "A Legal Officer will review the case and decide the next steps."
         );
 
         return postSubmitResponse;

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/TransferOutOfAdaConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/TransferOutOfAdaConfirmationTest.java
@@ -56,7 +56,7 @@ class TransferOutOfAdaConfirmationTest {
                 callbackResponse.getConfirmationBody().get())
                 .contains("#### What happens next\n\n"
                         + "All parties will be notified that this is no longer an accelerated detained appeal.\n\n"
-                        + "A Legal Officer will review the case and decide next steps.");
+                        + "A Legal Officer will review the case and decide the next steps.");
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-6586

### Change description ###

- Adding missing 'the' in confirmation content

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
