### PR TITLE
RIA-7397 markAsReadyForUtTransfer -> reinstateAppeal -> endAppeal incorrect content

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReinstateAppealStateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReinstateAppealStateHandler.java
@@ -77,6 +77,9 @@ public class ReinstateAppealStateHandler implements PreSubmitCallbackStateHandle
         asylumCase.write(REINSTATE_APPEAL_DATE, dateProvider.now().toString());
         asylumCase.write(RECORD_APPLICATION_ACTION_DISABLED, YesOrNo.NO);
 
+        // Prevents data populated in MarkAsReadyForUtTransferHandler being displayed on UI
+        asylumCase.clear(APPEAL_READY_FOR_UT_TRANSFER);
+
         return new PreSubmitCallbackResponse<>(asylumCase, stateBeforeEndAppeal.get());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
* Cleared appealReadyForUtTransfer field so that UI content on ended state is accurate when appeal not ended through markAsReadyForUtTransfer event
* Added test case for clearing the field


### Change description ###
* Cleared appealReadyForUtTransfer field so that UI content on ended state is accurate when appeal not ended through markAsReadyForUtTransfer event
* Added test case for clearing the field


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
