### PR TITLE
RIA-7003 unrep start appeal confirmation content change

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AppealSavedConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AppealSavedConfirmation.java
@@ -73,10 +73,10 @@ public class AppealSavedConfirmation implements PostSubmitCallbackHandler<Asylum
         }
 
         String submitAppealUrl = "/trigger/submitAppeal";
-        String submitLabel = "submit your appeal";
+        String submitLabel = "submit the appeal";
 
 
-        postSubmitResponse.setConfirmationHeader("# Your appeal details have been saved\n# You still need to submit it");
+        postSubmitResponse.setConfirmationHeader("# The appeal has been saved\n# You still need to submit it");
         postSubmitResponse.setConfirmationBody(
             "### Do this next\n\n"
             + "If you're ready to proceed [" + submitLabel + "](/case/IA/Asylum/"

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AppealSavedConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AppealSavedConfirmation.java
@@ -73,17 +73,28 @@ public class AppealSavedConfirmation implements PostSubmitCallbackHandler<Asylum
         }
 
         String submitAppealUrl = "/trigger/submitAppeal";
-        String submitLabel = "submit the appeal";
+        String submitLabel = "submit your appeal";
+        String submitLabelUnrep = "submit the appeal";
 
-
-        postSubmitResponse.setConfirmationHeader("# The appeal has been saved\n# You still need to submit it");
-        postSubmitResponse.setConfirmationBody(
-            "### Do this next\n\n"
-            + "If you're ready to proceed [" + submitLabel + "](/case/IA/Asylum/"
-            + callback.getCaseDetails().getId() + submitAppealUrl + ").\n\n"
-            + "#### Not ready to submit yet?\n"
-            + "You can return to the case details to make changes."
-        );
+        if (HandlerUtils.isInternalCase(asylumCase)) {
+            postSubmitResponse.setConfirmationHeader("# The appeal has been saved\n# You still need to submit it");
+            postSubmitResponse.setConfirmationBody(
+                "### Do this next\n\n"
+                + "If you're ready to proceed [" + submitLabelUnrep + "](/case/IA/Asylum/"
+                + callback.getCaseDetails().getId() + submitAppealUrl + ").\n\n"
+                + "#### Not ready to submit yet?\n"
+                + "You can return to the case details to make changes."
+            );
+        } else {
+            postSubmitResponse.setConfirmationHeader("# Your appeal details have been saved\n# You still need to submit it");
+            postSubmitResponse.setConfirmationBody(
+                "### Do this next\n\n"
+                + "If you're ready to proceed [" + submitLabel + "](/case/IA/Asylum/"
+                + callback.getCaseDetails().getId() + submitAppealUrl + ").\n\n"
+                + "#### Not ready to submit yet?\n"
+                + "You can return to the case details to make changes."
+            );
+        }
 
         if (asylumCase.read(AsylumCaseFieldDefinition.LOCAL_AUTHORITY_POLICY, OrganisationPolicy.class).isPresent()
             && callback.getEvent() == Event.START_APPEAL

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AppealSavedConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AppealSavedConfirmationTest.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ref.OrganisationEntityResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.FeatureToggler;
 import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.CcdCaseAssignment;
@@ -97,7 +98,7 @@ class AppealSavedConfirmationTest {
 
         assertThat(
             callbackResponse.getConfirmationHeader().get())
-            .contains("# The appeal has been saved");
+            .contains("# Your appeal details have been saved");
 
         assertThat(
             callbackResponse.getConfirmationBody().get())
@@ -106,7 +107,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit the appeal]"
+                "[submit your appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -142,7 +143,7 @@ class AppealSavedConfirmationTest {
 
         assertThat(
             callbackResponse.getConfirmationHeader().get())
-            .contains("# The appeal has been saved");
+            .contains("# Your appeal details have been saved");
 
         assertThat(
             callbackResponse.getConfirmationBody().get())
@@ -151,7 +152,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit the appeal]"
+                "[submit your appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -187,7 +188,7 @@ class AppealSavedConfirmationTest {
 
         assertThat(
             callbackResponse.getConfirmationHeader().get())
-            .contains("# The appeal has been saved");
+            .contains("# Your appeal details have been saved");
 
         assertThat(
             callbackResponse.getConfirmationBody().get())
@@ -196,7 +197,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit the appeal]"
+                "[submit your appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -232,7 +233,7 @@ class AppealSavedConfirmationTest {
 
         assertThat(
             callbackResponse.getConfirmationHeader().get())
-            .contains("# The appeal has been saved");
+            .contains("# Your appeal details have been saved");
 
         assertThat(
             callbackResponse.getConfirmationBody().get())
@@ -241,7 +242,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit the appeal]"
+                "[submit your appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -279,7 +280,7 @@ class AppealSavedConfirmationTest {
 
         assertThat(
             callbackResponse.getConfirmationHeader().get())
