### PR TITLE
RIA-7239 Add OOC decision type check when handling ADA appeals

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeDecisionDateChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeDecisionDateChecker.java
@@ -78,7 +78,8 @@ public class HomeOfficeDecisionDateChecker implements PreSubmitCallbackHandler<A
 
         Optional<OutOfCountryDecisionType> outOfCountryDecisionTypeOptional = asylumCase.read(OUT_OF_COUNTRY_DECISION_TYPE, OutOfCountryDecisionType.class);
 
-        if (HandlerUtils.isAcceleratedDetainedAppeal(asylumCase)) {
+        // If case data has oocDecisionType && ADA=YES, it means appeal was moving from in-country to OOC
+        if (HandlerUtils.isAcceleratedDetainedAppeal(asylumCase) && outOfCountryDecisionTypeOptional.isEmpty()) {
             handleAdaAppeal(asylumCase);
         } else if (!HandlerUtils.isAipJourney(asylumCase)) {
             boolean isOutOfCountry = outOfCountryDecisionTypeOptional.isPresent();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7239


### Change description ###
When appeal is changed from in-country (ADA) to OOC, the in-country fields such as isADA can remain. An extra check has been inserted to ensure the appeal is not treated as ADA if OOC decision type is present. If it is present, we know the appeal was moved from in-country to OOC.

### Testing ###
Tested and was able to move from ADA to OOC and save/submit appeal successfully. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
