### PR TITLE
RIA-7509 witness interpreters

### DIFF
--- a/charts/ia-case-api/values.preview.template.yaml
+++ b/charts/ia-case-api/values.preview.template.yaml
@@ -9,7 +9,7 @@ java:
     POSTGRES_PASSWORD: hmcts
     POSTGRES_CONNECTION_OPTIONS: ""
     #Un comment APIs if you need to test a local version
-    #IA_CASE_DOCUMENTS_API_URL: https://${SERVICE_NAME}-documents-api.preview.platform.hmcts.net
+    IA_CASE_DOCUMENTS_API_URL: https://${SERVICE_NAME}-documents-api.preview.platform.hmcts.net
     #IA_CASE_NOTIFICATIONS_API_URL: https://${SERVICE_NAME}-notifications-api.preview.platform.hmcts.net
     IA_TIMED_EVENT_SERVICE_URL: http://ia-timed-event-service-aat.service.core-compute-aat.internal/
     IA_TIMED_EVENT_SERVICE_ENABLED: "true"
@@ -91,8 +91,8 @@ ia-case-documents-api:
   enabled: true
   java:
     imagePullPolicy: Always
-    image: hmctspublic.azurecr.io/ia/case-documents-api:latest
-    # image: hmctspublic.azurecr.io/ia/case-documents-api:pr-564
+#    image: hmctspublic.azurecr.io/ia/case-documents-api:latest
+    image: hmctspublic.azurecr.io/ia/case-documents-api:pr-592
     releaseNameOverride: ${SERVICE_NAME}-case-documents-api
     ingressHost: ${SERVICE_NAME}-documents-api.preview.platform.hmcts.net
     environment:

--- a/charts/ia-case-api/values.preview.template.yaml
+++ b/charts/ia-case-api/values.preview.template.yaml
@@ -9,7 +9,7 @@ java:
     POSTGRES_PASSWORD: hmcts
     POSTGRES_CONNECTION_OPTIONS: ""
     #Un comment APIs if you need to test a local version
-    IA_CASE_DOCUMENTS_API_URL: https://${SERVICE_NAME}-documents-api.preview.platform.hmcts.net
+    #IA_CASE_DOCUMENTS_API_URL: https://${SERVICE_NAME}-documents-api.preview.platform.hmcts.net
     #IA_CASE_NOTIFICATIONS_API_URL: https://${SERVICE_NAME}-notifications-api.preview.platform.hmcts.net
     IA_TIMED_EVENT_SERVICE_URL: http://ia-timed-event-service-aat.service.core-compute-aat.internal/
     IA_TIMED_EVENT_SERVICE_ENABLED: "true"
@@ -91,8 +91,8 @@ ia-case-documents-api:
   enabled: true
   java:
     imagePullPolicy: Always
-#    image: hmctspublic.azurecr.io/ia/case-documents-api:latest
-    image: hmctspublic.azurecr.io/ia/case-documents-api:pr-592
+    image: hmctspublic.azurecr.io/ia/case-documents-api:latest
+    # image: hmctspublic.azurecr.io/ia/case-documents-api:pr-564
     releaseNameOverride: ${SERVICE_NAME}-case-documents-api
     ingressHost: ${SERVICE_NAME}-documents-api.preview.platform.hmcts.net
     environment:

