### PR TITLE
RIA-7641 Rename getter-like field to something non-getter-like

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/WitnessDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/WitnessDetails.java
@@ -18,7 +18,7 @@ public class WitnessDetails {
         this.witnessName = witnessName;
     }
 
-    public String getWitnessFullName() {
+    public String buildWitnessFullName() {
         String givenNames = witnessName == null ? " " : witnessName;
         String familyName = witnessFamilyName == null ? " " : witnessFamilyName;
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CreateFlagHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CreateFlagHandler.java
@@ -86,7 +86,7 @@ class CreateFlagHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
     private List<IdValue<StrategicCaseFlag>> mapWitnessesToFlag(List<IdValue<WitnessDetails>> witnessDetails) {
         return witnessDetails.stream().map(details -> {
-            String witnessName = details.getValue().getWitnessFullName();
+            String witnessName = details.getValue().buildWitnessFullName();
             if (witnessName.isBlank()) {
                 return null;
             } else {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReviewDraftHearingRequirementsPreparer.java
@@ -78,7 +78,7 @@ public class ReviewDraftHearingRequirementsPreparer implements PreSubmitCallback
 
         witnessDetails.ifPresent(idValues -> asylumCase.write(WITNESS_DETAILS_READONLY, idValues
             .stream()
-            .map(w -> String.format("Name\t\t%s", w.getValue().getWitnessFullName()))
+            .map(w -> String.format("Name\t\t%s", w.getValue().buildWitnessFullName()))
             .collect(Collectors.joining("\n"))));
 
         interpreterLanguage.ifPresent(idValues -> asylumCase.write(INTERPRETER_LANGUAGE_READONLY, idValues


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7641](https://tools.hmcts.net/jira/browse/RIA-7641)


### Change description ###
- Renamed `getWitnessFullName` to `buildWitnessFullName`. If the method looks like a getter (starts with _-get_) it'll build an object with such field even if not declared in the class, and then it'll fail validation when passed to CCD.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
