### PR TITLE
RIA-7119 ADA validation based on detention facility (only IRC can progress as ADA)

### DIFF
--- a/charts/ia-case-api/values.preview.template.yaml
+++ b/charts/ia-case-api/values.preview.template.yaml
@@ -83,7 +83,7 @@ ia-case-documents-api:
   enabled: true #set to true if testing against a local branch
   java:
     imagePullPolicy: Always
-    image: hmctspublic.azurecr.io/ia/case-documents-api:pr-583 #pr-520 or relevant PR number to change
+    image: hmctspublic.azurecr.io/ia/case-documents-api:pr-520 #pr-520 or relevant PR number to change
     releaseNameOverride: ${SERVICE_NAME}-case-documents-api
     ingressHost: ${SERVICE_NAME}-documents-api.preview.platform.hmcts.net
     environment:

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -16,5 +16,6 @@
         If it still happens, check that we don't use hutool-json and json-java. If we don't, extend the suppression date by another year.
         ]]</notes>
         <cve>CVE-2022-45688</cve>
+        <cve>CVE-2023-20883</cve>
     </suppress>
 </suppressions>

--- a/src/functionalTest/resources/scenarios/RIA-7119_edit_appeal_ada_validation_error_when_other_detention_facility_selected.json
+++ b/src/functionalTest/resources/scenarios/RIA-7119_edit_appeal_ada_validation_error_when_other_detention_facility_selected.json
@@ -1,0 +1,30 @@
+{
+  "description": "RIA-7119 Edit appeal validation of ADA question based on detention facility - Error thrown when 'other' detention facility and ADA is 'Yes'",
+  "request": {
+    "uri": "/asylum/ccdMidEvent",
+    "credentials": "LegalRepresentativeOrgSuccess",
+    "input": {
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "legalRepresentativeEmailAddress": "{TEST_LAW_FIRM_ORG_SUCCESS_USERNAME}",
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "isAcceleratedDetainedAppeal": "Yes",
+          "detentionFacility": "other"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": ["You can only select yes if the appellant is detained in an immigration removal centre"],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "isAcceleratedDetainedAppeal": "Yes",
+        "detentionFacility": "other"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7119_edit_appeal_ada_validation_error_when_prison_detention_facility_selected.json
+++ b/src/functionalTest/resources/scenarios/RIA-7119_edit_appeal_ada_validation_error_when_prison_detention_facility_selected.json
@@ -1,0 +1,30 @@
+{
+  "description": "RIA-7119 Edit appeal validation of ADA question based on detention facility - Error thrown when prison and ADA is 'Yes'",
+  "request": {
+    "uri": "/asylum/ccdMidEvent",
+    "credentials": "LegalRepresentativeOrgSuccess",
+    "input": {
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "legalRepresentativeEmailAddress": "{TEST_LAW_FIRM_ORG_SUCCESS_USERNAME}",
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "isAcceleratedDetainedAppeal": "Yes",
+          "detentionFacility": "prison"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": ["You can only select yes if the appellant is detained in an immigration removal centre"],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "isAcceleratedDetainedAppeal": "Yes",
+        "detentionFacility": "prison"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7119_edit_appeal_is_ada_set_to_no_when_other_detention_facility_selected.json
+++ b/src/functionalTest/resources/scenarios/RIA-7119_edit_appeal_is_ada_set_to_no_when_other_detention_facility_selected.json
@@ -1,0 +1,28 @@
+{
+  "description": "RIA-7119 Edit appeal isAcceleratedDetainedAppeal should be set to 'no' when 'other' is selected for detention facility",
+  "request": {
+    "uri": "/asylum/ccdMidEvent?pageId=detentionFacility",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "detentionFacility": "other"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "isAcceleratedDetainedAppeal": "No",
+        "detentionFacility": "other"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7119_edit_appeal_is_ada_set_to_no_when_prison_detention_facility_selected.json
+++ b/src/functionalTest/resources/scenarios/RIA-7119_edit_appeal_is_ada_set_to_no_when_prison_detention_facility_selected.json
@@ -1,0 +1,28 @@
+{
+  "description": "RIA-7119 Edit appeal isAcceleratedDetainedAppeal should be set to 'no' when 'prison' is selected for detention facility",
+  "request": {
+    "uri": "/asylum/ccdMidEvent?pageId=detentionFacility",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "detentionFacility": "prison"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "isAcceleratedDetainedAppeal": "No",
+        "detentionFacility": "prison"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7119_start_appeal_ada_validation_error_when_other_detention_facility_selected.json
+++ b/src/functionalTest/resources/scenarios/RIA-7119_start_appeal_ada_validation_error_when_other_detention_facility_selected.json
@@ -1,0 +1,30 @@
+{
+  "description": "RIA-7119 Start appeal validation of ADA question based on detention facility - Error thrown when 'other' detention facility and ADA is 'Yes'",
+  "request": {
+    "uri": "/asylum/ccdMidEvent",
+    "credentials": "LegalRepresentativeOrgSuccess",
+    "input": {
+      "eventId": "startAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "legalRepresentativeEmailAddress": "{TEST_LAW_FIRM_ORG_SUCCESS_USERNAME}",
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "isAcceleratedDetainedAppeal": "Yes",
+          "detentionFacility": "other"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": ["You can only select yes if the appellant is detained in an immigration removal centre"],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "isAcceleratedDetainedAppeal": "Yes",
+        "detentionFacility": "other"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7119_start_appeal_ada_validation_error_when_prison_selected.json
+++ b/src/functionalTest/resources/scenarios/RIA-7119_start_appeal_ada_validation_error_when_prison_selected.json
@@ -1,0 +1,30 @@
+{
+  "description": "RIA-7119 Start appeal validation of ADA question based on detention facility - Error thrown when prison and ADA is 'Yes'",
+  "request": {
+    "uri": "/asylum/ccdMidEvent",
+    "credentials": "LegalRepresentativeOrgSuccess",
+    "input": {
+      "eventId": "startAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "legalRepresentativeEmailAddress": "{TEST_LAW_FIRM_ORG_SUCCESS_USERNAME}",
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "isAcceleratedDetainedAppeal": "Yes",
+          "detentionFacility": "prison"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": ["You can only select yes if the appellant is detained in an immigration removal centre"],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "isAcceleratedDetainedAppeal": "Yes",
+        "detentionFacility": "prison"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7119_start_appeal_is_ada_set_to_no_when_other_detention_facility_selected.json
+++ b/src/functionalTest/resources/scenarios/RIA-7119_start_appeal_is_ada_set_to_no_when_other_detention_facility_selected.json
@@ -1,0 +1,28 @@
+{
+  "description": "RIA-7119 startAppeal isAcceleratedDetainedAppeal should be set to 'no' when 'other' is selected for detention facility",
+  "request": {
+    "uri": "/asylum/ccdMidEvent?pageId=detentionFacility",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "startAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "detentionFacility": "other"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "isAcceleratedDetainedAppeal": "No",
+        "detentionFacility": "other"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7119_start_appeal_is_ada_set_to_no_when_prison_detention_facility_selected.json
+++ b/src/functionalTest/resources/scenarios/RIA-7119_start_appeal_is_ada_set_to_no_when_prison_detention_facility_selected.json
@@ -1,0 +1,28 @@
+{
+  "description": "RIA-7119 startAppeal isAcceleratedDetainedAppeal should be set to 'no' when 'prison' is selected for detention facility",
+  "request": {
+    "uri": "/asylum/ccdMidEvent?pageId=detentionFacility",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "startAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "detentionFacility": "prison"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "isAcceleratedDetainedAppeal": "No",
+        "detentionFacility": "prison"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AcceleratedDetainedAppealValidationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AcceleratedDetainedAppealValidationHandler.java
@@ -1,0 +1,65 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import java.util.Arrays;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DetentionFacility;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+
+@Component
+public class AcceleratedDetainedAppealValidationHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return (callbackStage == PreSubmitCallbackStage.MID_EVENT)
+                && Arrays.asList(
+                Event.START_APPEAL,
+                Event.EDIT_APPEAL
+        ).contains(callback.getEvent());
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase =
+                callback
+                        .getCaseDetails()
+                        .getCaseData();
+
+        YesOrNo adaEnabled = asylumCase.read(DETENTION_FACILITY, String.class)
+                .orElse("")
+                .equals(DetentionFacility.IRC.toString()) ? YesOrNo.YES : YesOrNo.NO;
+
+        YesOrNo isAda = asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class).orElse(NO);
+
+        PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
+
+        if (isAda.equals(YES) && adaEnabled.equals(NO)) {
+            response.addError("You can only select yes if the appellant is detained in an immigration removal centre");
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEvent.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
+import java.util.List;
 import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
@@ -55,10 +56,11 @@ public class StartAppealMidEvent implements PreSubmitCallbackHandler<AsylumCase>
 
         PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
 
-        if (callback.getPageId().equals(DETENTION_FACILITY_PAGE_ID)) {
-            if (!asylumCase.read(DETENTION_FACILITY, String.class).orElse("").equals(DetentionFacility.IRC.toString())) {
-                asylumCase.write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.NO);
-            }
+        if (callback.getPageId().equals(DETENTION_FACILITY_PAGE_ID)
+                && List.of(Event.START_APPEAL, Event.EDIT_APPEAL).contains(callback.getEvent())
+                && !asylumCase.read(DETENTION_FACILITY, String.class).orElse("").equals(DetentionFacility.IRC.toString())
+        ) {
+            asylumCase.write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.NO);
         }
 
         if (callback.getPageId().equals(HOME_OFFICE_DECISION_PAGE_ID)) {

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AcceleratedDetainedAppealValidationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AcceleratedDetainedAppealValidationHandlerTest.java
@@ -1,0 +1,124 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DETENTION_FACILITY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ACCELERATED_DETAINED_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.*;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DetentionFacility;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class AcceleratedDetainedAppealValidationHandlerTest {
+
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+
+    private String callbackErrorMessage = "You can only select yes if the appellant is detained in an immigration removal centre";
+    private AcceleratedDetainedAppealValidationHandler acceleratedDetainedAppealValidationHandler;
+
+    @BeforeEach
+    public void setUp() {
+        acceleratedDetainedAppealValidationHandler = new AcceleratedDetainedAppealValidationHandler();
+
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+            for (PreSubmitCallbackStage stage: PreSubmitCallbackStage.values()) {
+                when(callback.getEvent()).thenReturn(event);
+                boolean canHandle = acceleratedDetainedAppealValidationHandler.canHandle(stage, callback);
+
+                if (stage == MID_EVENT && (event == Event.START_APPEAL || event == Event.EDIT_APPEAL)) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> acceleratedDetainedAppealValidationHandler.handle(ABOUT_TO_SUBMIT, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> acceleratedDetainedAppealValidationHandler.handle(ABOUT_TO_START, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> acceleratedDetainedAppealValidationHandler.canHandle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> acceleratedDetainedAppealValidationHandler.canHandle(MID_EVENT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DetentionFacility.class)
+    void should_add_error_to_response_only_when_ada_selected_with_prison_or_other_detention_facility(DetentionFacility detentionFacility) {
+        when(asylumCase.read(DETENTION_FACILITY, String.class)).thenReturn(Optional.of(detentionFacility.toString()));
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                acceleratedDetainedAppealValidationHandler.handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        Assertions.assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+        final Set<String> errors = callbackResponse.getErrors();
+
+        if (Arrays.asList(DetentionFacility.PRISON.toString(), DetentionFacility.OTHER.toString()).contains(detentionFacility.toString())) {
+            assertThat(errors).hasSize(1).containsOnly(callbackErrorMessage);
+        } else {
+            assertThat(errors).hasSize(0).doesNotContain(callbackErrorMessage);
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEventTest.java
@@ -215,4 +215,19 @@ class StartAppealMidEventTest {
             assertEquals(YesOrNo.NO, callbackResponse.getData().get("isAcceleratedDetainedAppeal"));
         }
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {HOME_OFFICE_DECISION_PAGE_ID, OUT_OF_COUNTRY_PAGE_ID, DETENTION_FACILITY_PAGE_ID})
+    void should_only_set_is_accelerated_detained_if_correct_page_id(String pageId) {
+        when(callback.getPageId()).thenReturn(pageId);
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(correctHomeOfficeReferenceFormatCid));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse = startAppealMidEvent.handle(MID_EVENT, callback);
+
+        if (pageId.equals(DETENTION_FACILITY_PAGE_ID)) {
+            verify(asylumCase, times(1)).write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.NO);
+        } else {
+            verify(asylumCase, never()).write(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class);
+        }
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEventTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -15,18 +14,21 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubm
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.values;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DetentionFacility;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.OutOfCountryDecisionType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
@@ -42,6 +44,8 @@ class StartAppealMidEventTest {
 
     private static final String HOME_OFFICE_DECISION_PAGE_ID = "homeOfficeDecision";
     private static final String OUT_OF_COUNTRY_PAGE_ID = "outOfCountry";
+    private static final String DETENTION_FACILITY_PAGE_ID = "detentionFacility";
+
     @Mock
     private Callback<AsylumCase> callback;
     @Mock
@@ -68,7 +72,7 @@ class StartAppealMidEventTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { HOME_OFFICE_DECISION_PAGE_ID,OUT_OF_COUNTRY_PAGE_ID, ""})
+    @ValueSource(strings = {HOME_OFFICE_DECISION_PAGE_ID, OUT_OF_COUNTRY_PAGE_ID, DETENTION_FACILITY_PAGE_ID, ""})
     void it_can_handle_callback(String pageId) {
 
         for (Event event : Event.values()) {
@@ -82,7 +86,9 @@ class StartAppealMidEventTest {
 
                 if ((event == Event.START_APPEAL || event == Event.EDIT_APPEAL || event == Event.EDIT_APPEAL_AFTER_SUBMIT)
                     && callbackStage == MID_EVENT
-                    && (callback.getPageId().equals(HOME_OFFICE_DECISION_PAGE_ID) || callback.getPageId().equals(OUT_OF_COUNTRY_PAGE_ID))) {
+                    && (callback.getPageId().equals(DETENTION_FACILITY_PAGE_ID)
+                        || callback.getPageId().equals(HOME_OFFICE_DECISION_PAGE_ID)
+                        || callback.getPageId().equals(OUT_OF_COUNTRY_PAGE_ID))) {
                     assertTrue(canHandle);
                 } else {
                     assertFalse(canHandle);
@@ -192,5 +198,21 @@ class StartAppealMidEventTest {
         assertEquals(asylumCase, callbackResponse.getData());
 
         verify(asylumCase, never()).write(any(),any());
+    }
+
+    @ParameterizedTest
+    @EnumSource(DetentionFacility.class)
+    void should_set_is_accelerated_detained_value_to_no_if_prison_or_other_detention_facility(DetentionFacility detentionFacility) {
+        when(callback.getPageId()).thenReturn(DETENTION_FACILITY_PAGE_ID);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                startAppealMidEvent.handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        if (Arrays.asList(DetentionFacility.PRISON.toString(), DetentionFacility.PRISON.toString()).contains(detentionFacility)) {
+            assertEquals(YesOrNo.NO, callbackResponse.getData().get("isAcceleratedDetainedAppeal"));
+        }
     }
 }


### PR DESCRIPTION
### NOTE ###
This PR contains the revert for preview env to point the documents api image back to PR 520.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7119


### Change description ###
* Updated StartAppealMidEvent to set isAcceleratedDetainedAppeal value to "no" if prison/other detention facility selected, so that isADA question is pre-selected to no during startAppeal/editAppeal when prison/other selected.
* Added new handler to return error to client when prison/other detention facility is selected and isAcceleratedDetainedAppeal "yes" is selected.
* Added unit test for new handler and updated StartAppealMidEventTest
* Added FTs for end-to-end testing of the new handler
* Added FTs for end-to-end testing of the updated StartAppealMidEvent handler (where pageId=detentionFacility)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
