### PR TITLE
RIA-7030 Update reinstateAppeal decisionMaker from TCW to LO

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReinstateAppealStateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReinstateAppealStateHandler.java
@@ -21,6 +21,8 @@ import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackStateHandl
 @Component
 public class ReinstateAppealStateHandler implements PreSubmitCallbackStateHandler<AsylumCase> {
 
+    private final String oldLegalOfficerDisplayName = "Tribunal Caseworker";
+    private final String newLegalOfficerDisplayName = "Legal Officer";
     private final DateProvider dateProvider;
     private final UserDetails userDetails;
     private final UserDetailsHelper userDetailsHelper;
@@ -67,7 +69,10 @@ public class ReinstateAppealStateHandler implements PreSubmitCallbackStateHandle
             return asylumCasePreSubmitCallbackResponse;
         }
 
-        asylumCase.write(REINSTATED_DECISION_MAKER, userDetailsHelper.getLoggedInUserRoleLabel(userDetails).toString());
+        String decisionMakerRole = userDetailsHelper.getLoggedInUserRoleLabel(userDetails).toString();
+        String updatedDecisionMakerRole = decisionMakerRole.equals(oldLegalOfficerDisplayName) ? newLegalOfficerDisplayName : decisionMakerRole;
+
+        asylumCase.write(REINSTATED_DECISION_MAKER, updatedDecisionMakerRole);
         asylumCase.write(APPEAL_STATUS, REINSTATED);
         asylumCase.write(REINSTATE_APPEAL_DATE, dateProvider.now().toString());
         asylumCase.write(RECORD_APPLICATION_ACTION_DISABLED, YesOrNo.NO);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReinstateAppealStateHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReinstateAppealStateHandlerTest.java
@@ -78,7 +78,7 @@ class ReinstateAppealStateHandlerTest {
 
         assertNotNull(returnedCallbackResponse);
         assertEquals(asylumCase, returnedCallbackResponse.getData());
-        verify(asylumCase).write(REINSTATED_DECISION_MAKER, UserRoleLabel.TRIBUNAL_CASEWORKER.toString());
+        verify(asylumCase).write(REINSTATED_DECISION_MAKER, "Legal Officer");
         verify(asylumCase).write(APPEAL_STATUS, AppealStatus.REINSTATED);
         verify(asylumCase).write(REINSTATE_APPEAL_DATE, date.toString());
         verify(asylumCase).write(RECORD_APPLICATION_ACTION_DISABLED, YesOrNo.NO);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7030


### Change description ###
Updated value of decision maker role for reinstate appeal from "Tribunal Caseworker" to "Legal Officer", when the decisionMaker is TCW.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
