### PR TITLE
RIA-7397 moving clearing of UtAppealReferenceNumber to end appeal handler

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandler.java
@@ -87,6 +87,9 @@ public class EndAppealHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
         asylumCase.write(STATE_BEFORE_END_APPEAL, previousState);
 
+        // Prevents data populated in MarkAsReadyForUtTransferHandler being displayed on UI
+        asylumCase.clear(APPEAL_READY_FOR_UT_TRANSFER);
+
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReinstateAppealStateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReinstateAppealStateHandler.java
@@ -77,9 +77,6 @@ public class ReinstateAppealStateHandler implements PreSubmitCallbackStateHandle
         asylumCase.write(REINSTATE_APPEAL_DATE, dateProvider.now().toString());
         asylumCase.write(RECORD_APPLICATION_ACTION_DISABLED, YesOrNo.NO);
 
-        // Prevents data populated in MarkAsReadyForUtTransferHandler being displayed on UI
-        asylumCase.clear(APPEAL_READY_FOR_UT_TRANSFER);
-
         return new PreSubmitCallbackResponse<>(asylumCase, stateBeforeEndAppeal.get());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReinstateAppealStateHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReinstateAppealStateHandlerTest.java
@@ -147,24 +147,4 @@ class ReinstateAppealStateHandlerTest {
             .hasMessage("callback must not be null")
             .isExactlyInstanceOf(NullPointerException.class);
     }
-
-    @Test
-    void should_clear_appeal_ready_for_ut_transfer_field() {
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(callback.getEvent()).thenReturn(REINSTATE_APPEAL);
-        when(asylumCase.read(STATE_BEFORE_END_APPEAL, State.class)).thenReturn(Optional.of(State.RESPONDENT_REVIEW));
-        when(asylumCase.read(REINSTATE_APPEAL_REASON)).thenReturn(Optional.of("test"));
-        when(userDetailsDetails.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.TRIBUNAL_CASEWORKER);
-
-        asylumCase.put(APPEAL_READY_FOR_UT_TRANSFER.toString(), YesOrNo.YES);
-
-        PreSubmitCallbackResponse<AsylumCase> returnedCallbackResponse =
-                reinstateAppealStateHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback, callbackResponse);
-
-        assertNotNull(returnedCallbackResponse);
-        assertEquals(asylumCase, returnedCallbackResponse.getData());
-        verify(asylumCase).clear(APPEAL_READY_FOR_UT_TRANSFER);
-    }
-
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7397


### Change description ###
*Moved the clearing of UtAppealReferenceNumber from ReinstateAppealStateHandler to EndAppealHandler


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
