### PR TITLE
RIA-7199 Adjusted dispatch priority for AdvancedFinalBundlingStitchin…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdvancedFinalBundlingStitchingCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdvancedFinalBundlingStitchingCallbackHandler.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
@@ -51,6 +52,11 @@ public class AdvancedFinalBundlingStitchingCallbackHandler implements PreSubmitC
         this.notificationSender = notificationSender;
         this.featureToggler = featureToggler;
         this.homeOfficeApi = homeOfficeApi;
+    }
+
+    @Override
+    public DispatchPriority getDispatchPriority() {
+        return DispatchPriority.LAST;
     }
 
     public boolean canHandle(

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdvancedFinalBundlingStitchingCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AdvancedFinalBundlingStitchingCallbackHandlerTest.java
@@ -33,6 +33,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
@@ -77,6 +78,11 @@ class AdvancedFinalBundlingStitchingCallbackHandlerTest {
         Bundle bundle = new Bundle("id", "title", "desc", "yes", Collections.emptyList(), Optional.of("NEW"),
             Optional.of(stitchedDocument), YesOrNo.YES, YesOrNo.YES, "fileName");
         caseBundles.add(new IdValue<>("1", bundle));
+    }
+
+    @Test
+    void should_be_handled_last() {
+        assertEquals(DispatchPriority.LAST, advancedFinalBundlingStitchingCallbackHandler.getDispatchPriority());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Adjusted dispatch priority for AdvancedFinalBundlingStitchingCallbackHandler so that document can be generated first before notification

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7199


### Change description ###
Adjusted dispatch priority for AdvancedFinalBundlingStitchingCallbackHandler so that document can be generated first before notification


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