--- a/src/functionalTest/resources/scenarios/RIA-7509-submit-hearing-requirements-with-witness-interpreters.json
+++ b/src/functionalTest/resources/scenarios/RIA-7509-submit-hearing-requirements-with-witness-interpreters.json
@@ -1,6 +1,6 @@
 {
   "description": "RIA-7509 Draft and submit hearing requirements for appellant with interpreters for witnesses",
-  "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
+  "enabled": false,
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "LegalRepresentative",

--- a/src/functionalTest/resources/scenarios/RIA-7509-submit-hearing-requirements-with-witness-interpreters.json
+++ b/src/functionalTest/resources/scenarios/RIA-7509-submit-hearing-requirements-with-witness-interpreters.json
@@ -1,0 +1,435 @@
+{
+  "description": "RIA-7509 Draft and submit hearing requirements for appellant with interpreters for witnesses",
+  "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "id": 7509,
+      "eventId": "draftHearingRequirements",
+      "state": "submitHearingRequirements",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isAppellantAttendTheHearing": "Yes",
+          "isAppellantGivingOralEvidence": "Yes",
+          "isWitnessesAttending": "Yes",
+          "witnessDetails": [
+            {
+              "id": "1",
+              "value": {
+                "witnessName": "witness name one",
+                "witnessFamilyName": "witness last name one"
+              }
+            },
+            {
+              "id": "2",
+              "value": {
+                "witnessName": "witness name two",
+                "witnessFamilyName": "witness last name two"
+              }
+            },
+            {
+              "id": "3",
+              "value": {
+                "witnessName": "witness name three",
+                "witnessFamilyName": "witness last name three"
+              }
+            }
+          ],
+          "isInterpreterServicesNeeded": "Yes",
+          "appellantInterpreterLanguageCategory": [
+            "signLanguageInterpreter"
+          ],
+          "appellantInterpreterSignLanguage": {
+            "languageRefData": {
+              "value": {
+                "code": "igbo",
+                "label": "igbo"
+              },
+              "list_items": [
+                {
+                  "code": "igbo",
+                  "label": "igbo"
+                }
+              ]
+            },
+            "languageManualEntry": [],
+            "languageManualEntryDescription": ""
+          },
+          "isAnyWitnessInterpreterRequired": "Yes",
+          "witness1": {
+            "id": "1",
+            "value": {
+              "witnessName": "witness name one",
+              "witnessFamilyName": "witness last name one"
+            }
+          },
+          "witnessListElement1": {
+            "value": [
+              {
+                "code": "witness name one",
+                "label": "witness last name one"
+              }
+            ],
+            "list_items": [
+              {
+                "code": "witness name one",
+                "label": "witness last name one"
+              }
+            ]
+          },
+          "witness1InterpreterSignLanguage": {},
+          "witness1InterpreterSpokenLanguage": {
+            "languageManualEntry": [],
+            "languageRefData": {
+              "value": {
+                "code": "ach",
+                "label": "Acholi"
+              },
+              "list_items": [
+                {
+                  "code": "abr",
+                  "label": "Brong"
+                },
+                {
+                  "code": "ach",
+                  "label": "Acholi"
+                },
+                {
+                  "code": "afr",
+                  "label": "Afrikaans"
+                }
+              ]
+            }
+          },
+          "witness2": {
+            "id": "2",
+            "value": {
+              "witnessName": "witness name two",
+              "witnessFamilyName": "witness last name two"
+            }
+          },
+          "witnessListElement2": {
+            "value": [
+              {
+                "code": "witness name two",
+                "label": "witness last name two"
+              }
+            ],
+            "list_items": [
+              {
+                "code": "witness name two",
+                "label": "witness last name two"
+              }
+            ]
+          },
+          "witness2InterpreterSignLanguage": {},
+          "witness2InterpreterSpokenLanguage": {
+            "languageManualEntry": [],
+            "languageRefData": {
+              "value": {
+                "code": "ach",
+                "label": "Acholi"
+              },
+              "list_items": [
+                {
+                  "code": "abr",
+                  "label": "Brong"
+                },
+                {
+                  "code": "ach",
+                  "label": "Acholi"
+                },
+                {
+                  "code": "afr",
+                  "label": "Afrikaans"
+                }
+              ]
+            }
+          },
+          "witness3": {
+            "id": "3",
+            "value": {
+              "witnessName": "witness name three",
+              "witnessFamilyName": "witness last name three"
+            }
+          },
+          "witnessListElement3": {
+            "value": [
+              {
+                "code": "witness name three",
+                "label": "witness last name three"
+              }
+            ],
+            "list_items": [
+              {
+                "code": "witness name three",
+                "label": "witness last name three"
+              }
+            ]
+          },
+          "witness3InterpreterSignLanguage": {
+            "languageManualEntry": [],
+            "languageRefData": {
+              "value": {
+                "code": "ase",
+                "label": "American Sign Language (ASL)"
+              },
+              "list_items": [
+                {
+                  "code": "ase",
+                  "label": "American Sign Language (ASL)"
+                },
+                {
+                  "code": "bfi",
+                  "label": "British Sign Language (BSL)"
+                }
+              ]
+            }
+          },
+          "witness3InterpreterSpokenLanguage": {},
+          "isHearingRoomNeeded": "Yes",
+          "isHearingLoopNeeded": "Yes",
+          "physicalOrMentalHealthIssues": "Yes",
+          "physicalOrMentalHealthIssuesDescription": "Physical or mental health issues description",
+          "pastExperiences": "Yes",
+          "pastExperiencesDescription": "Past experiences",
+          "multimediaEvidence": "Yes",
+          "multimediaEvidenceDescription": "Multimedia evidence",
+          "singleSexCourt": "Yes",
+          "singleSexCourtType": "All female",
+          "singleSexCourtTypeDescription": "Requirement for single sex court",
+          "inCameraCourt": "Yes",
+          "inCameraCourtDescription": "In camera court description",
+          "additionalRequests": "Yes",
+          "additionalRequestsDescription": "Additional requests description",
+          "hearingDateRangeDescription": "Only include dates between 27 Nov 2019 and 5 Feb 2020.",
+          "datesToAvoid": [
+            {
+              "id": "1",
+              "value": {
+                "dateToAvoid": "2019-12-25",
+                "dateToAvoidReason": "Xmas"
+              }
+            }
+          ],
+          "uploadAdditionalEvidenceActionAvailable": "Yes"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "isAppellantAttendTheHearing": "Yes",
+        "isAppellantGivingOralEvidence": "Yes",
+        "isWitnessesAttending": "Yes",
+        "witnessDetails": [
+          {
+            "id": "1",
+            "value": {
+              "witnessName": "witness name one",
+              "witnessFamilyName": "witness last name one"
+            }
+          },
+          {
+            "id": "2",
+            "value": {
+              "witnessName": "witness name two",
+              "witnessFamilyName": "witness last name two"
+            }
+          },
+          {
+            "id": "3",
+            "value": {
+              "witnessName": "witness name three",
+              "witnessFamilyName": "witness last name three"
+            }
+          }
+        ],
+        "isInterpreterServicesNeeded": "Yes",
+        "appellantInterpreterLanguageCategory": [
+          "signLanguageInterpreter"
+        ],
+        "appellantInterpreterSignLanguage": {
+          "languageRefData": {
+            "value": {
+              "code": "igbo",
+              "label": "igbo"
+            },
+            "list_items": [
+              {
+                "code": "igbo",
+                "label": "igbo"
+              }
+            ]
+          },
+          "languageManualEntry": [],
+          "languageManualEntryDescription": ""
+        },
+        "isAnyWitnessInterpreterRequired": "Yes",
+        "witness1": {
+          "id": "1",
+          "value": {
+            "witnessName": "witness name one",
+            "witnessFamilyName": "witness last name one"
+          }
+        },
+        "witnessListElement1": {
+          "value": [
+            {
+              "code": "witness name one",
+              "label": "witness last name one"
+            }
+          ],
+          "list_items": [
+            {
+              "code": "witness name one",
+              "label": "witness last name one"
+            }
+          ]
+        },
+        "witness1InterpreterSignLanguage": {},
+        "witness1InterpreterSpokenLanguage": {
+          "languageManualEntry": [],
+          "languageRefData": {
+            "value": {
+              "code": "ach",
+              "label": "Acholi"
+            },
+            "list_items": [
+              {
+                "code": "abr",
+                "label": "Brong"
+              },
+              {
+                "code": "ach",
+                "label": "Acholi"
+              },
+              {
+                "code": "afr",
+                "label": "Afrikaans"
+              }
+            ]
+          }
+        },
+        "witness2": {
+          "id": "2",
+          "value": {
+            "witnessName": "witness name two",
+            "witnessFamilyName": "witness last name two"
+          }
+        },
+        "witnessListElement2": {
+          "value": [
+            {
+              "code": "witness name two",
+              "label": "witness last name two"
+            }
+          ],
+          "list_items": [
+            {
+              "code": "witness name two",
+              "label": "witness last name two"
+            }
+          ]
+        },
+        "witness2InterpreterSignLanguage": {},
+        "witness2InterpreterSpokenLanguage": {
+          "languageManualEntry": [],
+          "languageRefData": {
+            "value": {
+              "code": "ach",
+              "label": "Acholi"
+            },
+            "list_items": [
+              {
+                "code": "abr",
+                "label": "Brong"
+              },
+              {
+                "code": "ach",
+                "label": "Acholi"
+              },
+              {
+                "code": "afr",
+                "label": "Afrikaans"
+              }
+            ]
+          }
+        },
+        "witness3": {
+          "id": "3",
+          "value": {
+            "witnessName": "witness name three",
+            "witnessFamilyName": "witness last name three"
+          }
+        },
+        "witnessListElement3": {
+          "value": [
+            {
+              "code": "witness name three",
+              "label": "witness last name three"
+            }
+          ],
+          "list_items": [
+            {
+              "code": "witness name three",
+              "label": "witness last name three"
+            }
+          ]
+        },
+        "witness3InterpreterSignLanguage": {
+          "languageManualEntry": [],
+          "languageRefData": {
+            "value": {
+              "code": "ase",
+              "label": "American Sign Language (ASL)"
+            },
+            "list_items": [
+              {
+                "code": "ase",
+                "label": "American Sign Language (ASL)"
+              },
+              {
+                "code": "bfi",
+                "label": "British Sign Language (BSL)"
+              }
+            ]
+          }
+        },
+        "witness3InterpreterSpokenLanguage": {},
+        "isHearingRoomNeeded": "Yes",
+        "isHearingLoopNeeded": "Yes",
+        "physicalOrMentalHealthIssues": "Yes",
+        "physicalOrMentalHealthIssuesDescription": "Physical or mental health issues description",
+        "pastExperiences": "Yes",
+        "pastExperiencesDescription": "Past experiences",
+        "multimediaEvidence": "Yes",
+        "multimediaEvidenceDescription": "Multimedia evidence",
+        "singleSexCourt": "Yes",
+        "singleSexCourtType": "All female",
+        "singleSexCourtTypeDescription": "Requirement for single sex court",
+        "inCameraCourt": "Yes",
+        "inCameraCourtDescription": "In camera court description",
+        "additionalRequests": "Yes",
+        "additionalRequestsDescription": "Additional requests description",
+        "hearingDateRangeDescription": "Only include dates between 27 Nov 2019 and 5 Feb 2020.",
+        "datesToAvoid": [
+          {
+            "id": "1",
+            "value": {
+              "dateToAvoid": "2019-12-25",
+              "dateToAvoidReason": "Xmas"
+            }
+          }
+        ],
+        "uploadAdditionalEvidenceActionAvailable": "Yes"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -767,6 +767,102 @@ public enum AsylumCaseFieldDefinition {
     WITNESS_DETAILS(
         "witnessDetails", new TypeReference<List<IdValue<WitnessDetails>>>() {}),
 
+    WHICH_WITNESSES_NEED_INTERPRETER(
+        "whichWitnessesNeedInterpreter", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_1(
+        "witness1", new TypeReference<WitnessDetails>() {}),
+
+    WITNESS_2(
+        "witness2", new TypeReference<WitnessDetails>() {}),
+
+    WITNESS_3(
+        "witness3", new TypeReference<WitnessDetails>() {}),
+
+    WITNESS_4(
+        "witness4", new TypeReference<WitnessDetails>() {}),
+
+    WITNESS_5(
+        "witness5", new TypeReference<WitnessDetails>() {}),
+
+    WITNESS_6(
+        "witness6", new TypeReference<WitnessDetails>() {}),
+
+    WITNESS_7(
+        "witness7", new TypeReference<WitnessDetails>() {}),
+
+    WITNESS_8(
+        "witness8", new TypeReference<WitnessDetails>() {}),
+
+    WITNESS_9(
+        "witness9", new TypeReference<WitnessDetails>() {}),
+
+    WITNESS_10(
+        "witness10", new TypeReference<WitnessDetails>() {}),
+
+    WITNESS_LIST_ELEMENT_1(
+        "witnessListElement1", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_2(
+        "witnessListElement2", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_3(
+        "witnessListElement3", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_4(
+        "witnessListElement4", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_5(
+        "witnessListElement5", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_6(
+        "witnessListElement6", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_7(
+        "witnessListElement7", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_8(
+        "witnessListElement8", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_9(
+        "witnessListElement9", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_10(
+        "witnessListElement10", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_1_INTERPRETER_LANGUAGE_CATEGORY(
+        "witness1InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+
+    WITNESS_2_INTERPRETER_LANGUAGE_CATEGORY(
+        "witness2InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+
+    WITNESS_3_INTERPRETER_LANGUAGE_CATEGORY(
+        "witness3InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+
+    WITNESS_4_INTERPRETER_LANGUAGE_CATEGORY(
+        "witness4InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+
+    WITNESS_5_INTERPRETER_LANGUAGE_CATEGORY(
+        "witness5InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+
+    WITNESS_6_INTERPRETER_LANGUAGE_CATEGORY(
+        "witness6InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+
+    WITNESS_7_INTERPRETER_LANGUAGE_CATEGORY(
+        "witness7InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+
+    WITNESS_8_INTERPRETER_LANGUAGE_CATEGORY(
+        "witness8InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+
+    WITNESS_9_INTERPRETER_LANGUAGE_CATEGORY(
+        "witness9InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+
+    WITNESS_10_INTERPRETER_LANGUAGE_CATEGORY(
+        "witness10InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+
+    IS_WITNESS_1_INTERPRETER_NEEDED(
+        "isWitness1InterpreterNeeded", new TypeReference<String>() {}),
+
     WITNESS_DETAILS_READONLY(
         "witnessDetailsReadonly", new TypeReference<List<IdValue<WitnessDetails>>>() {}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -860,6 +860,66 @@ public enum AsylumCaseFieldDefinition {
     WITNESS_10_INTERPRETER_LANGUAGE_CATEGORY(
         "witness10InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
 
+    WITNESS_1_INTERPRETER_SPOKEN_LANGUAGE(
+        "witness1InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_1_INTERPRETER_SIGN_LANGUAGE(
+        "witness1InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_2_INTERPRETER_SPOKEN_LANGUAGE(
+        "witness2InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_2_INTERPRETER_SIGN_LANGUAGE(
+        "witness2InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_3_INTERPRETER_SPOKEN_LANGUAGE(
+        "witness3InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_3_INTERPRETER_SIGN_LANGUAGE(
+        "witness3InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_4_INTERPRETER_SPOKEN_LANGUAGE(
+        "witness4InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_4_INTERPRETER_SIGN_LANGUAGE(
+        "witness4InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_5_INTERPRETER_SPOKEN_LANGUAGE(
+        "witness5InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_5_INTERPRETER_SIGN_LANGUAGE(
+        "witness5InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_6_INTERPRETER_SPOKEN_LANGUAGE(
+        "witness6InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_6_INTERPRETER_SIGN_LANGUAGE(
+        "witness6InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_7_INTERPRETER_SPOKEN_LANGUAGE(
+        "witness7InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_7_INTERPRETER_SIGN_LANGUAGE(
+        "witness7InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_8_INTERPRETER_SPOKEN_LANGUAGE(
+        "witness8InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_8_INTERPRETER_SIGN_LANGUAGE(
+        "witness8InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_9_INTERPRETER_SPOKEN_LANGUAGE(
+        "witness9InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_9_INTERPRETER_SIGN_LANGUAGE(
+        "witness9InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_10_INTERPRETER_SPOKEN_LANGUAGE(
+        "witness10InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
+    WITNESS_10_INTERPRETER_SIGN_LANGUAGE(
+        "witness10InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+
     IS_WITNESS_1_INTERPRETER_NEEDED(
         "isWitness1InterpreterNeeded", new TypeReference<String>() {}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/DynamicMultiSelectList.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/DynamicMultiSelectList.java
@@ -12,14 +12,14 @@ import lombok.ToString;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class DynamicMultiSelectList {
 
-    private List<Value> values;
+    private List<Value> value;
     private List<Value> listItems;
 
     public DynamicMultiSelectList(List<String> values) {
-        this.values = values.stream().map(value -> new Value(value, value)).collect(Collectors.toList());
+        this.value = values.stream().map(value -> new Value(value, value)).collect(Collectors.toList());
     }
 
-    private DynamicMultiSelectList() {
+    public DynamicMultiSelectList() {
     }
 
     public List<Value> getListItems() {
@@ -27,16 +27,16 @@ public class DynamicMultiSelectList {
     }
 
     public DynamicMultiSelectList(List<Value> values, List<Value> listItems) {
-        this.values = values;
+        this.value = values;
         this.listItems = listItems;
     }
 
-    public List<Value> getValues() {
-        return values;
+    public List<Value> getValue() {
+        return value;
     }
 
-    public void setValues(List<Value> values) {
-        this.values = values;
+    public void setValue(List<Value> value) {
+        this.value = value;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/DynamicMultiSelectList.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/DynamicMultiSelectList.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class DynamicMultiSelectList {
+
+    private List<Value> values;
+    private List<Value> listItems;
+
+    public DynamicMultiSelectList(List<String> values) {
+        this.values = values.stream().map(value -> new Value(value, value)).collect(Collectors.toList());
+    }
+
+    private DynamicMultiSelectList() {
+    }
+
+    public List<Value> getListItems() {
+        return listItems;
+    }
+
+    public DynamicMultiSelectList(List<Value> values, List<Value> listItems) {
+        this.values = values;
+        this.listItems = listItems;
+    }
+
+    public List<Value> getValues() {
+        return values;
+    }
+
+    public void setValues(List<Value> values) {
+        this.values = values;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdater.java
@@ -1,13 +1,23 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_SIGN_LANGUAGE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_SPOKEN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.WitnessesMidEventHandler.WITNESS_LIST_ELEMENT_N_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.WitnessesMidEventHandler.WITNESS_N_INTERPRETER_CATEGORY_FIELD;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicList;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicMultiSelectList;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageRefData;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.Value;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
@@ -26,10 +36,39 @@ public class InterpreterLanguagesDynamicListUpdater implements PreSubmitCallback
         this.refDataUserService = refDataUserService;
     }
 
+    private static final String NO_WITNESSES_SELECTED_ERROR = "Select at least one witness";
+    private static final String DRAFT_HEARING_REQUIREMENTS_PAGE_ID = "draftHearingRequirements";
+    private static final String WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID = "whichWitnessRequiresInterpreter";
     public static final String INTERPRETER_LANGUAGES = "InterpreterLanguage";
     public static final String SIGN_LANGUAGES = "SignLanguage";
     public static final String IS_CHILD_REQUIRED = "Y";
     public static final String YES = "Yes";
+    protected static final List<AsylumCaseFieldDefinition> WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE = List.of(
+        WITNESS_1_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_2_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_3_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_4_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_5_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_6_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_7_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_8_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_9_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_10_INTERPRETER_SPOKEN_LANGUAGE
+        );
+    protected static final List<AsylumCaseFieldDefinition> WITNESS_N_INTERPRETER_SIGN_LANGUAGE = List.of(
+        WITNESS_1_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_2_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_3_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_4_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_5_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_6_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_7_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_8_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_9_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_10_INTERPRETER_SIGN_LANGUAGE
+    );
+    private static final String SPOKEN = "spokenLanguageInterpreter";
+    private static final String SIGN = "signLanguageInterpreter";
 
     public boolean canHandle(
             PreSubmitCallbackStage callbackStage,
@@ -56,19 +95,78 @@ public class InterpreterLanguagesDynamicListUpdater implements PreSubmitCallback
                         .getCaseDetails()
                         .getCaseData();
 
-        populateDynamicList(asylumCase, INTERPRETER_LANGUAGES, APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
-        populateDynamicList(asylumCase, SIGN_LANGUAGES, APPELLANT_INTERPRETER_SIGN_LANGUAGE);
+        String pageId = callback.getPageId();
 
-        return new PreSubmitCallbackResponse<>(asylumCase);
+        if (Objects.equals(pageId, DRAFT_HEARING_REQUIREMENTS_PAGE_ID)) {
+            populateDynamicList(asylumCase, INTERPRETER_LANGUAGES, APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
+            populateDynamicList(asylumCase, SIGN_LANGUAGES, APPELLANT_INTERPRETER_SIGN_LANGUAGE);
+        }
+
+        PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
+
+        int numberOfWitnesses = asylumCase.read(WITNESS_DETAILS, List.class).orElse(Collections.emptyList()).size();
+
+        if (Objects.equals(pageId, WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID)) {
+
+            InterpreterLanguageRefData spokenLanguages = generateDynamicList(INTERPRETER_LANGUAGES);
+            InterpreterLanguageRefData signLanguages = generateDynamicList(SIGN_LANGUAGES);
+
+            Map<Integer,List<String>> witnessIndexToInterpreterNeeded = new HashMap<>();
+
+            int i = 0;
+            while (i < numberOfWitnesses) {
+                DynamicMultiSelectList witnessElement = asylumCase
+                    .read(WITNESS_LIST_ELEMENT_N_FIELD.get(i), DynamicMultiSelectList.class).orElse(null);
+
+                boolean witnessSelected = witnessElement != null
+                                        && !witnessElement.getValue().isEmpty()
+                                        && !witnessElement.getValue().get(0).getLabel().isEmpty();
+
+                if (witnessSelected) {
+
+                    Optional<List<String>> optionalSelectedInterpreterType = asylumCase.read(WITNESS_N_INTERPRETER_CATEGORY_FIELD.get(i));
+                    List<String> selectedInterpreterType = optionalSelectedInterpreterType.isEmpty()
+                        ? Collections.emptyList()
+                        : optionalSelectedInterpreterType.get();
+
+                    witnessIndexToInterpreterNeeded.put(i, selectedInterpreterType);
+                }
+                i++;
+            }
+
+            if (witnessIndexToInterpreterNeeded.isEmpty()) {
+                response.addError(NO_WITNESSES_SELECTED_ERROR);
+            }
+
+            witnessIndexToInterpreterNeeded.forEach((index, interpretersNeeded) -> {
+                interpretersNeeded.forEach(interpreterCategory -> {
+                    if (Objects.equals(interpreterCategory, SPOKEN)) {
+                        asylumCase.write(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(index), spokenLanguages);
+                    }
+                    if (Objects.equals(interpreterCategory, SIGN)) {
+                        asylumCase.write(WITNESS_N_INTERPRETER_SIGN_LANGUAGE.get(index), signLanguages);
+                    }
+                });
+            });
+
+        }
+
+        return response;
     }
 
     private void populateDynamicList(AsylumCase asylumCase, String languageCategory, AsylumCaseFieldDefinition languageCategoryDefinition) {
+        InterpreterLanguageRefData interpreterLanguage = generateDynamicList(languageCategory);
+
+        asylumCase.write(languageCategoryDefinition, interpreterLanguage);
+    }
+
+    private InterpreterLanguageRefData generateDynamicList(String languageCategory) {
         List<CategoryValues> languages;
         DynamicList dynamicListOfLanguages;
 
         try {
             CommonDataResponse commonDataResponse = refDataUserService.retrieveCategoryValues(
-                    languageCategory,
+                languageCategory,
                 IS_CHILD_REQUIRED
             );
 
@@ -78,15 +176,13 @@ public class InterpreterLanguagesDynamicListUpdater implements PreSubmitCallback
                 refDataUserService.mapCategoryValuesToDynamicListValues(languages));
 
         } catch (Exception e) {
-            throw new RuntimeException(String.format("Could not read response by RefData service for %s(s)",languageCategory), e);
+            throw new RuntimeException(String.format("Could not read response by RefData service for %s(s)", languageCategory), e);
         }
 
-        InterpreterLanguageRefData interpreterLanguage = new InterpreterLanguageRefData(
+        return new InterpreterLanguageRefData(
             dynamicListOfLanguages,
             Collections.emptyList(),
             "");
-
-        asylumCase.write(languageCategoryDefinition, interpreterLanguage);
     }
 }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesMidEventHandler.java
@@ -5,9 +5,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.DRAFT_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUIREMENTS;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -28,10 +26,8 @@ public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<Asylum
 
     private static final String IS_WITNESSES_ATTENDING_PAGE_ID = "isWitnessesAttending";
     private static final String IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID = "isAnyWitnessInterpreterRequired";
-    private static final String WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID = "whichWitnessRequiresInterpreter";
+    //private static final String WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID = "whichWitnessRequiresInterpreter";
     private static final String WITNESSES_NUMBER_EXCEEDED_ERROR = "Maximum number of witnesses is 10";
-    private static final String NO_WITNESSES_SELECTED_ERROR = "Select at least one witness";
-    private static final String TOO_MANY_INTERPRETER_TYPES_ERROR = "Select only one interpreter type for witness ";
 
     private static final List<AsylumCaseFieldDefinition> WITNESS_N_FIELD = List.of(
         WITNESS_1,
@@ -44,7 +40,7 @@ public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<Asylum
         WITNESS_8,
         WITNESS_9,
         WITNESS_10);
-    private static final List<AsylumCaseFieldDefinition> WITNESS_LIST_ELEMENT_N_FIELD = List.of(
+    protected static final List<AsylumCaseFieldDefinition> WITNESS_LIST_ELEMENT_N_FIELD = List.of(
         WITNESS_LIST_ELEMENT_1,
         WITNESS_LIST_ELEMENT_2,
         WITNESS_LIST_ELEMENT_3,
@@ -56,7 +52,7 @@ public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<Asylum
         WITNESS_LIST_ELEMENT_9,
         WITNESS_LIST_ELEMENT_10
     );
-    private static final List<AsylumCaseFieldDefinition> WITNESS_N_INTERPRETER_CATEGORY_FIELD = List.of(
+    protected static final List<AsylumCaseFieldDefinition> WITNESS_N_INTERPRETER_CATEGORY_FIELD = List.of(
         WITNESS_1_INTERPRETER_LANGUAGE_CATEGORY,
         WITNESS_2_INTERPRETER_LANGUAGE_CATEGORY,
         WITNESS_3_INTERPRETER_LANGUAGE_CATEGORY,
@@ -79,10 +75,7 @@ public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<Asylum
 
         return callbackStage == PreSubmitCallbackStage.MID_EVENT
                && Set.of(DRAFT_HEARING_REQUIREMENTS, UPDATE_HEARING_REQUIREMENTS).contains(callback.getEvent())
-               && Set.of(
-                   IS_WITNESSES_ATTENDING_PAGE_ID,
-            IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID,
-            WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID).contains(pageId);
+               && Set.of(IS_WITNESSES_ATTENDING_PAGE_ID, IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID).contains(pageId);
     }
 
     @Override
@@ -94,8 +87,6 @@ public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<Asylum
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
         String pageId = callback.getPageId();
         PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
-
-        clearWitnessFieldsPreemptively(asylumCase);
 
         Optional<List<IdValue<WitnessDetails>>> optionalWitnesses = asylumCase.read(WITNESS_DETAILS);
 
@@ -111,6 +102,8 @@ public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<Asylum
 
             case IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID:
 
+                clearWitnessFieldsPreemptively(asylumCase);
+
                 optionalWitnesses.ifPresent(witnesses -> {
                     int i = 0;
                     while (i < witnesses.size()) {
@@ -120,7 +113,7 @@ public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<Asylum
                         asylumCase.write(WITNESS_N_FIELD.get(i), witnesses.get(i).getValue());
                         asylumCase.write(WITNESS_LIST_ELEMENT_N_FIELD.get(i),
                             new DynamicMultiSelectList(
-                                List.of(new Value("", "")),
+                                Collections.emptyList(),
                                 List.of(new Value(fullName, fullName))
                             ));
                         i++;
@@ -128,71 +121,7 @@ public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<Asylum
                 });
                 break;
 
-
-            case WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID:
-
-                Set<Integer> selectedWitnessesIndexes = new HashSet<>();
-                List<DynamicMultiSelectList> selectedWitnesses = new ArrayList<>();
-
-                int i = 0;
-
-                while (i < WITNESS_LIST_ELEMENT_N_FIELD.size()) {
-                    DynamicMultiSelectList witnessElement = asylumCase
-                        .read(WITNESS_LIST_ELEMENT_N_FIELD.get(i), DynamicMultiSelectList.class).orElse(null);
-                    if (witnessElement != null && !witnessElement.getValues().isEmpty()) {
-                        selectedWitnesses.add(witnessElement);
-                        selectedWitnessesIndexes.add(i);
-                    }
-                    i++;
-                }
-
-                if (selectedWitnesses.isEmpty()) {
-                    response.addError(NO_WITNESSES_SELECTED_ERROR);
-                }
-
-                selectedWitnessesIndexes.forEach(indexOfSelectedWitness -> {
-                    Optional<List<String>> optionalWitnessInterpreters = asylumCase
-                        .read(WITNESS_N_INTERPRETER_CATEGORY_FIELD.get(indexOfSelectedWitness));
-                    if (!optionalWitnessInterpreters.isEmpty() && optionalWitnessInterpreters.get().size() == 2) {
-                        response.addError(TOO_MANY_INTERPRETER_TYPES_ERROR + indexOfSelectedWitness);
-                    }
-                });
-
         }
-
-        //optionalWitnesses.ifPresent(witnesses -> {
-        //    if (IS_WITNESSES_ATTENDING_PAGE_ID.equals(pageId)) {
-        //
-        //        if (witnesses.size() > WITNESS_N_FIELD.size()) {        // 10
-        //            response.addError(WITNESSES_NUMBER_EXCEEDED_ERROR);
-        //        }
-        //    } else {
-        //
-        //        int i = 0;
-        //        while (i < witnesses.size()) {
-        //
-        //            String fullName = buildWitnessFullName(witnesses.get(i).getValue());
-        //
-        //            asylumCase.write(WITNESS_N_FIELD.get(i), witnesses.get(i).getValue());
-        //            asylumCase.write(WITNESS_LIST_ELEMENT_N_FIELD.get(i),
-        //                new DynamicMultiSelectList(
-        //                    List.of(new Value("", "")),
-        //                    List.of(new Value(fullName, fullName))
-        //                ));
-        //            i++;
-        //        }
-        //    }
-
-
-
-            //while (i < WITNESS_N_FIELD.size()) { // 10
-            //    asylumCase.write(WITNESS_N_FIELD.get(i), null);
-            //    asylumCase.write(WITNESS_LIST_ELEMENT_N_FIELD.get(i), null);
-            //    asylumCase.write(WITNESS_N_INTERPRETER_CATEGORY_FIELD.get(i), null);
-            //    i++;
-            //}
-        //
-        //});
 
         return response;
     }
@@ -203,11 +132,7 @@ public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<Asylum
 
     private void clearWitnessFieldsPreemptively(AsylumCase asylumCase) {
         WITNESS_N_FIELD.forEach(field -> asylumCase.write(field, new WitnessDetails("", "")));
-        //WITNESS_N_FIELD.forEach(asylumCase::clear);
-        WITNESS_LIST_ELEMENT_N_FIELD.forEach(field -> asylumCase.write(field, new DynamicMultiSelectList(
-            List.of(new Value("", "")),
-            List.of(new Value("", ""))
-        )));
+        WITNESS_LIST_ELEMENT_N_FIELD.forEach(field -> asylumCase.write(field, new DynamicMultiSelectList()));
         WITNESS_N_INTERPRETER_CATEGORY_FIELD.forEach(field -> asylumCase.write(field, Collections.emptyList()));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesMidEventHandler.java
@@ -26,10 +26,9 @@ public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<Asylum
 
     private static final String IS_WITNESSES_ATTENDING_PAGE_ID = "isWitnessesAttending";
     private static final String IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID = "isAnyWitnessInterpreterRequired";
-    //private static final String WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID = "whichWitnessRequiresInterpreter";
     private static final String WITNESSES_NUMBER_EXCEEDED_ERROR = "Maximum number of witnesses is 10";
 
-    private static final List<AsylumCaseFieldDefinition> WITNESS_N_FIELD = List.of(
+    protected static final List<AsylumCaseFieldDefinition> WITNESS_N_FIELD = List.of(
         WITNESS_1,
         WITNESS_2,
         WITNESS_3,
@@ -120,7 +119,8 @@ public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<Asylum
                     }
                 });
                 break;
-
+            default:
+                break;
         }
 
         return response;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesMidEventHandler.java
@@ -1,15 +1,21 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_DETAILS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.DRAFT_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUIREMENTS;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicMultiSelectList;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.Value;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
@@ -20,18 +26,63 @@ import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 @Component
 public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
-    private static final String IS_WITNESSES_ATTENDING = "isWitnessesAttending";
-    private static final int TEN = 10;
+    private static final String IS_WITNESSES_ATTENDING_PAGE_ID = "isWitnessesAttending";
+    private static final String IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID = "isAnyWitnessInterpreterRequired";
+    private static final String WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID = "whichWitnessRequiresInterpreter";
     private static final String WITNESSES_NUMBER_EXCEEDED_ERROR = "Maximum number of witnesses is 10";
+    private static final String NO_WITNESSES_SELECTED_ERROR = "Select at least one witness";
+    private static final String TOO_MANY_INTERPRETER_TYPES_ERROR = "Select only one interpreter type for witness ";
+
+    private static final List<AsylumCaseFieldDefinition> WITNESS_N_FIELD = List.of(
+        WITNESS_1,
+        WITNESS_2,
+        WITNESS_3,
+        WITNESS_4,
+        WITNESS_5,
+        WITNESS_6,
+        WITNESS_7,
+        WITNESS_8,
+        WITNESS_9,
+        WITNESS_10);
+    private static final List<AsylumCaseFieldDefinition> WITNESS_LIST_ELEMENT_N_FIELD = List.of(
+        WITNESS_LIST_ELEMENT_1,
+        WITNESS_LIST_ELEMENT_2,
+        WITNESS_LIST_ELEMENT_3,
+        WITNESS_LIST_ELEMENT_4,
+        WITNESS_LIST_ELEMENT_5,
+        WITNESS_LIST_ELEMENT_6,
+        WITNESS_LIST_ELEMENT_7,
+        WITNESS_LIST_ELEMENT_8,
+        WITNESS_LIST_ELEMENT_9,
+        WITNESS_LIST_ELEMENT_10
+    );
+    private static final List<AsylumCaseFieldDefinition> WITNESS_N_INTERPRETER_CATEGORY_FIELD = List.of(
+        WITNESS_1_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_2_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_3_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_4_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_5_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_6_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_7_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_8_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_9_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_10_INTERPRETER_LANGUAGE_CATEGORY
+    );
+
 
     @Override
     public boolean canHandle(PreSubmitCallbackStage callbackStage, Callback<AsylumCase> callback) {
         requireNonNull(callbackStage, "callbackStage must not be null");
         requireNonNull(callback, "callback must not be null");
 
+        String pageId = callback.getPageId();
+
         return callbackStage == PreSubmitCallbackStage.MID_EVENT
                && Set.of(DRAFT_HEARING_REQUIREMENTS, UPDATE_HEARING_REQUIREMENTS).contains(callback.getEvent())
-               && callback.getPageId().equals(IS_WITNESSES_ATTENDING);
+               && Set.of(
+                   IS_WITNESSES_ATTENDING_PAGE_ID,
+            IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID,
+            WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID).contains(pageId);
     }
 
     @Override
@@ -41,17 +92,123 @@ public class WitnessesMidEventHandler implements PreSubmitCallbackHandler<Asylum
         }
 
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
-
+        String pageId = callback.getPageId();
         PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
+
+        clearWitnessFieldsPreemptively(asylumCase);
 
         Optional<List<IdValue<WitnessDetails>>> optionalWitnesses = asylumCase.read(WITNESS_DETAILS);
 
-        optionalWitnesses.ifPresent(witnesses -> {
-            if (witnesses.size() > TEN) {
-                response.addError(WITNESSES_NUMBER_EXCEEDED_ERROR);
-            }
-        });
+        switch (pageId) {
+            case IS_WITNESSES_ATTENDING_PAGE_ID:
+
+                optionalWitnesses.ifPresent(witnesses -> {
+                    if (witnesses.size() > WITNESS_N_FIELD.size()) {        // 10
+                        response.addError(WITNESSES_NUMBER_EXCEEDED_ERROR);
+                    }
+                });
+                break;
+
+            case IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID:
+
+                optionalWitnesses.ifPresent(witnesses -> {
+                    int i = 0;
+                    while (i < witnesses.size()) {
+
+                        String fullName = buildWitnessFullName(witnesses.get(i).getValue());
+
+                        asylumCase.write(WITNESS_N_FIELD.get(i), witnesses.get(i).getValue());
+                        asylumCase.write(WITNESS_LIST_ELEMENT_N_FIELD.get(i),
+                            new DynamicMultiSelectList(
+                                List.of(new Value("", "")),
+                                List.of(new Value(fullName, fullName))
+                            ));
+                        i++;
+                    }
+                });
+                break;
+
+
+            case WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID:
+
+                Set<Integer> selectedWitnessesIndexes = new HashSet<>();
+                List<DynamicMultiSelectList> selectedWitnesses = new ArrayList<>();
+
+                int i = 0;
+
+                while (i < WITNESS_LIST_ELEMENT_N_FIELD.size()) {
+                    DynamicMultiSelectList witnessElement = asylumCase
+                        .read(WITNESS_LIST_ELEMENT_N_FIELD.get(i), DynamicMultiSelectList.class).orElse(null);
+                    if (witnessElement != null && !witnessElement.getValues().isEmpty()) {
+                        selectedWitnesses.add(witnessElement);
+                        selectedWitnessesIndexes.add(i);
+                    }
+                    i++;
+                }
+
+                if (selectedWitnesses.isEmpty()) {
+                    response.addError(NO_WITNESSES_SELECTED_ERROR);
+                }
+
+                selectedWitnessesIndexes.forEach(indexOfSelectedWitness -> {
+                    Optional<List<String>> optionalWitnessInterpreters = asylumCase
+                        .read(WITNESS_N_INTERPRETER_CATEGORY_FIELD.get(indexOfSelectedWitness));
+                    if (!optionalWitnessInterpreters.isEmpty() && optionalWitnessInterpreters.get().size() == 2) {
+                        response.addError(TOO_MANY_INTERPRETER_TYPES_ERROR + indexOfSelectedWitness);
+                    }
+                });
+
+        }
+
+        //optionalWitnesses.ifPresent(witnesses -> {
+        //    if (IS_WITNESSES_ATTENDING_PAGE_ID.equals(pageId)) {
+        //
+        //        if (witnesses.size() > WITNESS_N_FIELD.size()) {        // 10
+        //            response.addError(WITNESSES_NUMBER_EXCEEDED_ERROR);
+        //        }
+        //    } else {
+        //
+        //        int i = 0;
+        //        while (i < witnesses.size()) {
+        //
+        //            String fullName = buildWitnessFullName(witnesses.get(i).getValue());
+        //
+        //            asylumCase.write(WITNESS_N_FIELD.get(i), witnesses.get(i).getValue());
+        //            asylumCase.write(WITNESS_LIST_ELEMENT_N_FIELD.get(i),
+        //                new DynamicMultiSelectList(
+        //                    List.of(new Value("", "")),
+        //                    List.of(new Value(fullName, fullName))
+        //                ));
+        //            i++;
+        //        }
+        //    }
+
+
+
+            //while (i < WITNESS_N_FIELD.size()) { // 10
+            //    asylumCase.write(WITNESS_N_FIELD.get(i), null);
+            //    asylumCase.write(WITNESS_LIST_ELEMENT_N_FIELD.get(i), null);
+            //    asylumCase.write(WITNESS_N_INTERPRETER_CATEGORY_FIELD.get(i), null);
+            //    i++;
+            //}
+        //
+        //});
 
         return response;
     }
+
+    private String buildWitnessFullName(WitnessDetails witnessDetails) {
+        return (witnessDetails.getWitnessName() + " " + witnessDetails.getWitnessFamilyName()).trim();
+    }
+
+    private void clearWitnessFieldsPreemptively(AsylumCase asylumCase) {
+        WITNESS_N_FIELD.forEach(field -> asylumCase.write(field, new WitnessDetails("", "")));
+        //WITNESS_N_FIELD.forEach(asylumCase::clear);
+        WITNESS_LIST_ELEMENT_N_FIELD.forEach(field -> asylumCase.write(field, new DynamicMultiSelectList(
+            List.of(new Value("", "")),
+            List.of(new Value("", ""))
+        )));
+        WITNESS_N_INTERPRETER_CATEGORY_FIELD.forEach(field -> asylumCase.write(field, Collections.emptyList()));
+    }
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdaterTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -13,6 +14,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_SIGN_LANGUAGE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_SPOKEN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_1_INTERPRETER_LANGUAGE_CATEGORY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_1_INTERPRETER_SPOKEN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_2_INTERPRETER_LANGUAGE_CATEGORY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_2_INTERPRETER_SIGN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_DETAILS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_LIST_ELEMENT_1;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_LIST_ELEMENT_2;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
 
@@ -29,10 +37,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicList;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicMultiSelectList;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageRefData;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.Value;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.RefDataUserService;
 import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.model.dto.hearingdetails.CategoryValues;
@@ -43,6 +57,9 @@ import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.model.dto.hearingdet
 @SuppressWarnings("unchecked")
 class InterpreterLanguagesDynamicListUpdaterTest {
 
+    private static final String NO_WITNESSES_SELECTED_ERROR = "Select at least one witness";
+    private static final String DRAFT_HEARING_REQUIREMENTS_PAGE_ID = "draftHearingRequirements";
+    private static final String WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID = "whichWitnessRequiresInterpreter";
     public static final String INTERPRETER_LANGUAGES = "InterpreterLanguage";
     public static final String SIGN_LANGUAGES = "SignLanguage";
     public static final String IS_CHILD_REQUIRED = "Y";
@@ -66,6 +83,14 @@ class InterpreterLanguagesDynamicListUpdaterTest {
     private CategoryValues categoryValues;
     @Mock
     private Value value;
+    @Mock
+    private WitnessDetails witnessDetails1;
+    @Mock
+    private WitnessDetails witnessDetails2;
+    @Mock
+    private DynamicMultiSelectList witnessListElement1;
+    @Mock
+    private DynamicMultiSelectList witnessListElement2;
 
     @BeforeEach
     public void setUp() {
@@ -84,6 +109,7 @@ class InterpreterLanguagesDynamicListUpdaterTest {
         List<Value> values = List.of(value);
 
         when(callback.getEvent()).thenReturn(event);
+        when(callback.getPageId()).thenReturn(DRAFT_HEARING_REQUIREMENTS_PAGE_ID);
         when(refDataUserService.retrieveCategoryValues(INTERPRETER_LANGUAGES, IS_CHILD_REQUIRED))
             .thenReturn(commonDataResponse);
         when(refDataUserService.retrieveCategoryValues(SIGN_LANGUAGES, IS_CHILD_REQUIRED))
@@ -114,12 +140,55 @@ class InterpreterLanguagesDynamicListUpdaterTest {
 
     @Test
     void should_not_populate_dynamic_list_if_interpreter_language_ref_data_exists() {
+        when(callback.getPageId()).thenReturn(DRAFT_HEARING_REQUIREMENTS_PAGE_ID);
         when(asylumCase.read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE)).thenReturn(Optional.empty());
         when(callback.getCaseDetailsBefore()).thenReturn(Optional.of(caseDetailsBefore));
         when(caseDetailsBefore.getCaseData()).thenReturn(asylumCaseBefore);
         when(asylumCaseBefore.read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE)).thenReturn(Optional.empty());
 
         verify(refDataUserService, never()).retrieveCategoryValues(anyString(), anyString());
+    }
+
+    @Test
+    void should_populate_dynamic_lists_for_witnesses() {
+        when(callback.getPageId()).thenReturn(WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID);
+        when(asylumCase.read(WITNESS_DETAILS, List.class)).thenReturn(Optional.of(List.of(witnessDetails1,witnessDetails2)));
+        when(refDataUserService.retrieveCategoryValues(INTERPRETER_LANGUAGES, IS_CHILD_REQUIRED))
+            .thenReturn(commonDataResponse);
+        when(refDataUserService.retrieveCategoryValues(SIGN_LANGUAGES, IS_CHILD_REQUIRED))
+            .thenReturn(commonDataResponse);
+        List<CategoryValues> languages = List.of(categoryValues);
+        List<Value> values = List.of(value);
+        when(refDataUserService.filterCategoryValuesByCategoryId(commonDataResponse, INTERPRETER_LANGUAGES))
+            .thenReturn(languages);
+        when(refDataUserService.filterCategoryValuesByCategoryId(commonDataResponse, SIGN_LANGUAGES))
+            .thenReturn(languages);
+        when(refDataUserService.mapCategoryValuesToDynamicListValues(languages)).thenReturn(values);
+        when(asylumCase.read(WITNESS_LIST_ELEMENT_1, DynamicMultiSelectList.class)).thenReturn(Optional.of(witnessListElement1));
+        when(asylumCase.read(WITNESS_LIST_ELEMENT_2, DynamicMultiSelectList.class)).thenReturn(Optional.of(witnessListElement2));
+        List<Value> user = List.of(new Value("name lastname", "name lastName"));
+        when(witnessListElement1.getValue()).thenReturn(user);
+        when(witnessListElement2.getValue()).thenReturn(user);
+
+        // selecting spoken interpreter for witness1 and sign interpreter for witness2
+        when(asylumCase.read(WITNESS_1_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(List.of("spokenLanguageInterpreter")));
+        when(asylumCase.read(WITNESS_2_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(List.of("signLanguageInterpreter")));
+
+        interpreterLanguagesDynamicListUpdater.handle(MID_EVENT, callback);
+
+        verify(asylumCase).write(eq(WITNESS_1_INTERPRETER_SPOKEN_LANGUAGE), any(InterpreterLanguageRefData.class));
+        verify(asylumCase).write(eq(WITNESS_2_INTERPRETER_SIGN_LANGUAGE), any(InterpreterLanguageRefData.class));
+    }
+
+    @Test
+    void should_add_ui_error_if_no_witness_is_selected() {
+        when(callback.getPageId()).thenReturn(WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID);
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(Collections.emptyList()));
+
+        PreSubmitCallbackResponse<AsylumCase> response = interpreterLanguagesDynamicListUpdater
+            .handle(MID_EVENT, callback);
+
+        assertTrue(response.getErrors().contains(NO_WITNESSES_SELECTED_ERROR));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesMidEventHandlerTest.java
@@ -4,9 +4,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_DETAILS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.DRAFT_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.SEND_DIRECTION;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUIREMENTS;
@@ -28,12 +32,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicMultiSelectList;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.Value;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ExtendWith(MockitoExtension.class)
@@ -41,6 +48,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallb
 public class WitnessesMidEventHandlerTest {
 
     private static final String IS_WITNESSES_ATTENDING = "isWitnessesAttending";
+    private static final String IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID = "isAnyWitnessInterpreterRequired";
     private static final String WITNESSES_NUMBER_EXCEEDED_ERROR = "Maximum number of witnesses is 10";
 
     @Mock
@@ -51,6 +59,8 @@ public class WitnessesMidEventHandlerTest {
     private AsylumCase asylumCase;
     @Mock
     private WitnessDetails witnessDetails;
+    private String witnessName = "name";
+    private String witnessFamilyName = "lastName";
 
     private WitnessesMidEventHandler witnessesMidEventHandler;
 
@@ -59,6 +69,8 @@ public class WitnessesMidEventHandlerTest {
         witnessesMidEventHandler = new WitnessesMidEventHandler();
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(witnessDetails.getWitnessName()).thenReturn(witnessName);
+        when(witnessDetails.getWitnessFamilyName()).thenReturn(witnessFamilyName);
         when(callback.getPageId()).thenReturn(IS_WITNESSES_ATTENDING);
     }
 
@@ -87,6 +99,55 @@ public class WitnessesMidEventHandlerTest {
         PreSubmitCallbackResponse<AsylumCase> response = witnessesMidEventHandler.handle(MID_EVENT, callback);
 
         assertTrue(response.getErrors().isEmpty());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Event.class, names = { "DRAFT_HEARING_REQUIREMENTS", "UPDATE_HEARING_REQUIREMENTS"})
+    void should_fill_witness_list_elements(Event event) {
+        List<IdValue<WitnessDetails>> witnesses = Collections
+            .nCopies(10, new IdValue<>("1", witnessDetails));
+
+        when(callback.getEvent()).thenReturn(event);
+        when(callback.getPageId()).thenReturn(IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID);
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnesses));
+
+        PreSubmitCallbackResponse<AsylumCase> response = witnessesMidEventHandler.handle(MID_EVENT, callback);
+
+        DynamicMultiSelectList dynamicMultiSelectListEmpty = new DynamicMultiSelectList();
+        DynamicMultiSelectList dynamicMultiSelectList = new DynamicMultiSelectList(Collections.emptyList(),
+            List.of(new Value("name lastName", "name lastName"))
+        );
+
+        verify(asylumCase, times(2)).write(eq(WITNESS_1), any(WitnessDetails.class));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_1), eq(dynamicMultiSelectListEmpty));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_1), eq(dynamicMultiSelectList));
+        verify(asylumCase, times(2)).write(eq(WITNESS_2), any(WitnessDetails.class));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_2), eq(dynamicMultiSelectListEmpty));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_2), eq(dynamicMultiSelectList));
+        verify(asylumCase, times(2)).write(eq(WITNESS_3), any(WitnessDetails.class));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_3), eq(dynamicMultiSelectListEmpty));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_3), eq(dynamicMultiSelectList));
+        verify(asylumCase, times(2)).write(eq(WITNESS_4), any(WitnessDetails.class));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_4), eq(dynamicMultiSelectListEmpty));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_4), eq(dynamicMultiSelectList));
+        verify(asylumCase, times(2)).write(eq(WITNESS_5), any(WitnessDetails.class));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_5), eq(dynamicMultiSelectListEmpty));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_5), eq(dynamicMultiSelectList));
+        verify(asylumCase, times(2)).write(eq(WITNESS_6), any(WitnessDetails.class));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_6), eq(dynamicMultiSelectListEmpty));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_6), eq(dynamicMultiSelectList));
+        verify(asylumCase, times(2)).write(eq(WITNESS_7), any(WitnessDetails.class));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_7), eq(dynamicMultiSelectListEmpty));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_7), eq(dynamicMultiSelectList));
+        verify(asylumCase, times(2)).write(eq(WITNESS_8), any(WitnessDetails.class));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_8), eq(dynamicMultiSelectListEmpty));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_8), eq(dynamicMultiSelectList));
+        verify(asylumCase, times(2)).write(eq(WITNESS_9), any(WitnessDetails.class));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_9), eq(dynamicMultiSelectListEmpty));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_9), eq(dynamicMultiSelectList));
+        verify(asylumCase, times(2)).write(eq(WITNESS_10), any(WitnessDetails.class));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_10), eq(dynamicMultiSelectListEmpty));
+        verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_10), eq(dynamicMultiSelectList));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7509](https://tools.hmcts.net/jira/browse/RIA-7509)


### Change description ###
**📊📈📉 [DIAGRAM on CONFLUENCE](https://tools.hmcts.net/confluence/display/~Marcello.Fabbri/Interpreter+Language+refactor+for+witnesses)**


Added logic to: 
- extrapolate the witnesses from the collection (`witnessDetails`) into the individual fields (`witness1`, witness2`...)
- fill the witness list elements according to the individual witnesses (`witness1` -> `witnessListElement`1 ...)
- read the selected type of interpreter (spoken/sign) each witness requires (`witness1InterpreterLanguageCategory `, `witness2InterpreterLanguageCategory`...) and fill the dynamic lists inside the InterpreterLanguageRefData complex type of each subsequent page accordingly (`witness1InterpreterSpokenLanguage`, `witness2InterpreterSpokenLanguage`...)

| witness1  | witnessListElement1  | witness1InterpreterLanguageCategory  | witness1InterpreterSpokenLanguage  | witness1InterpreterSignLanguage  |
|-----------|----------------------|--------------------------------------|------------------------------------|----------------------------------|
| witness2  | witnessListElement2  | witness2InterpreterLanguageCategory  | witness2InterpreterSpokenLanguage  | witness2InterpreterSignLanguage  |
| witness3  | witnessListElement3  | witness3InterpreterLanguageCategory  | witness3InterpreterSpokenLanguage  | witness3InterpreterSignLanguage  |
| witness4  | witnessListElement4  | witness4InterpreterLanguageCategory  | witness4InterpreterSpokenLanguage  | witness4InterpreterSignLanguage  |
| witness5  | witnessListElement5  | witness5InterpreterLanguageCategory  | witness5InterpreterSpokenLanguage  | witness5InterpreterSignLanguage  |
| witness6  | witnessListElement6  | witness6InterpreterLanguageCategory  | witness6InterpreterSpokenLanguage  | witness6InterpreterSignLanguage  |
| witness7  | witnessListElement7  | witness7InterpreterLanguageCategory  | witness7InterpreterSpokenLanguage  | witness7InterpreterSignLanguage  |
| witness8  | witnessListElement8  | witness8InterpreterLanguageCategory  | witness8InterpreterSpokenLanguage  | witness8InterpreterSignLanguage  |
| witness9  | witnessListElement9  | witness9InterpreterLanguageCategory  | witness9InterpreterSpokenLanguage  | witness9InterpreterSignLanguage  |
| witness10 | witnessListElement10 | witness10InterpreterLanguageCategory | witness10InterpreterSpokenLanguage | witness10InterpreterSignLanguage |


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
