### PR TITLE
RIA-7220 set appeal type length by default for list without req

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListCaseWithoutHearingRequirementsPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListCaseWithoutHearingRequirementsPreparer.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class ListCaseWithoutHearingRequirementsPreparer implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
+               && callback.getEvent() == Event.LIST_CASE_WITHOUT_HEARING_REQUIREMENTS;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        setDefaultHearingLengthForAppealType(asylumCase);
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    static void setDefaultHearingLengthForAppealType(AsylumCase asylumCase) {
+        final Optional<AppealType> optionalAppealType = asylumCase.read(APPEAL_TYPE, AppealType.class);
+
+        if (optionalAppealType.isPresent()) {
+            AppealType appealType = optionalAppealType.get();
+
+            switch (appealType) {
+                case HU:
+                case EA:
+                case EU:
+                    asylumCase.write(LIST_CASE_HEARING_LENGTH, HearingLength.LENGTH_2_HOURS.toString());
+                    break;
+                case DC:
+                case PA:
+                case RP:
+                    asylumCase.write(LIST_CASE_HEARING_LENGTH, HearingLength.LENGTH_3_HOURS.toString());
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListCaseWithoutHearingRequirementsPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListCaseWithoutHearingRequirementsPreparerTest.java
@@ -1,0 +1,106 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class ListCaseWithoutHearingRequirementsPreparerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+
+    private ListCaseWithoutHearingRequirementsPreparer listCaseWithoutHearingRequirementsPreparer;
+
+    @BeforeEach
+    public void setUp() {
+        listCaseWithoutHearingRequirementsPreparer =
+            new ListCaseWithoutHearingRequirementsPreparer();
+
+        when(callback.getEvent()).thenReturn(Event.LIST_CASE_WITHOUT_HEARING_REQUIREMENTS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> listCaseWithoutHearingRequirementsPreparer.handle(ABOUT_TO_SUBMIT, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.LIST_CASE);
+        assertThatThrownBy(() -> listCaseWithoutHearingRequirementsPreparer.handle(ABOUT_TO_START, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> listCaseWithoutHearingRequirementsPreparer.canHandle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> listCaseWithoutHearingRequirementsPreparer.canHandle(ABOUT_TO_START, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> listCaseWithoutHearingRequirementsPreparer.handle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> listCaseWithoutHearingRequirementsPreparer.handle(ABOUT_TO_START, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "HU, 120",
+        "EA, 120",
+        "EU, 120",
+        "DC, 180",
+        "PA, 180",
+        "RP, 180",
+    })
+    void should_set_default_length_hearing_for_appeal_type(AppealType appealType, String expectedResult) {
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(appealType));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                listCaseWithoutHearingRequirementsPreparer.handle(ABOUT_TO_START, callback);
+
+        assertNotNull(callback);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).write(
+                LIST_CASE_HEARING_LENGTH,
+                expectedResult);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7220


### Change description ###
-Added the ListCaseWithoutHearingRequirementsPreparer for listCaseWithoutHearingRequirements event
-Added the unit test for ListCaseWithoutHearingRequirementsPreparer
-Set the default appeal type length as ticket mention


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
