### PR TITLE
RIA-7487: Display hearing adjustment information on Hearing and Appoi…

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7487-update-hearing-adjustments-display-decision-and-tribunal-response-in-hearing-tab.json
+++ b/src/functionalTest/resources/scenarios/RIA-7487-update-hearing-adjustments-display-decision-and-tribunal-response-in-hearing-tab.json
@@ -1,0 +1,66 @@
+{
+  "description": "RIA-7487 Update hearing adjustments (display decision and tribunal response in hearing tab)",
+  "enabled": "false",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "updateHearingAdjustments",
+      "state": "prepareForHearing",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "listCaseHearingCentre": "taylorHouse",
+          "reviewedHearingRequirements": "No",
+          "listCaseHearingLength": "300",
+          "remoteVideoCallTribunalResponse": "remote call reason",
+          "vulnerabilitiesTribunalResponse": "vulnerabilities reason",
+          "multimediaTribunalResponse": "multimedia reason",
+          "singleSexCourtTribunalResponse": "singleSexCourt reason",
+          "inCameraCourtTribunalResponse": "inCameraCourt reason",
+          "additionalTribunalResponse": "additional reason",
+          "uploadAdditionalEvidenceActionAvailable": "Yes",
+          "isRemoteHearingAllowed": "Granted",
+          "isVulnerabilitiesAllowed": "Granted",
+          "isMultimediaAllowed": "Granted",
+          "isSingleSexCourtAllowed": "Refused",
+          "isInCameraCourtAllowed": "Refused",
+          "isAdditionalAdjustmentsAllowed": "Granted",
+          "currentCaseStateVisibleToCaseOfficer": "unknown"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "listCaseHearingLength": "300",
+        "remoteVideoCallTribunalResponse": "remote call reason",
+        "vulnerabilitiesTribunalResponse": "vulnerabilities reason",
+        "multimediaTribunalResponse": "multimedia reason",
+        "singleSexCourtTribunalResponse": "singleSexCourt reason",
+        "inCameraCourtTribunalResponse": "inCameraCourt reason",
+        "additionalTribunalResponse": "additional reason",
+        "uploadAdditionalEvidenceActionAvailable": "Yes",
+        "reviewedHearingRequirements": "Yes",
+        "reviewedUpdatedHearingRequirements": "Yes",
+        "isRemoteHearingAllowed": "Granted",
+        "isVulnerabilitiesAllowed": "Granted",
+        "isMultimediaAllowed": "Granted",
+        "isSingleSexCourtAllowed": "Refused",
+        "isInCameraCourtAllowed": "Refused",
+        "isAdditionalAdjustmentsAllowed": "Granted",
+        "remoteHearingDecisionForDisplay": "Granted - remote call reason",
+        "vulnerabilitiesDecisionForDisplay": "Granted - vulnerabilities reason",
+        "multimediaDecisionForDisplay": "Granted - multimedia reason",
+        "singleSexCourtDecisionForDisplay": "Refused - singleSexCourt reason",
+        "inCameraCourtDecisionForDisplay": "Refused - inCameraCourt reason",
+        "otherDecisionForDisplay": "Granted - additional reason",
+        "currentCaseStateVisibleToCaseOfficer": "prepareForHearing"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -794,6 +794,42 @@ public enum AsylumCaseFieldDefinition {
     ADDITIONAL_TRIBUNAL_RESPONSE(
         "additionalTribunalResponse", new TypeReference<String>() {}),
 
+    IS_REMOTE_HEARING_ALLOWED(
+            "isRemoteHearingAllowed", new TypeReference<String>() {}),
+
+    IS_VULNERABILITIES_ALLOWED(
+            "isVulnerabilitiesAllowed", new TypeReference<String>() {}),
+
+    IS_MULTIMEDIA_ALLOWED(
+            "isMultimediaAllowed", new TypeReference<String>() {}),
+
+    IS_SINGLE_SEX_COURT_ALLOWED(
+            "isSingleSexCourtAllowed", new TypeReference<String>() {}),
+
+    IS_IN_CAMERA_COURT_ALLOWED(
+            "isInCameraCourtAllowed", new TypeReference<String>() {}),
+
+    IS_ADDITIONAL_ADJUSTMENTS_ALLOWED(
+            "isAdditionalAdjustmentsAllowed", new TypeReference<String>() {}),
+
+    REMOTE_HEARING_DECISION_FOR_DISPLAY(
+            "remoteHearingDecisionForDisplay", new TypeReference<String>() {}),
+
+    MULTIMEDIA_DECISION_FOR_DISPLAY(
+            "multimediaDecisionForDisplay", new TypeReference<String>() {}),
+
+    SINGLE_SEX_COURT_DECISION_FOR_DISPLAY(
+            "singleSexCourtDecisionForDisplay", new TypeReference<String>() {}),
+
+    IN_CAMERA_COURT_DECISION_FOR_DISPLAY(
+            "inCameraCourtDecisionForDisplay", new TypeReference<String>() {}),
+
+    VULNERABILITIES_DECISION_FOR_DISPLAY(
+            "vulnerabilitiesDecisionForDisplay", new TypeReference<String>() {}),
+
+    OTHER_DECISION_FOR_DISPLAY(
+            "otherDecisionForDisplay", new TypeReference<String>() {}),
+
     REASON_TO_FORCE_REQUEST_CASE_BUILDING(
         "reasonToForceRequestCaseBuilding", new TypeReference<String>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandler.java
@@ -84,6 +84,14 @@ public class UpdateHearingRequirementsHandler implements PreSubmitCallbackHandle
         asylumCase.clear(IN_CAMERA_COURT_TRIBUNAL_RESPONSE);
         asylumCase.clear(ADDITIONAL_TRIBUNAL_RESPONSE);
 
+        // Clear review decision display fields once the update happens
+        asylumCase.clear(VULNERABILITIES_DECISION_FOR_DISPLAY);
+        asylumCase.clear(REMOTE_HEARING_DECISION_FOR_DISPLAY);
+        asylumCase.clear(MULTIMEDIA_DECISION_FOR_DISPLAY);
+        asylumCase.clear(SINGLE_SEX_COURT_DECISION_FOR_DISPLAY);
+        asylumCase.clear(IN_CAMERA_COURT_DECISION_FOR_DISPLAY);
+        asylumCase.clear(OTHER_DECISION_FOR_DISPLAY);
+
         if (asylumCase.read(CASE_FLAG_SET_ASIDE_REHEARD_EXISTS, YesOrNo.class).map(flag -> flag.equals(YesOrNo.YES)).orElse(false)
             && featureToggler.getValue("reheard-feature", false)) {
             previousRequirementsAndRequestsAppender.appendAndTrim(asylumCase);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewUpdateHearingRequirementsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewUpdateHearingRequirementsHandlerTest.java
@@ -5,21 +5,23 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DISABLE_OVERVIEW_PAGE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.UPDATE_HEARING_REQUIREMENTS_EXISTS;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ADDITIONAL_TRIBUNAL_RESPONSE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.values;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
@@ -30,9 +32,9 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallb
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 
-
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ReviewUpdateHearingRequirementsHandlerTest {
 
     @Mock
@@ -47,17 +49,17 @@ class ReviewUpdateHearingRequirementsHandlerTest {
     @BeforeEach
     public void setup() {
 
+        when(callback.getEvent()).thenReturn(Event.UPDATE_HEARING_ADJUSTMENTS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(caseDetails.getState()).thenReturn(State.PREPARE_FOR_HEARING);
+
         reviewUpdateHearingRequirementsHandler =
             new ReviewUpdateHearingRequirementsHandler();
     }
 
     @Test
     void should_update_review_hearing_adjustments() {
-
-        when(callback.getEvent()).thenReturn(Event.UPDATE_HEARING_ADJUSTMENTS);
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(caseDetails.getState()).thenReturn(State.PREPARE_FOR_HEARING);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             reviewUpdateHearingRequirementsHandler.handle(ABOUT_TO_SUBMIT, callback);
@@ -75,6 +77,32 @@ class ReviewUpdateHearingRequirementsHandlerTest {
 
         reset(callback);
         reset(asylumCase);
+    }
+
+    @Test
+    void should_update_hearing_adjustment_responses() {
+        when(asylumCase.read(VULNERABILITIES_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of("Response to vulnerabilities"));
+        when(asylumCase.read(IS_VULNERABILITIES_ALLOWED, String.class)).thenReturn(Optional.of("Granted"));
+        when(asylumCase.read(REMOTE_VIDEO_CALL_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of("Response to remote call"));
+        when(asylumCase.read(IS_REMOTE_HEARING_ALLOWED, String.class)).thenReturn(Optional.of("Granted"));
+        when(asylumCase.read(MULTIMEDIA_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of("Response to multimedia"));
+        when(asylumCase.read(IS_MULTIMEDIA_ALLOWED, String.class)).thenReturn(Optional.of("Refused"));
+        when(asylumCase.read(SINGLE_SEX_COURT_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of("Response to single sex court"));
+        when(asylumCase.read(IS_SINGLE_SEX_COURT_ALLOWED, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(IN_CAMERA_COURT_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of("Response to in camera court"));
+        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class)).thenReturn(Optional.of("Refused"));
+        when(asylumCase.read(ADDITIONAL_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(IS_ADDITIONAL_ADJUSTMENTS_ALLOWED, String.class)).thenReturn(Optional.empty());
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                reviewUpdateHearingRequirementsHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        verify(asylumCase, times(1)).write(VULNERABILITIES_DECISION_FOR_DISPLAY, "Granted - Response to vulnerabilities");
+        verify(asylumCase, times(1)).write(REMOTE_HEARING_DECISION_FOR_DISPLAY, "Granted - Response to remote call");
+        verify(asylumCase, times(1)).write(MULTIMEDIA_DECISION_FOR_DISPLAY, "Refused - Response to multimedia");
+        verify(asylumCase, never()).write(eq(SINGLE_SEX_COURT_DECISION_FOR_DISPLAY), anyString());
+        verify(asylumCase, times(1)).write(IN_CAMERA_COURT_DECISION_FOR_DISPLAY, "Refused - Response to in camera court");
+        verify(asylumCase, never()).write(eq(OTHER_DECISION_FOR_DISPLAY), anyString());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandlerTest.java
@@ -11,17 +11,8 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ADDITIONAL_TRIBUNAL_RESPONSE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPLICATIONS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPLICATION_UPDATE_HEARING_REQUIREMENTS_EXISTS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CASE_FLAG_SET_ASIDE_REHEARD_EXISTS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IN_CAMERA_COURT_TRIBUNAL_RESPONSE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.MULTIMEDIA_TRIBUNAL_RESPONSE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REMOTE_VIDEO_CALL_TRIBUNAL_RESPONSE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REVIEWED_HEARING_REQUIREMENTS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SINGLE_SEX_COURT_TRIBUNAL_RESPONSE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.VULNERABILITIES_TRIBUNAL_RESPONSE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_DETAILS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.OTHER_DECISION_FOR_DISPLAY;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -133,6 +124,14 @@ class UpdateHearingRequirementsHandlerTest {
         verify(asylumCase).clear(IN_CAMERA_COURT_TRIBUNAL_RESPONSE);
         verify(asylumCase).clear(ADDITIONAL_TRIBUNAL_RESPONSE);
 
+        // review decision display fields should be cleared
+        verify(asylumCase).clear(VULNERABILITIES_DECISION_FOR_DISPLAY);
+        verify(asylumCase).clear(REMOTE_HEARING_DECISION_FOR_DISPLAY);
+        verify(asylumCase).clear(MULTIMEDIA_DECISION_FOR_DISPLAY);
+        verify(asylumCase).clear(SINGLE_SEX_COURT_DECISION_FOR_DISPLAY);
+        verify(asylumCase).clear(IN_CAMERA_COURT_DECISION_FOR_DISPLAY);
+        verify(asylumCase).clear(OTHER_DECISION_FOR_DISPLAY);
+
         verify(asylumCase).write(eq(APPLICATIONS), applicationsCaptor.capture());
         assertEquals("Completed", applicationsCaptor.getValue().get(0).getValue().getApplicationStatus());
     }
@@ -165,6 +164,14 @@ class UpdateHearingRequirementsHandlerTest {
         verify(asylumCase).clear(SINGLE_SEX_COURT_TRIBUNAL_RESPONSE);
         verify(asylumCase).clear(IN_CAMERA_COURT_TRIBUNAL_RESPONSE);
         verify(asylumCase).clear(ADDITIONAL_TRIBUNAL_RESPONSE);
+
+        // review decision display fields should be cleared
+        verify(asylumCase).clear(VULNERABILITIES_DECISION_FOR_DISPLAY);
+        verify(asylumCase).clear(REMOTE_HEARING_DECISION_FOR_DISPLAY);
+        verify(asylumCase).clear(MULTIMEDIA_DECISION_FOR_DISPLAY);
+        verify(asylumCase).clear(SINGLE_SEX_COURT_DECISION_FOR_DISPLAY);
+        verify(asylumCase).clear(IN_CAMERA_COURT_DECISION_FOR_DISPLAY);
+        verify(asylumCase).clear(OTHER_DECISION_FOR_DISPLAY);
 
         verify(asylumCase).write(eq(APPLICATIONS), applicationsCaptor.capture());
         assertEquals("Completed", applicationsCaptor.getValue().get(0).getValue().getApplicationStatus());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7487


### Change description ###
* Populate the fields to display hearing adjustment requests decision and Tribunal's responses while handling hearing adjustments review event.
* Ensure these fields are cleared alongside other related fields on 'update hearing requirements' event.
* Ensure the current functionality still works for existing and in-flight appeals


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
