### PR TITLE
RIA-7116 Set appeal type length by default for hearing requirements

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparer.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguage;
@@ -65,6 +66,8 @@ public class ReviewDraftHearingRequirementsPreparer implements PreSubmitCallback
 
         decorateOutsideEvidenceDefaultsForOldCases(asylumCase);
 
+        setDefaultHearingLengthForAppealType(asylumCase);
+
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 
@@ -108,6 +111,29 @@ public class ReviewDraftHearingRequirementsPreparer implements PreSubmitCallback
 
         if (!isEvidenceFromOutsideUkInCountry.isPresent()) {
             asylumCase.write(IS_EVIDENCE_FROM_OUTSIDE_UK_IN_COUNTRY, YesOrNo.NO);
+        }
+    }
+
+    static void setDefaultHearingLengthForAppealType(AsylumCase asylumCase) {
+        final Optional<AppealType> optionalAppealType = asylumCase.read(APPEAL_TYPE, AppealType.class);
+
+        if (optionalAppealType.isPresent()) {
+            AppealType appealType = optionalAppealType.get();
+
+            switch (appealType) {
+                case HU:
+                case EA:
+                case EU:
+                    asylumCase.write(LIST_CASE_HEARING_LENGTH, "120");
+                    break;
+                case DC:
+                case PA:
+                case RP:
+                    asylumCase.write(LIST_CASE_HEARING_LENGTH, "180");
+                    break;
+                default:
+                    break;
+            }
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparerTest.java
@@ -129,12 +129,12 @@ class ReviewDraftHearingRequirementsPreparerTest {
 
     @ParameterizedTest
     @CsvSource({
-            "HU, 120",
-            "EA, 120",
-            "EU, 120",
-            "DC, 180",
-            "PA, 180",
-            "RP, 180",
+        "HU, 120",
+        "EA, 120",
+        "EU, 120",
+        "DC, 180",
+        "PA, 180",
+        "RP, 180",
     })
     void should_set_default_length_hearing_for_appeal_type(AppealType appealType, String expectedResult) {
         when(asylumCase.read(REVIEWED_HEARING_REQUIREMENTS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparerTest.java
@@ -16,10 +16,13 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
@@ -122,6 +125,30 @@ class ReviewDraftHearingRequirementsPreparerTest {
         verify(asylumCase, times(1)).write(
             IS_EVIDENCE_FROM_OUTSIDE_UK_IN_COUNTRY,
             YesOrNo.NO);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "HU, 120",
+            "EA, 120",
+            "EU, 120",
+            "DC, 180",
+            "PA, 180",
+            "RP, 180",
+    })
+    void should_set_default_length_hearing_for_appeal_type(AppealType appealType, String expectedResult) {
+        when(asylumCase.read(REVIEWED_HEARING_REQUIREMENTS, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(appealType));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                reviewDraftHearingRequirementsPreparer.handle(ABOUT_TO_START, callback);
+
+        assertNotNull(callback);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).write(
+                LIST_CASE_HEARING_LENGTH,
+                expectedResult);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7116


### Change description ###
-Added the default length for hearing according to the different appeal type
-Added the unit test of setting default length in different appeal type


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
