### PR TITLE
RIA-7044 Mark as ready transfer to UR event to notification handler

### DIFF
--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-api
 home: https://github.com/hmcts/ia-case-api
-version: 0.0.34
+version: 0.0.35
 description: Immigration & Asylum Case API
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -137,7 +137,8 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
             Event.MARK_APPEAL_AS_DETAINED,
             Event.CREATE_CASE_LINK,
             Event.MAINTAIN_CASE_LINKS,
-            Event.UPDATE_PAYMENT_STATUS
+            Event.UPDATE_PAYMENT_STATUS,
+            Event.MARK_AS_READY_FOR_UT_TRANSFER
         );
         if (!isSaveAndContinueEnabled) {
             eventsToHandle.add(Event.BUILD_CASE);
@@ -168,7 +169,8 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
                 Event.REINSTATE_APPEAL,
                 Event.END_APPEAL,
                 Event.SUBMIT_APPEAL,
-                Event.UPDATE_HEARING_ADJUSTMENTS
+                Event.UPDATE_HEARING_ADJUSTMENTS,
+                Event.MARK_AS_READY_FOR_UT_TRANSFER
 
         );
         if (!isSaveAndContinueEnabled) {

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
@@ -141,7 +141,8 @@ class SendNotificationHandlerTest {
             Event.REMOVE_DETAINED_STATUS,
             Event.MARK_APPEAL_AS_DETAINED,
             Event.CREATE_CASE_LINK,
-            Event.MAINTAIN_CASE_LINKS
+            Event.MAINTAIN_CASE_LINKS,
+            Event.MARK_AS_READY_FOR_UT_TRANSFER
         ).forEach(event -> {
 
             AsylumCase expectedUpdatedCase = mock(AsylumCase.class);
@@ -294,7 +295,8 @@ class SendNotificationHandlerTest {
                         Event.REMOVE_DETAINED_STATUS,
                         Event.MARK_APPEAL_AS_DETAINED,
                         Event.CREATE_CASE_LINK,
-                        Event.MAINTAIN_CASE_LINKS
+                        Event.MAINTAIN_CASE_LINKS,
+                        Event.MARK_AS_READY_FOR_UT_TRANSFER
                     ).contains(event)) {
 
                     assertTrue(canHandle);


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RIA-7044](https://tools.hmcts.net/jira/browse/RIA-7044)

### Change description ###

- Adding the Mark as ready for transfer to UT event to the send notification handler

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
