### PR TITLE
RIA-7052 Skip BE handling of supplementary data if citizen in AIP journey

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/iacaseapi/component/testutils/fixtures/CaseDetailsForTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/iacaseapi/component/testutils/fixtures/CaseDetailsForTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iacaseapi.component.testutils.fixtures;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
+import java.util.Map;
 import lombok.Data;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
@@ -16,13 +17,16 @@ public class CaseDetailsForTest {
     private AsylumCase caseData;
     @JsonProperty("created_date")
     private LocalDateTime createdDate;
+    @JsonProperty("supplementary_data")
+    private Map<String,String> supplementaryData;
 
-    CaseDetailsForTest(long id, String jurisdiction, State state, AsylumCase caseData, LocalDateTime createdDate) {
+    CaseDetailsForTest(long id, String jurisdiction, State state, AsylumCase caseData, LocalDateTime createdDate, Map<String,String> supplementaryData) {
         this.id = id;
         this.jurisdiction = jurisdiction;
         this.state = state;
         this.caseData = caseData;
         this.createdDate = createdDate;
+        this.supplementaryData = supplementaryData;
     }
 
     public static class CaseDetailsForTestBuilder implements Builder<CaseDetailsForTest> {
@@ -36,6 +40,7 @@ public class CaseDetailsForTest {
         private State state;
         private AsylumCase caseData;
         private LocalDateTime createdDate = LocalDateTime.now();
+        private Map<String,String> supplementaryData = Map.of("HMCTSServiceId","BFA1");
 
         CaseDetailsForTestBuilder() {
         }
@@ -65,12 +70,17 @@ public class CaseDetailsForTest {
             return this;
         }
 
+        public CaseDetailsForTestBuilder supplementaryData(Map<String,String> supplementaryData) {
+            this.supplementaryData = supplementaryData;
+            return this;
+        }
+
         public CaseDetailsForTest build() {
-            return new CaseDetailsForTest(id, jurisdiction, state, caseData, createdDate);
+            return new CaseDetailsForTest(id, jurisdiction, state, caseData, createdDate, supplementaryData);
         }
 
         public String toString() {
-            return "CaseDetailsForTest.CaseDetailsForTestBuilder(id=" + this.id + ", jurisdiction=" + this.jurisdiction + ", state=" + this.state + ", caseData=" + this.caseData + ", createdDate=" + this.createdDate + ")";
+            return "CaseDetailsForTest.CaseDetailsForTestBuilder(id=" + this.id + ", jurisdiction=" + this.jurisdiction + ", state=" + this.state + ", caseData=" + this.caseData + ", createdDate=" + this.createdDate + ", supplementaryData=" + this.supplementaryData + ")";
         }
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/UserDetailsRequestScopeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/UserDetailsRequestScopeTest.java
@@ -6,11 +6,16 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.component.testutils.fixtures.AsylumCaseForTest.anAsylumCase;
 import static uk.gov.hmcts.reform.iacaseapi.component.testutils.fixtures.CallbackForTest.CallbackForTestBuilder.callback;
 import static uk.gov.hmcts.reform.iacaseapi.component.testutils.fixtures.CaseDetailsForTest.CaseDetailsForTestBuilder.someCaseDetailsWith;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_GIVEN_NAMES;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.MAKE_AN_APPLICATION_DETAILS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.MAKE_AN_APPLICATION_TYPES;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.MAKE_AN_APPLICATION;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.APPEAL_SUBMITTED;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -68,6 +73,7 @@ class UserDetailsRequestScopeTest extends SpringBootIntegrationTest implements W
                     someCaseDetailsWith()
                         .id(4321)
                         .state(APPEAL_SUBMITTED)
+                        .supplementaryData(Map.of("HMCTSServiceId","BFA1"))
                         .caseData(
                             anAsylumCase()
                                 .with(APPEAL_TYPE, AppealType.PA)
@@ -79,7 +85,8 @@ class UserDetailsRequestScopeTest extends SpringBootIntegrationTest implements W
                 )
         );
 
-        // assert that only one request is sent to Idam API for user info data
-        Mockito.verify(idamApi, times(1)).userInfo(token);
+        // assert that only two requests in total are sent to Idam API for user info data (one for the event,
+        // one to determine if supplementary data need handling based on user role + journey type
+        Mockito.verify(idamApi, times(2)).userInfo(token);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AsylumSupplementaryDataFixingHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AsylumSupplementaryDataFixingHandler.java
@@ -40,7 +40,7 @@ public class AsylumSupplementaryDataFixingHandler implements PreSubmitCallbackHa
             Callback<AsylumCase> callback
     ) {
         return !userDetailsProvider.getUserDetails().getRoles().contains(CITIZEN)
-               && !isAipJourney(callback.getCaseDetails().getCaseData());
+               || !isAipJourney(callback.getCaseDetails().getCaseData());
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AsylumSupplementaryDataFixingHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AsylumSupplementaryDataFixingHandler.java
@@ -1,8 +1,11 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isAipJourney;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.UserDetailsProvider;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
@@ -15,10 +18,15 @@ import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.CcdSupplementaryUpda
 @Component
 public class AsylumSupplementaryDataFixingHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
-    private final CcdSupplementaryUpdater ccdSupplementaryUpdater;
+    private static final String CITIZEN = "citizen";
 
-    public AsylumSupplementaryDataFixingHandler(CcdSupplementaryUpdater ccdSupplementaryUpdater) {
+    private final CcdSupplementaryUpdater ccdSupplementaryUpdater;
+    private final UserDetailsProvider userDetailsProvider;
+
+    public AsylumSupplementaryDataFixingHandler(CcdSupplementaryUpdater ccdSupplementaryUpdater,
+                                                UserDetailsProvider userDetailsProvider) {
         this.ccdSupplementaryUpdater = ccdSupplementaryUpdater;
+        this.userDetailsProvider = userDetailsProvider;
     }
 
     @Override
@@ -31,7 +39,8 @@ public class AsylumSupplementaryDataFixingHandler implements PreSubmitCallbackHa
             PreSubmitCallbackStage callbackStage,
             Callback<AsylumCase> callback
     ) {
-        return true;
+        return !userDetailsProvider.getUserDetails().getRoles().contains(CITIZEN)
+               && !isAipJourney(callback.getCaseDetails().getCaseData());
     }
 
     @Override

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AsylumSupplementaryDataFixingHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AsylumSupplementaryDataFixingHandlerTest.java
@@ -1,26 +1,31 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority.EARLIEST;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.UserDetailsProvider;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.UserDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.CcdSupplementaryUpdater;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,12 +39,16 @@ class AsylumSupplementaryDataFixingHandlerTest {
     private AsylumCase asylumCase;
     @Mock
     private CcdSupplementaryUpdater ccdSupplementaryUpdater;
+    @Mock
+    private UserDetailsProvider userDetailsProvider;
+    @Mock
+    private UserDetails userDetails;
 
     private AsylumSupplementaryDataFixingHandler asylumSupplementaryDataFixingHandler;
 
     @BeforeEach
     public void setUp() {
-        asylumSupplementaryDataFixingHandler = new AsylumSupplementaryDataFixingHandler(ccdSupplementaryUpdater);
+        asylumSupplementaryDataFixingHandler = new AsylumSupplementaryDataFixingHandler(ccdSupplementaryUpdater, userDetailsProvider);
     }
 
     @Test
@@ -66,7 +75,7 @@ class AsylumSupplementaryDataFixingHandlerTest {
         when(caseDetails.getSupplementaryData()).thenReturn(supplementaryData);
 
         PreSubmitCallbackResponse<AsylumCase> response = asylumSupplementaryDataFixingHandler.handle(
-            PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            ABOUT_TO_SUBMIT, callback);
 
         verify(ccdSupplementaryUpdater).setHmctsServiceIdSupplementary(callback);
     }
@@ -90,8 +99,16 @@ class AsylumSupplementaryDataFixingHandlerTest {
         when(caseDetails.getSupplementaryData()).thenReturn(supplementaryData);
 
         PreSubmitCallbackResponse<AsylumCase> response = asylumSupplementaryDataFixingHandler.handle(
-            PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            ABOUT_TO_SUBMIT, callback);
 
         verify(ccdSupplementaryUpdater, times(0)).setHmctsServiceIdSupplementary(callback);
+    }
+
+    @Test
+    void should_not_handle_if_citizen_in_aip_journey() {
+        when(userDetailsProvider.getUserDetails()).thenReturn(userDetails);
+        when(userDetails.getRoles()).thenReturn(List.of("citizen"));
+
+        assertFalse(asylumSupplementaryDataFixingHandler.canHandle(ABOUT_TO_START, callback));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7052](https://tools.hmcts.net/jira/browse/RIA-7052)
([RIA-6516](https://tools.hmcts.net/jira/browse/RIA-6516))


### Change description ###
- With supplementary data being set from the AIP frontend, the setting of supplementary data from the backend can be muted when the case is AIP and the user is `"citizen"` (avoiding a 400 exception)
- changed integration test to verify that idamApi is now called two times instead of one (since a new call is being made to verify the user's role when choosing to skip the setting of supplementary data)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