-            .contains("# The appeal has been saved");
+            .contains("# Your appeal details have been saved");
 
         assertThat(
             callbackResponse.getConfirmationBody().get())
@@ -288,7 +289,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit the appeal]"
+                "[submit your appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -325,7 +326,7 @@ class AppealSavedConfirmationTest {
 
         assertThat(
             callbackResponse.getConfirmationHeader().get())
-            .contains("# The appeal has been saved");
+            .contains("# Your appeal details have been saved");
 
         assertThat(
             callbackResponse.getConfirmationBody().get())
@@ -334,7 +335,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit the appeal]"
+                "[submit your appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -373,7 +374,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit the appeal]"
+                "[submit your appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -406,7 +407,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit the appeal]"
+                "[submit your appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -438,7 +439,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit the appeal]"
+                "[submit your appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -508,6 +509,50 @@ class AppealSavedConfirmationTest {
         assertTrue(callbackResponse.getConfirmationBody().isPresent());
 
         verify(ccdCaseAssignment, times(0)).revokeAccessToCase(callback, organisationIdentifier);
+    }
+
+    @Test
+    void should_return_confirmation_for_internal_cases_admin() {
+
+        long caseId = 1234;
+
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(AppealType.EA));
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(caseDetails.getId()).thenReturn(caseId);
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        when(professionalOrganisationRetriever.retrieve()).thenReturn(organisationEntityResponse);
+        when(organisationEntityResponse.getOrganisationIdentifier()).thenReturn(organisationIdentifier);
+        when(featureToggler.getValue("share-case-feature", false)).thenReturn(true);
+
+        PostSubmitCallbackResponse callbackResponse =
+            appealSavedConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        assertThat(
+            callbackResponse.getConfirmationHeader().get())
+            .contains("# The appeal has been saved");
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get())
+            .contains("### Do this next");
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get())
+            .contains(
+                "[submit the appeal]"
+                + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
+            );
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get())
+            .contains("Not ready to submit yet?");
+
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AppealSavedConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/AppealSavedConfirmationTest.java
@@ -97,7 +97,7 @@ class AppealSavedConfirmationTest {
 
         assertThat(
             callbackResponse.getConfirmationHeader().get())
-            .contains("# Your appeal details have been saved");
+            .contains("# The appeal has been saved");
 
         assertThat(
             callbackResponse.getConfirmationBody().get())
@@ -106,7 +106,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit your appeal]"
+                "[submit the appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -142,7 +142,7 @@ class AppealSavedConfirmationTest {
 
         assertThat(
             callbackResponse.getConfirmationHeader().get())
-            .contains("# Your appeal details have been saved");
+            .contains("# The appeal has been saved");
 
         assertThat(
             callbackResponse.getConfirmationBody().get())
@@ -151,7 +151,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit your appeal]"
+                "[submit the appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -187,7 +187,7 @@ class AppealSavedConfirmationTest {
 
         assertThat(
             callbackResponse.getConfirmationHeader().get())
-            .contains("# Your appeal details have been saved");
+            .contains("# The appeal has been saved");
 
         assertThat(
             callbackResponse.getConfirmationBody().get())
@@ -196,7 +196,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit your appeal]"
+                "[submit the appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -232,7 +232,7 @@ class AppealSavedConfirmationTest {
 
         assertThat(
             callbackResponse.getConfirmationHeader().get())
-            .contains("# Your appeal details have been saved");
+            .contains("# The appeal has been saved");
 
         assertThat(
             callbackResponse.getConfirmationBody().get())
@@ -241,7 +241,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit your appeal]"
+                "[submit the appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -279,7 +279,7 @@ class AppealSavedConfirmationTest {
 
         assertThat(
             callbackResponse.getConfirmationHeader().get())
-            .contains("# Your appeal details have been saved");
+            .contains("# The appeal has been saved");
 
         assertThat(
             callbackResponse.getConfirmationBody().get())
@@ -288,7 +288,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit your appeal]"
+                "[submit the appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -325,7 +325,7 @@ class AppealSavedConfirmationTest {
 
         assertThat(
             callbackResponse.getConfirmationHeader().get())
-            .contains("# Your appeal details have been saved");
+            .contains("# The appeal has been saved");
 
         assertThat(
             callbackResponse.getConfirmationBody().get())
@@ -334,7 +334,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit your appeal]"
+                "[submit the appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -373,7 +373,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit your appeal]"
+                "[submit the appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -406,7 +406,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit your appeal]"
+                "[submit the appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 
@@ -438,7 +438,7 @@ class AppealSavedConfirmationTest {
         assertThat(
             callbackResponse.getConfirmationBody().get())
             .contains(
-                "[submit your appeal]"
+                "[submit the appeal]"
                 + "(/case/IA/Asylum/" + caseId + "/trigger/submitAppeal)"
             );
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7003

### Change description ###

- Adding new content for Unrrepped/Internal/Admin-created cases confirmation screen for startAppeal event and logic to show correct version for both LR and Admin
- Added new unit test 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
