### PR TITLE
RIA-7200 added async stitching event to list of doc generation events

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandler.java
@@ -102,6 +102,7 @@ public class GenerateDocumentHandler implements PreSubmitCallbackHandler<AsylumC
             Event.ADA_SUITABILITY_REVIEW,
             Event.REQUEST_CASE_BUILDING,
             Event.REQUEST_RESPONDENT_REVIEW,
+            Event.ASYNC_STITCHING_COMPLETE,
             Event.UPLOAD_HOME_OFFICE_APPEAL_RESPONSE
         );
         if (isEmStitchingEnabled) {

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandlerTest.java
@@ -147,7 +147,8 @@ class GenerateDocumentHandlerTest {
             GENERATE_UPPER_TRIBUNAL_BUNDLE,
             SUBMIT_REASONS_FOR_APPEAL,
             SUBMIT_CLARIFYING_QUESTION_ANSWERS,
-            REQUEST_CASE_BUILDING
+            REQUEST_CASE_BUILDING,
+            ASYNC_STITCHING_COMPLETE
         ).forEach(event -> {
 
             AsylumCase expectedUpdatedCase = mock(AsylumCase.class);
@@ -299,6 +300,7 @@ class GenerateDocumentHandlerTest {
                         SUBMIT_CLARIFYING_QUESTION_ANSWERS,
                         REQUEST_CASE_BUILDING,
                         REQUEST_RESPONDENT_REVIEW,
+                        ASYNC_STITCHING_COMPLETE,
                         UPLOAD_HOME_OFFICE_APPEAL_RESPONSE
                     ).contains(event)) {
 
@@ -395,7 +397,8 @@ class GenerateDocumentHandlerTest {
                         SUBMIT_CLARIFYING_QUESTION_ANSWERS,
                         REQUEST_CASE_BUILDING,
                         REQUEST_RESPONDENT_REVIEW,
-                        UPLOAD_HOME_OFFICE_APPEAL_RESPONSE
+                        UPLOAD_HOME_OFFICE_APPEAL_RESPONSE,
+                        ASYNC_STITCHING_COMPLETE
                     );
 
                 if (callbackStage.equals(PreSubmitCallbackStage.ABOUT_TO_SUBMIT)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7200


### Change description ###
* Added async stitching complete event to document generation list of events to handle. Generate hearing bundle calls asynch stitching event in the background. Doc generation for hearing bundle must only happen when async stitching is complete.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
