### PR TITLE
RIA-7061 hide linked cases tab when empty

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -970,6 +970,9 @@ public enum AsylumCaseFieldDefinition {
     REASON_FOR_LINK_APPEAL(
         "reasonForLinkAppeal", new TypeReference<ReasonForLinkAppealOptions>() {}),
 
+    CASE_LINKS(
+        "caseLinks", new TypeReference<List<IdValue<CaseLink>>>(){}),
+
     HEARING_DECISION_SELECTED(
         "hearingDecisionSelected", new TypeReference<String>(){}),
     IS_FEE_PAYMENT_ENABLED(

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/CaseLink.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/CaseLink.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+
+@Value
+@ToString
+@EqualsAndHashCode
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
+public class CaseLink {
+
+    String caseType;
+    String caseReference;
+    List<IdValue<ReasonForLink>> reasonForLink;
+    String createdDateTime;
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ReasonForLink.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ReasonForLink.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+
+@Value
+@ToString
+@EqualsAndHashCode
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
+public class ReasonForLink {
+
+    String reason;
+    String otherDescription;
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MaintainCaseLinksHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MaintainCaseLinksHandler.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CASE_LINKS;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CaseLink;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class MaintainCaseLinksHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(PreSubmitCallbackStage callbackStage, Callback<AsylumCase> callback) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+               && callback.getEvent() == Event.MAINTAIN_CASE_LINKS;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(PreSubmitCallbackStage callbackStage,
+                                                        Callback<AsylumCase> callback) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        Optional<List<IdValue<CaseLink>>> optionalCaseLinks = asylumCase.read(CASE_LINKS);
+        boolean isLastCaseLinkToBeRemoved = optionalCaseLinks.map(List::isEmpty).orElse(false);
+
+        if (isLastCaseLinkToBeRemoved) {
+            asylumCase.clear(CASE_LINKS);
+        }
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MaintainCaseLinksHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MaintainCaseLinksHandlerTest.java
@@ -1,0 +1,123 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CASE_LINKS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CaseLink;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class MaintainCaseLinksHandlerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private List<IdValue<CaseLink>> caseLinks;
+    @InjectMocks
+    private MaintainCaseLinksHandler maintainCaseLinksHandler;
+
+    @BeforeEach
+    void setup() {
+        maintainCaseLinksHandler = new MaintainCaseLinksHandler();
+    }
+
+    @Test
+    void should_clear_caseLinks_field_if_empty() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(CASE_LINKS)).thenReturn(Optional.of(caseLinks));
+        when(caseLinks.isEmpty()).thenReturn(true);
+        when(callback.getEvent()).thenReturn(Event.MAINTAIN_CASE_LINKS);
+
+        maintainCaseLinksHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        verify(asylumCase, times(1)).clear(CASE_LINKS);
+    }
+
+    @Test
+    void should_not_clear_caseLinks_field_if_empty() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(CASE_LINKS)).thenReturn(Optional.of(caseLinks));
+        when(caseLinks.isEmpty()).thenReturn(false);
+        when(callback.getEvent()).thenReturn(Event.MAINTAIN_CASE_LINKS);
+
+        maintainCaseLinksHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        verify(asylumCase, never()).clear(CASE_LINKS);
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> maintainCaseLinksHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> maintainCaseLinksHandler.canHandle(ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> maintainCaseLinksHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> maintainCaseLinksHandler.handle(ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = maintainCaseLinksHandler.canHandle(callbackStage, callback);
+
+                if ((event == Event.MAINTAIN_CASE_LINKS)
+                    && callbackStage == ABOUT_TO_SUBMIT) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7061](https://tools.hmcts.net/jira/browse/RIA-7061)


### Change description ###
- Cleared `caseLinks` field if left empty when unlinking cases from case (so that ccd definitions can hide the tab based on whether the collection exists or not)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
