### PR TITLE
RIA-7641 Clear appellant interpreter language when updating hearing reqs

### DIFF
--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-api
 home: https://github.com/hmcts/ia-case-api
-version: 0.0.36
+version: 0.0.37
 description: Immigration & Asylum Case API
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -764,6 +764,9 @@ public enum AsylumCaseFieldDefinition {
     WITNESS_COUNT(
         "witnessCount", new TypeReference<String>() {}),
 
+    IS_INTERPRETER_SERVICES_NEEDED(
+        "isInterpreterServicesNeeded", new TypeReference<YesOrNo>(){}),
+
     WITNESS_DETAILS(
         "witnessDetails", new TypeReference<List<IdValue<WitnessDetails>>>() {}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/InterpreterLanguagesUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/InterpreterLanguagesUtils.java
@@ -1,0 +1,88 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers;
+
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_10_INTERPRETER_LANGUAGE_CATEGORY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_1_INTERPRETER_LANGUAGE_CATEGORY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_2_INTERPRETER_LANGUAGE_CATEGORY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_3_INTERPRETER_LANGUAGE_CATEGORY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_4_INTERPRETER_LANGUAGE_CATEGORY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_5_INTERPRETER_LANGUAGE_CATEGORY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_6_INTERPRETER_LANGUAGE_CATEGORY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_7_INTERPRETER_LANGUAGE_CATEGORY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_8_INTERPRETER_LANGUAGE_CATEGORY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_9_INTERPRETER_LANGUAGE_CATEGORY;
+
+import java.util.List;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+
+public final class InterpreterLanguagesUtils {
+
+    private InterpreterLanguagesUtils() {
+        // Utils classes should not have public or default constructors
+    }
+
+    public static final List<AsylumCaseFieldDefinition> WITNESS_N_FIELD = List.of(
+        WITNESS_1,
+        WITNESS_2,
+        WITNESS_3,
+        WITNESS_4,
+        WITNESS_5,
+        WITNESS_6,
+        WITNESS_7,
+        WITNESS_8,
+        WITNESS_9,
+        WITNESS_10);
+
+    public static final List<AsylumCaseFieldDefinition> WITNESS_LIST_ELEMENT_N_FIELD = List.of(
+        WITNESS_LIST_ELEMENT_1,
+        WITNESS_LIST_ELEMENT_2,
+        WITNESS_LIST_ELEMENT_3,
+        WITNESS_LIST_ELEMENT_4,
+        WITNESS_LIST_ELEMENT_5,
+        WITNESS_LIST_ELEMENT_6,
+        WITNESS_LIST_ELEMENT_7,
+        WITNESS_LIST_ELEMENT_8,
+        WITNESS_LIST_ELEMENT_9,
+        WITNESS_LIST_ELEMENT_10
+    );
+
+    public static final List<AsylumCaseFieldDefinition> WITNESS_N_INTERPRETER_CATEGORY_FIELD = List.of(
+        WITNESS_1_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_2_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_3_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_4_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_5_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_6_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_7_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_8_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_9_INTERPRETER_LANGUAGE_CATEGORY,
+        WITNESS_10_INTERPRETER_LANGUAGE_CATEGORY
+    );
+
+    public static final List<AsylumCaseFieldDefinition> WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE = List.of(
+        WITNESS_1_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_2_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_3_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_4_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_5_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_6_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_7_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_8_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_9_INTERPRETER_SPOKEN_LANGUAGE,
+        WITNESS_10_INTERPRETER_SPOKEN_LANGUAGE
+    );
+
+    public static final List<AsylumCaseFieldDefinition> WITNESS_N_INTERPRETER_SIGN_LANGUAGE = List.of(
+        WITNESS_1_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_2_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_3_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_4_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_5_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_6_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_7_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_8_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_9_INTERPRETER_SIGN_LANGUAGE,
+        WITNESS_10_INTERPRETER_SIGN_LANGUAGE
+    );
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
@@ -4,6 +4,11 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_LIST_ELEMENT_N_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_CATEGORY_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SIGN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -115,6 +120,15 @@ public class DraftHearingRequirementsHandler implements PreSubmitCallbackHandler
             asylumCase.clear(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY);
             asylumCase.clear(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
             asylumCase.clear(APPELLANT_INTERPRETER_SIGN_LANGUAGE);
+        }
+
+        if (witnessDetails.isEmpty()) {
+            // if no witnesses present clear all witness-related fields
+            WITNESS_N_FIELD.forEach(asylumCase::clear);
+            WITNESS_LIST_ELEMENT_N_FIELD.forEach(asylumCase::clear);
+            WITNESS_N_INTERPRETER_CATEGORY_FIELD.forEach(asylumCase::clear);
+            WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.forEach(asylumCase::clear);
+            WITNESS_N_INTERPRETER_SIGN_LANGUAGE.forEach(asylumCase::clear);
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -103,6 +104,17 @@ public class DraftHearingRequirementsHandler implements PreSubmitCallbackHandler
             asylumCase.clear(HEARING_REQUIREMENTS);
         } else {
             asylumCase.write(CURRENT_HEARING_DETAILS_VISIBLE, YesOrNo.YES);
+        }
+
+        boolean isInterpreterServicesNeeded = asylumCase
+            .read(IS_INTERPRETER_SERVICES_NEEDED, YesOrNo.class)
+            .map(yesOrNo -> yesOrNo.equals(YES))
+            .orElse(false);
+
+        if (!isInterpreterServicesNeeded) {
+            asylumCase.clear(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY);
+            asylumCase.clear(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
+            asylumCase.clear(APPELLANT_INTERPRETER_SIGN_LANGUAGE);
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdater.java
@@ -97,9 +97,20 @@ public class InterpreterLanguagesDynamicListUpdater implements PreSubmitCallback
 
         String pageId = callback.getPageId();
 
+        boolean hasSpokenLang = callback.getCaseDetailsBefore()
+            .map(caseDetails -> caseDetails.getCaseData().read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class).isPresent())
+            .orElse(false);
+        boolean hasSignLang = callback.getCaseDetailsBefore()
+            .map(caseDetails -> caseDetails.getCaseData().read(APPELLANT_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class).isPresent())
+            .orElse(false);
+
         if (Objects.equals(pageId, DRAFT_HEARING_REQUIREMENTS_PAGE_ID)) {
-            populateDynamicList(asylumCase, INTERPRETER_LANGUAGES, APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
-            populateDynamicList(asylumCase, SIGN_LANGUAGES, APPELLANT_INTERPRETER_SIGN_LANGUAGE);
+            if (!hasSpokenLang) {
+                populateDynamicList(asylumCase, INTERPRETER_LANGUAGES, APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
+            }
+            if (!hasSignLang) {
+                populateDynamicList(asylumCase, SIGN_LANGUAGES, APPELLANT_INTERPRETER_SIGN_LANGUAGE);
+            }
         }
 
         PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdater.java
@@ -2,8 +2,10 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
-import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.WitnessesMidEventHandler.WITNESS_LIST_ELEMENT_N_FIELD;
-import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.WitnessesMidEventHandler.WITNESS_N_INTERPRETER_CATEGORY_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_LIST_ELEMENT_N_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_CATEGORY_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SIGN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,30 +45,6 @@ public class InterpreterLanguagesDynamicListUpdater implements PreSubmitCallback
     public static final String SIGN_LANGUAGES = "SignLanguage";
     public static final String IS_CHILD_REQUIRED = "Y";
     public static final String YES = "Yes";
-    protected static final List<AsylumCaseFieldDefinition> WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE = List.of(
-        WITNESS_1_INTERPRETER_SPOKEN_LANGUAGE,
-        WITNESS_2_INTERPRETER_SPOKEN_LANGUAGE,
-        WITNESS_3_INTERPRETER_SPOKEN_LANGUAGE,
-        WITNESS_4_INTERPRETER_SPOKEN_LANGUAGE,
-        WITNESS_5_INTERPRETER_SPOKEN_LANGUAGE,
-        WITNESS_6_INTERPRETER_SPOKEN_LANGUAGE,
-        WITNESS_7_INTERPRETER_SPOKEN_LANGUAGE,
-        WITNESS_8_INTERPRETER_SPOKEN_LANGUAGE,
-        WITNESS_9_INTERPRETER_SPOKEN_LANGUAGE,
-        WITNESS_10_INTERPRETER_SPOKEN_LANGUAGE
-        );
-    protected static final List<AsylumCaseFieldDefinition> WITNESS_N_INTERPRETER_SIGN_LANGUAGE = List.of(
-        WITNESS_1_INTERPRETER_SIGN_LANGUAGE,
-        WITNESS_2_INTERPRETER_SIGN_LANGUAGE,
-        WITNESS_3_INTERPRETER_SIGN_LANGUAGE,
-        WITNESS_4_INTERPRETER_SIGN_LANGUAGE,
-        WITNESS_5_INTERPRETER_SIGN_LANGUAGE,
-        WITNESS_6_INTERPRETER_SIGN_LANGUAGE,
-        WITNESS_7_INTERPRETER_SIGN_LANGUAGE,
-        WITNESS_8_INTERPRETER_SIGN_LANGUAGE,
-        WITNESS_9_INTERPRETER_SIGN_LANGUAGE,
-        WITNESS_10_INTERPRETER_SIGN_LANGUAGE
-    );
     private static final String SPOKEN = "spokenLanguageInterpreter";
     private static final String SIGN = "signLanguageInterpreter";
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandler.java
@@ -5,13 +5,18 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageCategory.SIGN_LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageCategory.SPOKEN_LANGUAGE_INTERPRETER;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.Application;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ApplicationType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageRefData;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
@@ -71,9 +76,9 @@ public class UpdateHearingRequirementsHandler implements PreSubmitCallbackHandle
 
         asylumCase.write(WITNESS_COUNT, witnessDetails.size());
 
-        asylumCase.write(DISABLE_OVERVIEW_PAGE, YesOrNo.YES);
+        asylumCase.write(DISABLE_OVERVIEW_PAGE, YES);
         asylumCase.write(CURRENT_CASE_STATE_VISIBLE_TO_CASE_OFFICER, State.UNKNOWN);
-        asylumCase.write(UPDATE_HEARING_REQUIREMENTS_EXISTS, YesOrNo.YES);
+        asylumCase.write(UPDATE_HEARING_REQUIREMENTS_EXISTS, YES);
 
         changeUpdateHearingsApplicationsToCompleted(asylumCase);
         asylumCase.clear(APPLICATION_UPDATE_HEARING_REQUIREMENTS_EXISTS);
@@ -97,7 +102,7 @@ public class UpdateHearingRequirementsHandler implements PreSubmitCallbackHandle
         asylumCase.clear(IN_CAMERA_COURT_DECISION_FOR_DISPLAY);
         asylumCase.clear(OTHER_DECISION_FOR_DISPLAY);
 
-        if (asylumCase.read(CASE_FLAG_SET_ASIDE_REHEARD_EXISTS, YesOrNo.class).map(flag -> flag.equals(YesOrNo.YES)).orElse(false)
+        if (asylumCase.read(CASE_FLAG_SET_ASIDE_REHEARD_EXISTS, YesOrNo.class).map(flag -> flag.equals(YES)).orElse(false)
             && featureToggler.getValue("reheard-feature", false)) {
             previousRequirementsAndRequestsAppender.appendAndTrim(asylumCase);
         }
@@ -133,21 +138,32 @@ public class UpdateHearingRequirementsHandler implements PreSubmitCallbackHandle
     }
 
     private void ensureOnlySelectedLanguageCategoryIsSet(AsylumCase asylumCase) {
-        Optional<List<String>> languageCategoriesOptional = asylumCase
+        boolean isInterpreterServicesNeeded = asylumCase
+            .read(IS_INTERPRETER_SERVICES_NEEDED, YesOrNo.class)
+            .map(yesOrNo -> yesOrNo.equals(YES))
+            .orElse(false);
+
+        if (!isInterpreterServicesNeeded) {
+            asylumCase.clear(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY);
+            asylumCase.clear(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
+            asylumCase.clear(APPELLANT_INTERPRETER_SIGN_LANGUAGE);
+        } else {
+            Optional<List<String>> languageCategoriesOptional = asylumCase
                 .read(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY);
-        if (languageCategoriesOptional.isPresent()) {
-            List<String> languageCategories = languageCategoriesOptional.get();
-            Optional<InterpreterLanguageRefData> appellantInterpreterSpokenLanguage = asylumCase.read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
-            Optional<InterpreterLanguageRefData> appellantInterpreterSignLanguage = asylumCase.read(APPELLANT_INTERPRETER_SIGN_LANGUAGE);
+            if (languageCategoriesOptional.isPresent()) {
+                List<String> languageCategories = languageCategoriesOptional.get();
+                Optional<InterpreterLanguageRefData> appellantInterpreterSpokenLanguage = asylumCase.read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
+                Optional<InterpreterLanguageRefData> appellantInterpreterSignLanguage = asylumCase.read(APPELLANT_INTERPRETER_SIGN_LANGUAGE);
 
-            if (appellantInterpreterSpokenLanguage.isPresent()
+                if (appellantInterpreterSpokenLanguage.isPresent()
                     && !languageCategories.contains(SPOKEN_LANGUAGE_INTERPRETER.getValue())) {
-                asylumCase.clear(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
-            }
+                    asylumCase.clear(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
+                }
 
-            if (appellantInterpreterSignLanguage.isPresent()
+                if (appellantInterpreterSignLanguage.isPresent()
                     && !languageCategories.contains(SIGN_LANGUAGE_INTERPRETER.getValue())) {
-                asylumCase.clear(APPELLANT_INTERPRETER_SIGN_LANGUAGE);
+                    asylumCase.clear(APPELLANT_INTERPRETER_SIGN_LANGUAGE);
+                }
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandler.java
@@ -6,6 +6,11 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageCategory.SIGN_LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageCategory.SPOKEN_LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_LIST_ELEMENT_N_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_CATEGORY_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SIGN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE;
 
 import java.util.Collections;
 import java.util.List;
@@ -107,6 +112,10 @@ public class UpdateHearingRequirementsHandler implements PreSubmitCallbackHandle
             previousRequirementsAndRequestsAppender.appendAndTrim(asylumCase);
         }
 
+        if (witnessDetails.isEmpty()) {
+            clearWitnessRelatedFields(asylumCase);
+        }
+
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 
@@ -166,6 +175,15 @@ public class UpdateHearingRequirementsHandler implements PreSubmitCallbackHandle
                 }
             }
         }
+    }
+
+    private void clearWitnessRelatedFields(AsylumCase asylumCase) {
+        // to be called if the witness collection is updated to empty
+        WITNESS_N_FIELD.forEach(asylumCase::clear);
+        WITNESS_LIST_ELEMENT_N_FIELD.forEach(asylumCase::clear);
+        WITNESS_N_INTERPRETER_CATEGORY_FIELD.forEach(asylumCase::clear);
+        WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.forEach(asylumCase::clear);
+        WITNESS_N_INTERPRETER_SIGN_LANGUAGE.forEach(asylumCase::clear);
     }
 }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandlerTest.java
@@ -11,6 +11,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_LIST_ELEMENT_N_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_CATEGORY_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SIGN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -139,6 +144,19 @@ class DraftHearingRequirementsHandlerTest {
         verify(asylumCase, times(1)).clear(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY);
         verify(asylumCase, times(1)).clear(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
         verify(asylumCase, times(1)).clear(APPELLANT_INTERPRETER_SIGN_LANGUAGE);
+    }
+
+    @Test
+    void should_clear_all_witness_related_fields_if_no_witnesses_in_collection() {
+
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.empty());
+        draftHearingRequirementsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        WITNESS_N_FIELD.forEach(field -> verify(asylumCase, times(1)).clear(field));
+        WITNESS_LIST_ELEMENT_N_FIELD.forEach(field -> verify(asylumCase, times(1)).clear(field));
+        WITNESS_N_INTERPRETER_CATEGORY_FIELD.forEach(field -> verify(asylumCase, times(1)).clear(field));
+        WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.forEach(field -> verify(asylumCase, times(1)).clear(field));
+        WITNESS_N_INTERPRETER_SIGN_LANGUAGE.forEach(field -> verify(asylumCase, times(1)).clear(field));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandlerTest.java
@@ -129,6 +129,19 @@ class DraftHearingRequirementsHandlerTest {
     }
 
     @Test
+    void should_clear_appellant_language_fields_if_interpreter_services_not_required() {
+
+        when(asylumCase.read(IS_INTERPRETER_SERVICES_NEEDED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            draftHearingRequirementsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        verify(asylumCase, times(1)).clear(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY);
+        verify(asylumCase, times(1)).clear(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
+        verify(asylumCase, times(1)).clear(APPELLANT_INTERPRETER_SIGN_LANGUAGE);
+    }
+
+    @Test
     void should_set_witness_count_and_available_fields() {
 
         when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(Arrays

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandlerTest.java
@@ -15,6 +15,11 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.OTHER_DECISION_FOR_DISPLAY;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageCategory.SIGN_LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageCategory.SPOKEN_LANGUAGE_INTERPRETER;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_LIST_ELEMENT_N_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_CATEGORY_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SIGN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -254,6 +259,19 @@ class UpdateHearingRequirementsHandlerTest {
         verify(asylumCase, times(1)).clear(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY);
         verify(asylumCase, times(1)).clear(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
         verify(asylumCase, times(1)).clear(APPELLANT_INTERPRETER_SIGN_LANGUAGE);
+    }
+
+    @Test
+    void should_clear_all_witness_related_fields_if_no_witnesses_in_collection() {
+
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.empty());
+        updateHearingRequirementsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        WITNESS_N_FIELD.forEach(field -> verify(asylumCase, times(1)).clear(field));
+        WITNESS_LIST_ELEMENT_N_FIELD.forEach(field -> verify(asylumCase, times(1)).clear(field));
+        WITNESS_N_INTERPRETER_CATEGORY_FIELD.forEach(field -> verify(asylumCase, times(1)).clear(field));
+        WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.forEach(field -> verify(asylumCase, times(1)).clear(field));
+        WITNESS_N_INTERPRETER_SIGN_LANGUAGE.forEach(field -> verify(asylumCase, times(1)).clear(field));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandlerTest.java
@@ -200,6 +200,7 @@ class UpdateHearingRequirementsHandlerTest {
     @Test
     void should_set_appellant_interpreter_sign_language_when_only_sign_language_category_selected() {
 
+        when(asylumCase.read(IS_INTERPRETER_SERVICES_NEEDED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(asylumCase.read(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY))
             .thenReturn(Optional.of(List.of(SIGN_LANGUAGE_INTERPRETER.getValue())));
         when(asylumCase.read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE)).thenReturn(Optional.of(interpreterLanguage));
@@ -215,6 +216,7 @@ class UpdateHearingRequirementsHandlerTest {
     @Test
     void should_set_appellant_interpreter_spoken_language_when_only_spoken_language_category_selected() {
 
+        when(asylumCase.read(IS_INTERPRETER_SERVICES_NEEDED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(asylumCase.read(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY))
                 .thenReturn(Optional.of(List.of(SPOKEN_LANGUAGE_INTERPRETER.getValue())));
         when(asylumCase.read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE)).thenReturn(Optional.of(interpreterLanguage));
@@ -230,6 +232,7 @@ class UpdateHearingRequirementsHandlerTest {
     @Test
     void should_set_appellant_interpreter_spoken_and_sign_language_when_spoken_and_sign_language_categories_selected() {
 
+        when(asylumCase.read(IS_INTERPRETER_SERVICES_NEEDED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(asylumCase.read(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY))
                 .thenReturn(Optional.of(List.of(SPOKEN_LANGUAGE_INTERPRETER.getValue(), SIGN_LANGUAGE_INTERPRETER.getValue())));
         when(asylumCase.read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE)).thenReturn(Optional.of(interpreterLanguage));
@@ -240,6 +243,17 @@ class UpdateHearingRequirementsHandlerTest {
         verify(asylumCase, times(0)).clear(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
         verify(asylumCase, times(0)).clear(APPELLANT_INTERPRETER_SIGN_LANGUAGE);
 
+    }
+
+    @Test
+    void should_clear_all_appellant_interpreter_fields_if_interprerer_services_not_required() {
+
+        when(asylumCase.read(IS_INTERPRETER_SERVICES_NEEDED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        updateHearingRequirementsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        verify(asylumCase, times(1)).clear(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY);
+        verify(asylumCase, times(1)).clear(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);
+        verify(asylumCase, times(1)).clear(APPELLANT_INTERPRETER_SIGN_LANGUAGE);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7641](https://tools.hmcts.net/jira/browse/RIA-7641)

### Change description ###
- Made handlers clear interpreter fields for appellant if `isInterpreterServicesNeeded` is set to no (otherwise they'd persist in the case data even if invisible on the UI)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
