### PR TITLE
RIA-7046 Reinstate appeal changes after Transfer to UT

### DIFF
--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-api
 home: https://github.com/hmcts/ia-case-api
-version: 0.0.34
+version: 0.0.35
 description: Immigration & Asylum Case API
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAsReadyForUtTransferHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAsReadyForUtTransferHandler.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.DocumentTag;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
@@ -81,6 +83,17 @@ public class MarkAsReadyForUtTransferHandler implements PreSubmitCallbackHandler
         }
         asylumCase.write(APPEAL_READY_FOR_UT_TRANSFER, YesOrNo.YES);
         asylumCase.write(APPEAL_READY_FOR_UT_TRANSFER_OUTCOME, "Transferred to the Upper Tribunal as an expedited related appeal");
+
+        State previousState = callback
+            .getCaseDetailsBefore()
+            .map(CaseDetails::getState)
+            .orElseThrow(() -> new IllegalStateException("cannot find previous case state"));
+
+        asylumCase.write(STATE_BEFORE_END_APPEAL, previousState);
+        asylumCase.clear(REINSTATE_APPEAL_REASON);
+        asylumCase.clear(REINSTATED_DECISION_MAKER);
+        asylumCase.clear(APPEAL_STATUS);
+        asylumCase.clear(REINSTATE_APPEAL_DATE);
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAsReadyForUtTransferHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/MarkAsReadyForUtTransferHandlerTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.DocumentTag;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.DocumentWithMetadata;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
@@ -65,6 +66,8 @@ class MarkAsReadyForUtTransferHandlerTest {
     @Mock
     private CaseDetails<AsylumCase> mockCaseDetails;
     @Mock
+    private CaseDetails<AsylumCase> previousCaseDetails;
+    @Mock
     private AsylumCase mockAsylumCase;
     @Mock
     private DocumentsAppender mockDocumentsAppender;
@@ -73,6 +76,7 @@ class MarkAsReadyForUtTransferHandlerTest {
     @Mock
     private DocumentWithMetadata appealForm1WithMetadata;
     private MarkAsReadyForUtTransferHandler markAsReadyForUtTransferHandler;
+    private State previousState = State.APPEAL_SUBMITTED;
 
     @BeforeEach
     public void setUp() {
@@ -81,7 +85,9 @@ class MarkAsReadyForUtTransferHandlerTest {
 
         when(mockCallback.getCaseDetails()).thenReturn(mockCaseDetails);
         when(mockCallback.getCaseDetails().getCaseData()).thenReturn(mockAsylumCase);
-
+        when(previousCaseDetails.getState()).thenReturn(previousState);
+        when(mockCallback
+            .getCaseDetailsBefore()).thenReturn(Optional.of(previousCaseDetails));
     }
 
     @Test
@@ -104,6 +110,11 @@ class MarkAsReadyForUtTransferHandlerTest {
         );
         verify(mockAsylumCase, times(1)).write(APPEAL_READY_FOR_UT_TRANSFER, YesOrNo.YES);
         verify(mockAsylumCase, times(1)).write(APPEAL_READY_FOR_UT_TRANSFER_OUTCOME, "Transferred to the Upper Tribunal as an expedited related appeal");
+        verify(mockAsylumCase).write(STATE_BEFORE_END_APPEAL, previousState);
+        verify(mockAsylumCase).clear(REINSTATE_APPEAL_REASON);
+        verify(mockAsylumCase).clear(REINSTATED_DECISION_MAKER);
+        verify(mockAsylumCase).clear(APPEAL_STATUS);
+        verify(mockAsylumCase).clear(REINSTATE_APPEAL_DATE);
     }
 
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7046

### Change description ###

- Recording state before transferring to UT so when reinstated it is put back in same state as before
- Clearing reinstate fields to mirror End Appeal process

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
