### PR TITLE
RIA-7105: Enable Non Standard Directions to the Appellant

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7105-case-officer-sends-non-standard-direction-to-appellant-aip.json
+++ b/src/functionalTest/resources/scenarios/RIA-7105-case-officer-sends-non-standard-direction-to-appellant-aip.json
@@ -1,10 +1,10 @@
 {
-  "description": "RIA-2632: Case officer cannot send direction of an AIP case",
+  "description": "RIA-7105: Case officer sends non standard direction to appellant (AIP)",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "CaseOfficer",
     "input": {
-      "id": 1122,
+      "id": 71051,
       "eventId": "sendDirection",
       "state": "appealSubmitted",
       "caseData": {
@@ -20,10 +20,23 @@
   },
   "expectation": {
     "status": 200,
-    "errors": [ "You cannot use this function to send a direction to an appellant in person." ],
+    "errors": [],
     "caseData": {
-      "template": "minimal-aip-appeal-submitted.json"
+      "template": "minimal-aip-appeal-submitted.json",
+      "replacements": {
+        "directions": [
+          {
+            "id": "1",
+            "value": {
+              "explanation": "Some direction.",
+              "parties": "appellant",
+              "dateDue": "{$TODAY+28}",
+              "dateSent": "{$TODAY}",
+              "tag": ""
+            }
+          }
+        ]
+      }
     }
   }
 }
-

--- a/src/functionalTest/resources/scenarios/RIA-7105-case-officer-sends-non-standard-direction-to-respondent-aip.json
+++ b/src/functionalTest/resources/scenarios/RIA-7105-case-officer-sends-non-standard-direction-to-respondent-aip.json
@@ -1,0 +1,42 @@
+{
+  "description": "RIA-7105: Case officer sends non standard direction to respondent (AIP)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 71053,
+      "eventId": "sendDirection",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json",
+        "replacements": {
+          "sendDirectionExplanation": "Some direction.",
+          "sendDirectionDateDue": "{$TODAY+28}",
+          "sendDirectionParties": "respondent",
+          "notificationsSent": []
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json",
+      "replacements": {
+        "directions": [
+          {
+            "id": "1",
+            "value": {
+              "explanation": "Some direction.",
+              "parties": "respondent",
+              "dateDue": "{$TODAY+28}",
+              "dateSent": "{$TODAY}",
+              "tag": ""
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7105-judge-sends-non-standard-direction-to-appellant-aip.json
+++ b/src/functionalTest/resources/scenarios/RIA-7105-judge-sends-non-standard-direction-to-appellant-aip.json
@@ -1,0 +1,42 @@
+{
+  "description": "RIA-7105: Judge sends non standard direction to appellant (AIP)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 71052,
+      "eventId": "sendDirection",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json",
+        "replacements": {
+          "sendDirectionExplanation": "Some direction.",
+          "sendDirectionDateDue": "{$TODAY+28}",
+          "sendDirectionParties": "appellant",
+          "notificationsSent": []
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json",
+      "replacements": {
+        "directions": [
+          {
+            "id": "1",
+            "value": {
+              "explanation": "Some direction.",
+              "parties": "appellant",
+              "dateDue": "{$TODAY+28}",
+              "dateSent": "{$TODAY}",
+              "tag": ""
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7105-judge-sends-non-standard-direction-to-respondent-aip.json
+++ b/src/functionalTest/resources/scenarios/RIA-7105-judge-sends-non-standard-direction-to-respondent-aip.json
@@ -1,0 +1,42 @@
+{
+  "description": "RIA-7105: Judge sends non standard direction to respondent (AIP)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 71054,
+      "eventId": "sendDirection",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json",
+        "replacements": {
+          "sendDirectionExplanation": "Some direction.",
+          "sendDirectionDateDue": "{$TODAY+28}",
+          "sendDirectionParties": "respondent",
+          "notificationsSent": []
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json",
+      "replacements": {
+        "directions": [
+          {
+            "id": "1",
+            "value": {
+              "explanation": "Some direction.",
+              "parties": "respondent",
+              "dateDue": "{$TODAY+28}",
+              "dateSent": "{$TODAY}",
+              "tag": ""
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/AsylumCaseSendDirectionEventValidForJourneyTypeChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/eventvalidation/AsylumCaseSendDirectionEventValidForJourneyTypeChecker.java
@@ -1,16 +1,15 @@
 package uk.gov.hmcts.reform.iacaseapi.infrastructure.eventvalidation;
 
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SEND_DIRECTION_PARTIES;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType.REP;
 
+import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.Parties;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
 
 @Slf4j
 @Component
@@ -20,17 +19,17 @@ public class AsylumCaseSendDirectionEventValidForJourneyTypeChecker implements E
         Event event = callback.getEvent();
         if (event == Event.SEND_DIRECTION) {
             final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
-            final JourneyType journeyType = asylumCase.<JourneyType>read(AsylumCaseFieldDefinition.JOURNEY_TYPE).orElse(REP);
 
             Parties directionTo = asylumCase.read(SEND_DIRECTION_PARTIES, Parties.class)
                     .orElseThrow(() -> new IllegalStateException("sendDirectionParties is not present"));
 
-            if (journeyType == JourneyType.AIP && directionTo != Parties.RESPONDENT) {
-                log.error("Cannot send a direction for an AIP case");
-                return new EventValid("You cannot use this function to send a direction to an appellant in person.");
-            } else if (journeyType == REP && directionTo == Parties.APPELLANT) {
+            if (HandlerUtils.isRepJourney(asylumCase) && directionTo == Parties.APPELLANT) {
                 log.error("Cannot send an appellant a direction for a repped case");
                 return new EventValid("This is a legally represented case. You cannot select appellant as the recipient.");
+            }
+            if (HandlerUtils.isAipJourney(asylumCase) && Arrays.asList(Parties.LEGAL_REPRESENTATIVE, Parties.BOTH).contains(directionTo)) {
+                log.error("Cannot send a legal representative a direction for an appellant in person case");
+                return new EventValid("This is an appellant in person case. You cannot select legal representative as the recipient.");
             }
         }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7105


### Change description ###
* Enable Non Standard Directions to the Appellant for AIP appeals


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
