### PR TITLE
RIA-7642 Update hearing reqs witnesses languages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -365,7 +365,8 @@ dependencies {
     testImplementation group: 'com.h2database', name: 'h2', version: '1.4.197'
 
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version :'3.5.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version :'4.3.0'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version :'5.2.0'
     testImplementation(group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '3.1.6') {
         exclude group: "com.github.tomakehurst", module: "wiremock-standalone"
     }

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -35,5 +35,6 @@
         <cve>CVE-2023-35116</cve>
         <cve>CVE-2023-1370</cve>
         <cve>CVE-2023-34034</cve>
+        <cve>CVE-2020-8908</cve>
     </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -17,7 +17,7 @@
         ]]</notes>
         <cve>CVE-2022-45688</cve>
     </suppress>
-    <suppress until="2023-00-27">
+    <suppress until="2023-09-27">
         <notes>Temporarily suppress vulnerability</notes>
         <cve>CVE-2023-20863</cve>
         <cve>CVE-2023-20873</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -17,7 +17,7 @@
         ]]</notes>
         <cve>CVE-2022-45688</cve>
     </suppress>
-    <suppress until="2023-07-27">
+    <suppress until="2023-00-27">
         <notes>Temporarily suppress vulnerability</notes>
         <cve>CVE-2023-20863</cve>
         <cve>CVE-2023-20873</cve>

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -764,8 +764,14 @@ public enum AsylumCaseFieldDefinition {
     WITNESS_COUNT(
         "witnessCount", new TypeReference<String>() {}),
 
+    IS_WITNESSES_ATTENDING(
+        "isWitnessesAttending", new TypeReference<YesOrNo>() {}),
+
     IS_INTERPRETER_SERVICES_NEEDED(
         "isInterpreterServicesNeeded", new TypeReference<YesOrNo>(){}),
+
+    IS_ANY_WITNESS_INTERPRETER_REQUIRED(
+        "isAnyWitnessInterpreterRequired", new TypeReference<YesOrNo>(){}),
 
     WITNESS_DETAILS(
         "witnessDetails", new TypeReference<List<IdValue<WitnessDetails>>>() {}),

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/WitnessDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/WitnessDetails.java
@@ -19,8 +19,8 @@ public class WitnessDetails {
     }
 
     public String buildWitnessFullName() {
-        String givenNames = witnessName == null ? " " : witnessName;
-        String familyName = witnessFamilyName == null ? " " : witnessFamilyName;
+        String givenNames = getWitnessName() == null ? " " : getWitnessName();
+        String familyName = getWitnessFamilyName() == null ? " " : getWitnessFamilyName();
 
         return !(givenNames.isBlank() || familyName.isBlank()) ? givenNames + " " + familyName : givenNames;
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/InterpreterLanguagesUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/InterpreterLanguagesUtils.java
@@ -1,19 +1,20 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers;
 
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_10_INTERPRETER_LANGUAGE_CATEGORY;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_1_INTERPRETER_LANGUAGE_CATEGORY;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_2_INTERPRETER_LANGUAGE_CATEGORY;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_3_INTERPRETER_LANGUAGE_CATEGORY;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_4_INTERPRETER_LANGUAGE_CATEGORY;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_5_INTERPRETER_LANGUAGE_CATEGORY;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_6_INTERPRETER_LANGUAGE_CATEGORY;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_7_INTERPRETER_LANGUAGE_CATEGORY;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_8_INTERPRETER_LANGUAGE_CATEGORY;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_9_INTERPRETER_LANGUAGE_CATEGORY;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicList;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicMultiSelectList;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageRefData;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.Value;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 
 public final class InterpreterLanguagesUtils {
 
@@ -84,5 +85,82 @@ public final class InterpreterLanguagesUtils {
         WITNESS_9_INTERPRETER_SIGN_LANGUAGE,
         WITNESS_10_INTERPRETER_SIGN_LANGUAGE
     );
+
+    /**
+     * Method to generate the structure of these five fields for the first time (draftHearingRequirements)
+     * @param asylumCase The asylum case before the draftHearingRequirements event
+     * @return           The asylum case enriched with the witness individual fields and the witness individual lists.
+     */
+    public static AsylumCase decentralizeWitnessesFromCollection(AsylumCase asylumCase) {
+
+        boolean isWitnessAttending = asylumCase.read(IS_WITNESSES_ATTENDING, YesOrNo.class)
+            .map(yesOrNo -> yesOrNo.equals(YesOrNo.YES))
+            .orElse(false);
+
+        Optional<List<IdValue<WitnessDetails>>> optionalWitnessDetailsCollection = asylumCase.read(WITNESS_DETAILS);
+        List<IdValue<WitnessDetails>> witnessDetailsIdValues = optionalWitnessDetailsCollection.orElse(Collections.emptyList());
+        List<WitnessDetails> witnesses = witnessDetailsIdValues.stream()
+            .map(IdValue::getValue).collect(Collectors.toList());
+
+        // on "isWitnessAttending" page
+        // on "isAnyWitnessInterpreterRequired" page (shown when "isWitnessAttending=Yes")
+        clearAllWitnessFields(asylumCase);
+
+        // on "isAnyWitnessInterpreterRequired" page (shown when "isWitnessAttending=Yes")
+        if (isWitnessAttending) {
+            int i = 0;
+            while (i < witnesses.size()) {
+
+                String fullName = buildWitnessFullName(witnesses.get(i));
+
+                asylumCase.write(WITNESS_N_FIELD.get(i), witnesses.get(i));
+                asylumCase.write(WITNESS_LIST_ELEMENT_N_FIELD.get(i),
+                    new DynamicMultiSelectList(
+                        Collections.emptyList(),
+                        List.of(new Value(fullName, fullName))
+                    ));
+                i++;
+            }
+        }
+
+        return asylumCase;
+    }
+
+    private void nullifyAllWitnessFields(AsylumCase asylumCase) {
+        WITNESS_N_FIELD.forEach(field -> asylumCase.write(field, new WitnessDetails("", "")));
+        WITNESS_LIST_ELEMENT_N_FIELD.forEach(field -> asylumCase.write(field, new DynamicMultiSelectList()));
+        WITNESS_N_INTERPRETER_CATEGORY_FIELD.forEach(field -> asylumCase.write(field, Collections.emptyList()));
+        DynamicList dummyDynamicList = new DynamicList("");
+        WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.forEach(field ->
+            asylumCase.write(field, new InterpreterLanguageRefData(dummyDynamicList, Collections.emptyList(), "")));
+        WITNESS_N_INTERPRETER_SIGN_LANGUAGE.forEach(field ->
+            asylumCase.write(field, new InterpreterLanguageRefData(dummyDynamicList, Collections.emptyList(), "")));
+    }
+
+    private static void clearAllWitnessFields(AsylumCase asylumCase) {
+        WITNESS_N_FIELD.forEach(asylumCase::clear);
+        WITNESS_LIST_ELEMENT_N_FIELD.forEach(asylumCase::clear);
+        WITNESS_N_INTERPRETER_CATEGORY_FIELD.forEach(asylumCase::clear);
+        WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.forEach(asylumCase::clear);
+        WITNESS_N_INTERPRETER_SIGN_LANGUAGE.forEach(asylumCase::clear);
+    }
+
+    public static String buildWitnessFullName(WitnessDetails witnessDetails) {
+        return (witnessDetails.getWitnessName() + " " + witnessDetails.getWitnessFamilyName()).trim();
+    }
+
+    public static void clearWitnessIndividualFields(AsylumCase asylumCase) {
+        WITNESS_N_FIELD.forEach(field -> asylumCase.write(field, new WitnessDetails("", "")));
+        WITNESS_LIST_ELEMENT_N_FIELD.forEach(field -> asylumCase.write(field, new DynamicMultiSelectList()));
+        WITNESS_N_INTERPRETER_CATEGORY_FIELD.forEach(field -> asylumCase.write(field, Collections.emptyList()));
+    }
+
+    public static void clearWitnessInterpreterLanguageFields(AsylumCase asylumCase) {
+        DynamicList dummyDynamicList = new DynamicList("");
+        WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.forEach(field ->
+            asylumCase.write(field, new InterpreterLanguageRefData(dummyDynamicList, Collections.emptyList(), "")));
+        WITNESS_N_INTERPRETER_SIGN_LANGUAGE.forEach(field ->
+            asylumCase.write(field, new InterpreterLanguageRefData(dummyDynamicList, Collections.emptyList(), "")));
+    }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/InterpreterLanguagesUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/InterpreterLanguagesUtils.java
@@ -87,7 +87,7 @@ public final class InterpreterLanguagesUtils {
     );
 
     /**
-     * Method to generate the structure of these five fields for the first time (draftHearingRequirements)
+     * Method to generate the structure of these five fields for the first time (draftHearingRequirements).
      * @param asylumCase The asylum case before the draftHearingRequirements event
      * @return           The asylum case enriched with the witness individual fields and the witness individual lists.
      */
@@ -124,17 +124,6 @@ public final class InterpreterLanguagesUtils {
         }
 
         return asylumCase;
-    }
-
-    private void nullifyAllWitnessFields(AsylumCase asylumCase) {
-        WITNESS_N_FIELD.forEach(field -> asylumCase.write(field, new WitnessDetails("", "")));
-        WITNESS_LIST_ELEMENT_N_FIELD.forEach(field -> asylumCase.write(field, new DynamicMultiSelectList()));
-        WITNESS_N_INTERPRETER_CATEGORY_FIELD.forEach(field -> asylumCase.write(field, Collections.emptyList()));
-        DynamicList dummyDynamicList = new DynamicList("");
-        WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.forEach(field ->
-            asylumCase.write(field, new InterpreterLanguageRefData(dummyDynamicList, Collections.emptyList(), "")));
-        WITNESS_N_INTERPRETER_SIGN_LANGUAGE.forEach(field ->
-            asylumCase.write(field, new InterpreterLanguageRefData(dummyDynamicList, Collections.emptyList(), "")));
     }
 
     private static void clearAllWitnessFields(AsylumCase asylumCase) {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdater.java
@@ -32,21 +32,21 @@ import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.model.dto.hearingdet
 @Component
 public class InterpreterLanguagesDynamicListUpdater implements PreSubmitCallbackHandler<AsylumCase> {
 
-    RefDataUserService refDataUserService;
+    static RefDataUserService refDataUserService;
 
     public InterpreterLanguagesDynamicListUpdater(RefDataUserService refDataUserService) {
         this.refDataUserService = refDataUserService;
     }
 
-    private static final String NO_WITNESSES_SELECTED_ERROR = "Select at least one witness";
     private static final String DRAFT_HEARING_REQUIREMENTS_PAGE_ID = "draftHearingRequirements";
     private static final String WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID = "whichWitnessRequiresInterpreter";
     public static final String INTERPRETER_LANGUAGES = "InterpreterLanguage";
     public static final String SIGN_LANGUAGES = "SignLanguage";
     public static final String IS_CHILD_REQUIRED = "Y";
     public static final String YES = "Yes";
-    private static final String SPOKEN = "spokenLanguageInterpreter";
-    private static final String SIGN = "signLanguageInterpreter";
+    protected static final String NO_WITNESSES_SELECTED_ERROR = "Select at least one witness";
+    protected static final String SPOKEN = "spokenLanguageInterpreter";
+    protected static final String SIGN = "signLanguageInterpreter";
 
     public boolean canHandle(
             PreSubmitCallbackStage callbackStage,
@@ -56,7 +56,7 @@ public class InterpreterLanguagesDynamicListUpdater implements PreSubmitCallback
         requireNonNull(callback, "callback must not be null");
 
         return callbackStage == PreSubmitCallbackStage.MID_EVENT
-            && List.of(Event.DRAFT_HEARING_REQUIREMENTS, Event.UPDATE_HEARING_REQUIREMENTS)
+            && List.of(Event.DRAFT_HEARING_REQUIREMENTS)
                 .contains(callback.getEvent());
     }
 
@@ -149,7 +149,7 @@ public class InterpreterLanguagesDynamicListUpdater implements PreSubmitCallback
         asylumCase.write(languageCategoryDefinition, interpreterLanguage);
     }
 
-    private InterpreterLanguageRefData generateDynamicList(String languageCategory) {
+    protected static InterpreterLanguageRefData generateDynamicList(String languageCategory) {
         List<CategoryValues> languages;
         DynamicList dynamicListOfLanguages;
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdater.java
@@ -110,20 +110,6 @@ public class InterpreterLanguagesDynamicListUpdater implements PreSubmitCallback
         // POPULATE APPELLANT INTERPRETER LANGUAGE DYNAMIC LIST IF NECESSARY
         // TO BE RUN FOR: 1) DRAFT_HEARING_REQUIREMENTS 2) UPDATE_HEARING_REQUIREMENTS
 
-        //boolean hasRefDataSpokenLangPopulated = callback.getCaseDetailsBefore()
-        //    .map(caseDetails -> caseDetails.getCaseData().read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)
-        //        .orElse(new InterpreterLanguageRefData(new DynamicList(null, Collections.emptyList()), Collections.emptyList(), null))
-        //        .getLanguageRefData() != null)
-        //    .orElse(false);
-        //
-        //
-        //boolean hasRefDataSignLangPopulated = callback.getCaseDetailsBefore()
-        //    .map(caseDetails -> caseDetails.getCaseData().read(APPELLANT_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)
-        //        .orElse(new InterpreterLanguageRefData(new DynamicList(null, Collections.emptyList()), Collections.emptyList(), null))
-        //        .getLanguageRefData() != null)
-        //    .orElse(false);
-
-
         if (Objects.equals(pageId, APPELLANT_INTERPRETER_LANGUAGE_CATEGORY)) {
             if (shouldPopulateSpokenLanguage) {
                 populateDynamicList(asylumCase, asylumCaseBefore, INTERPRETER_LANGUAGES, APPELLANT_INTERPRETER_SPOKEN_LANGUAGE);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdater.java
@@ -32,7 +32,7 @@ import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.model.dto.hearingdet
 @Component
 public class InterpreterLanguagesDynamicListUpdater implements PreSubmitCallbackHandler<AsylumCase> {
 
-    static RefDataUserService refDataUserService;
+    private final RefDataUserService refDataUserService;
 
     public InterpreterLanguagesDynamicListUpdater(RefDataUserService refDataUserService) {
         this.refDataUserService = refDataUserService;
@@ -149,7 +149,7 @@ public class InterpreterLanguagesDynamicListUpdater implements PreSubmitCallback
         asylumCase.write(languageCategoryDefinition, interpreterLanguage);
     }
 
-    protected static InterpreterLanguageRefData generateDynamicList(String languageCategory) {
+    public InterpreterLanguageRefData generateDynamicList(String languageCategory) {
         List<CategoryValues> languages;
         DynamicList dynamicListOfLanguages;
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesUpdateMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesUpdateMidEventHandler.java
@@ -119,6 +119,7 @@ public class WitnessesUpdateMidEventHandler extends WitnessesDraftMidEventHandle
 
         Map<Integer,Integer> newToOldWitnessesIndexes = newWitnessesToOldWitnessesIndexes(callback);
 
+        // CODE REPETITION IN THIS STATEMENT IS DUE TO CHECKSTYLE NOT PERMITTING FALLTHROUGH
         switch (pageId) {
             case IS_WITNESSES_ATTENDING_PAGE_ID:
 
@@ -140,21 +141,51 @@ public class WitnessesUpdateMidEventHandler extends WitnessesDraftMidEventHandle
                 // skip if this isn't the last page before "whichWitnessRequiresInterpreter"
                 YesOrNo isInterpreterServicesNeeded = asylumCase.read(IS_INTERPRETER_SERVICES_NEEDED, YesOrNo.class)
                     .orElse(NO);
-                if (isInterpreterServicesNeeded.equals(YES)) {
-                    break;
+                if (!isInterpreterServicesNeeded.equals(YES)) {
+                    if (optionalWitnesses.isEmpty() || isWitnessAttending.equals(NO)) {
+                        // if no witnesses present nullify with dummies all witness-related fields (clearing does not work)
+                        clearWitnessIndividualFields(asylumCase);
+                        clearWitnessInterpreterLanguageFields(asylumCase);
+
+                    } else {
+                        optionalWitnesses.ifPresent(witnesses -> transferOldWitnessesToNewWitnesses(
+                            asylumCase, oldAsylumCase, witnesses, newToOldWitnessesIndexes));
+                    }
                 }
+
+                break;
 
             case APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_PAGE_ID:
                 // skip if this isn't the last page before "whichWitnessRequiresInterpreter"
-                if (appellantInterpreterLanguageCategory.contains(SPOKEN)) {
-                    break;
+                if (!appellantInterpreterLanguageCategory.contains(SPOKEN)) {
+                    if (optionalWitnesses.isEmpty() || isWitnessAttending.equals(NO)) {
+                        // if no witnesses present nullify with dummies all witness-related fields (clearing does not work)
+                        clearWitnessIndividualFields(asylumCase);
+                        clearWitnessInterpreterLanguageFields(asylumCase);
+
+                    } else {
+                        optionalWitnesses.ifPresent(witnesses -> transferOldWitnessesToNewWitnesses(
+                            asylumCase, oldAsylumCase, witnesses, newToOldWitnessesIndexes));
+                    }
                 }
+
+                break;
 
             case APPELLANT_INTERPRETER_SIGN_LANGUAGE_PAGE_ID:
                 // skip if this isn't the last page before "whichWitnessRequiresInterpreter"
-                if (appellantInterpreterLanguageCategory.contains(SIGN)) {
-                    break;
+                if (!appellantInterpreterLanguageCategory.contains(SIGN)) {
+                    if (optionalWitnesses.isEmpty() || isWitnessAttending.equals(NO)) {
+                        // if no witnesses present nullify with dummies all witness-related fields (clearing does not work)
+                        clearWitnessIndividualFields(asylumCase);
+                        clearWitnessInterpreterLanguageFields(asylumCase);
+
+                    } else {
+                        optionalWitnesses.ifPresent(witnesses -> transferOldWitnessesToNewWitnesses(
+                            asylumCase, oldAsylumCase, witnesses, newToOldWitnessesIndexes));
+                    }
                 }
+
+                break;
 
             case IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID:
 
@@ -171,17 +202,11 @@ public class WitnessesUpdateMidEventHandler extends WitnessesDraftMidEventHandle
 
             case WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID:
 
-                InterpreterLanguageRefData spokenLanguages = interpreterLanguagesDynamicListUpdater
-                    .generateDynamicList(INTERPRETER_LANGUAGES);
-                InterpreterLanguageRefData signLanguages = interpreterLanguagesDynamicListUpdater
-                    .generateDynamicList(SIGN_LANGUAGES);
-
-                Map<Integer,List<String>> witnessIndexToInterpreterNeeded = new HashMap<>();
-
-                int numberOfWitnesses = optionalWitnesses.map(List::size).orElse(0);
-
                 Map<Integer, InterpreterLanguageRefData> existingSpokenSelections = new HashMap<>();
                 Map<Integer, InterpreterLanguageRefData> existingSignSelections = new HashMap<>();
+
+                Map<Integer,List<String>> witnessIndexToInterpreterNeeded = new HashMap<>();
+                int numberOfWitnesses = optionalWitnesses.map(List::size).orElse(0);
 
                 newToOldWitnessesIndexes.forEach((n,o) -> {
                     oldAsylumCase
@@ -217,6 +242,11 @@ public class WitnessesUpdateMidEventHandler extends WitnessesDraftMidEventHandle
                 if (witnessIndexToInterpreterNeeded.isEmpty()) {
                     response.addError(NO_WITNESSES_SELECTED_ERROR);
                 }
+
+                InterpreterLanguageRefData spokenLanguages = interpreterLanguagesDynamicListUpdater
+                    .generateDynamicList(INTERPRETER_LANGUAGES);
+                InterpreterLanguageRefData signLanguages = interpreterLanguagesDynamicListUpdater
+                    .generateDynamicList(SIGN_LANGUAGES);
 
                 witnessIndexToInterpreterNeeded.forEach((index, interpretersNeeded) -> {
                     interpretersNeeded.forEach(interpreterCategory -> {
@@ -258,6 +288,8 @@ public class WitnessesUpdateMidEventHandler extends WitnessesDraftMidEventHandle
                     }
                     j++;
                 }
+
+                break;
 
             default:
                 break;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesUpdateMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesUpdateMidEventHandler.java
@@ -254,12 +254,22 @@ public class WitnessesUpdateMidEventHandler extends WitnessesDraftMidEventHandle
                             InterpreterLanguageRefData selection = existingSpokenSelections.get(index) != null
                                 ? existingSpokenSelections.get(index)
                                 : spokenLanguages;
+
+                            // necessary to fill the dynamic dropdown list when the selection was manually entered
+                            if (selection.getLanguageRefData() == null || selection.getLanguageRefData().getListItems() == null) {
+                                selection.setLanguageRefData(spokenLanguages.getLanguageRefData());
+                            }
                             asylumCase.write(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(index), selection);
                         }
                         if (Objects.equals(interpreterCategory, SIGN)) {
                             InterpreterLanguageRefData selection = existingSignSelections.get(index) != null
                                 ? existingSignSelections.get(index)
                                 : signLanguages;
+
+                            // necessary to fill the dynamic dropdown list when the selection was manually entered
+                            if (selection.getLanguageRefData() == null || selection.getLanguageRefData().getListItems() == null) {
+                                selection.setLanguageRefData(signLanguages.getLanguageRefData());
+                            }
                             asylumCase.write(WITNESS_N_INTERPRETER_SIGN_LANGUAGE.get(index), selection);
                         }
                     });

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesUpdateMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesUpdateMidEventHandler.java
@@ -1,0 +1,362 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_LANGUAGE_CATEGORY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_INTERPRETER_SERVICES_NEEDED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_WITNESSES_ATTENDING;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_DETAILS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUIREMENTS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_LIST_ELEMENT_N_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_CATEGORY_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SIGN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.buildWitnessFullName;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.clearWitnessIndividualFields;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.clearWitnessInterpreterLanguageFields;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.InterpreterLanguagesDynamicListUpdater.INTERPRETER_LANGUAGES;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.InterpreterLanguagesDynamicListUpdater.NO_WITNESSES_SELECTED_ERROR;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.InterpreterLanguagesDynamicListUpdater.SIGN;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.InterpreterLanguagesDynamicListUpdater.SIGN_LANGUAGES;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.InterpreterLanguagesDynamicListUpdater.SPOKEN;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.InterpreterLanguagesDynamicListUpdater.generateDynamicList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicMultiSelectList;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageRefData;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.Value;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class WitnessesUpdateMidEventHandler extends WitnessesDraftMidEventHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private static final String IS_WITNESSES_ATTENDING_PAGE_ID = "isWitnessesAttending";
+    private static final String IS_INTERPRETER_SERVICES_NEEDED_PAGE_ID = "isInterpreterServicesNeeded";
+    private static final String APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_PAGE_ID = "appellantInterpreterSpokenLanguage";
+    private static final String APPELLANT_INTERPRETER_SIGN_LANGUAGE_PAGE_ID = "appellantInterpreterSignLanguage";
+    private static final String WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID = "whichWitnessRequiresInterpreter";
+    private static final String IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID = "isAnyWitnessInterpreterRequired";
+    private static final String ADDITIONAL_INSTRUCTIONS_PAGE_ID = "additionalInstructions";
+    private static final String WITNESSES_NUMBER_EXCEEDED_ERROR = "Maximum number of witnesses is 10";
+    private List<AsylumCaseFieldDefinition> fieldsToBeCleared = new ArrayList<>();
+
+    @Override
+    public boolean canHandle(PreSubmitCallbackStage callbackStage, Callback<AsylumCase> callback) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        String pageId = callback.getPageId();
+
+        return (callbackStage == MID_EVENT
+               && callback.getEvent().equals(UPDATE_HEARING_REQUIREMENTS)
+               && Set.of(IS_WITNESSES_ATTENDING_PAGE_ID,
+            IS_INTERPRETER_SERVICES_NEEDED_PAGE_ID,
+            APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_PAGE_ID,
+            APPELLANT_INTERPRETER_SIGN_LANGUAGE_PAGE_ID,
+            WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID,
+            IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID).contains(pageId))
+               || (callbackStage == ABOUT_TO_SUBMIT
+                   && callback.getEvent().equals(UPDATE_HEARING_REQUIREMENTS));
+    }
+
+    @Override
+    public DispatchPriority getDispatchPriority() {
+        return DispatchPriority.LATEST;
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<AsylumCase> handle(PreSubmitCallbackStage callbackStage, Callback<AsylumCase> callback) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+        
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+        PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
+
+        if (callbackStage.equals(ABOUT_TO_SUBMIT)) {
+            fieldsToBeCleared.forEach(asylumCase::clear);
+            return response;
+        }
+
+        AsylumCase oldAsylumCase = callback.getCaseDetailsBefore().orElse(callback.getCaseDetails()).getCaseData();
+        String pageId = callback.getPageId();
+        YesOrNo isWitnessAttending = asylumCase.read(IS_WITNESSES_ATTENDING, YesOrNo.class).orElse(NO);
+
+        Optional<List<String>> optionalAppellantInterpreterLanguageCategory = asylumCase
+            .read(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY);
+        List<String> appellantInterpreterLanguageCategory = optionalAppellantInterpreterLanguageCategory
+            .orElse(Collections.emptyList());
+
+        Optional<List<IdValue<WitnessDetails>>> optionalWitnesses = asylumCase.read(WITNESS_DETAILS);
+
+        Map<Integer,Integer> newToOldWitnessesIndexes = newWitnessesToOldWitnessesIndexes(callback);
+
+        switch (pageId) {
+            case IS_WITNESSES_ATTENDING_PAGE_ID:
+
+                // cannot add more than 10 witnesses to the collection
+                optionalWitnesses.ifPresent(witnesses -> {
+                    if (witnesses.size() > WITNESS_N_FIELD.size()) {        // 10
+                        response.addError(WITNESSES_NUMBER_EXCEEDED_ERROR);
+                    }
+                });
+
+                if (optionalWitnesses.isEmpty() || isWitnessAttending.equals(NO)) {
+                    // if no witnesses present nullify with dummies all witness-related fields (clearing does not work)
+                    clearWitnessIndividualFields(asylumCase);
+                    clearWitnessInterpreterLanguageFields(asylumCase);
+                }
+                break;
+
+            case IS_INTERPRETER_SERVICES_NEEDED_PAGE_ID:
+                // skip if this isn't the last page before "whichWitnessRequiresInterpreter"
+                YesOrNo isInterpreterServicesNeeded = asylumCase.read(IS_INTERPRETER_SERVICES_NEEDED, YesOrNo.class)
+                    .orElse(NO);
+                if (isInterpreterServicesNeeded.equals(YES)) {
+                    break;
+                }
+
+            case APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_PAGE_ID:
+                // skip if this isn't the last page before "whichWitnessRequiresInterpreter"
+                if (appellantInterpreterLanguageCategory.contains(SPOKEN)) {
+                    break;
+                }
+
+            case APPELLANT_INTERPRETER_SIGN_LANGUAGE_PAGE_ID:
+                // skip if this isn't the last page before "whichWitnessRequiresInterpreter"
+                if (appellantInterpreterLanguageCategory.contains(SIGN)) {
+                    break;
+                }
+
+            case IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID:
+
+                if (optionalWitnesses.isEmpty() || isWitnessAttending.equals(NO)) {
+                    // if no witnesses present nullify with dummies all witness-related fields (clearing does not work)
+                    clearWitnessIndividualFields(asylumCase);
+                    clearWitnessInterpreterLanguageFields(asylumCase);
+
+                } else {
+                    optionalWitnesses.ifPresent(witnesses -> transferOldWitnessesToNewWitnesses(
+                        asylumCase, oldAsylumCase, witnesses, newToOldWitnessesIndexes));
+                }
+                break;
+
+            case WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID:
+
+                InterpreterLanguageRefData spokenLanguages = generateDynamicList(INTERPRETER_LANGUAGES);
+                InterpreterLanguageRefData signLanguages = generateDynamicList(SIGN_LANGUAGES);
+
+                Map<Integer,List<String>> witnessIndexToInterpreterNeeded = new HashMap<>();
+
+                int numberOfWitnesses = optionalWitnesses.map(List::size).orElse(0);
+
+                Map<Integer, InterpreterLanguageRefData> existingSpokenSelections = new HashMap<>();
+                Map<Integer, InterpreterLanguageRefData> existingSignSelections = new HashMap<>();
+
+                newToOldWitnessesIndexes.forEach((n,o) -> {
+                    oldAsylumCase
+                        .read(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(o), InterpreterLanguageRefData.class)
+                        .ifPresent(spokenLanguageSelection -> existingSpokenSelections.put(n, spokenLanguageSelection));
+
+                    oldAsylumCase
+                        .read(WITNESS_N_INTERPRETER_SIGN_LANGUAGE.get(o), InterpreterLanguageRefData.class)
+                        .ifPresent(signLanguageSelection -> existingSignSelections.put(n, signLanguageSelection));
+                });
+
+                int i = 0;
+                while (i < numberOfWitnesses) {
+                    DynamicMultiSelectList witnessElement = asylumCase
+                        .read(WITNESS_LIST_ELEMENT_N_FIELD.get(i), DynamicMultiSelectList.class).orElse(null);
+
+                    boolean witnessSelected = witnessElement != null
+                                              && !witnessElement.getValue().isEmpty()
+                                              && !witnessElement.getValue().get(0).getLabel().isEmpty();
+
+                    if (witnessSelected) {
+
+                        Optional<List<String>> optionalSelectedInterpreterType = asylumCase.read(WITNESS_N_INTERPRETER_CATEGORY_FIELD.get(i));
+                        List<String> selectedInterpreterType = optionalSelectedInterpreterType.isEmpty()
+                            ? Collections.emptyList()
+                            : optionalSelectedInterpreterType.get();
+
+                        witnessIndexToInterpreterNeeded.put(i, selectedInterpreterType);
+                    }
+                    i++;
+                }
+
+                if (witnessIndexToInterpreterNeeded.isEmpty()) {
+                    response.addError(NO_WITNESSES_SELECTED_ERROR);
+                }
+
+                witnessIndexToInterpreterNeeded.forEach((index, interpretersNeeded) -> {
+                    interpretersNeeded.forEach(interpreterCategory -> {
+                        if (Objects.equals(interpreterCategory, SPOKEN)) {
+                            InterpreterLanguageRefData selection = existingSpokenSelections.get(index) != null
+                                ? existingSpokenSelections.get(index)
+                                : spokenLanguages;
+                            asylumCase.write(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(index), selection);
+                        }
+                        if (Objects.equals(interpreterCategory, SIGN)) {
+                            InterpreterLanguageRefData selection = existingSignSelections.get(index) != null
+                                ? existingSignSelections.get(index)
+                                : signLanguages;
+                            asylumCase.write(WITNESS_N_INTERPRETER_SIGN_LANGUAGE.get(index), selection);
+                        }
+                    });
+                });
+
+                int j = 0;
+                while (j < 10) {
+                    if (witnessIndexToInterpreterNeeded.get(j) == null) {
+                        asylumCase.clear(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(j));
+                        asylumCase.clear(WITNESS_N_INTERPRETER_SIGN_LANGUAGE.get(j));
+                        asylumCase.write(WITNESS_N_INTERPRETER_CATEGORY_FIELD.get(j), Collections.emptyList());
+
+                        fieldsToBeCleared.addAll(
+                            Set.of(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(j),
+                            WITNESS_N_INTERPRETER_SIGN_LANGUAGE.get(j))
+                        );
+                    } else {
+                        if (!witnessIndexToInterpreterNeeded.get(j).contains(SPOKEN)) {
+                            asylumCase.clear(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(j));
+                            fieldsToBeCleared.add(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(j));
+                        }
+                        if (!witnessIndexToInterpreterNeeded.get(j).contains(SIGN)) {
+                            asylumCase.clear(WITNESS_N_INTERPRETER_SIGN_LANGUAGE.get(j));
+                            fieldsToBeCleared.add(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(j));
+                        }
+                    }
+                    j++;
+                }
+            //
+            //case ADDITIONAL_INSTRUCTIONS_PAGE_ID:
+            //    fieldsToBeCleared.forEach(asylumCase::clear);
+            default:
+                break;
+        }
+
+        return response;
+    }
+
+    private Map<Integer,Integer> newWitnessesToOldWitnessesIndexes(Callback<AsylumCase> callback) {
+        Map<Integer,Integer> newToOld = new HashMap<>();
+
+        CaseDetails<AsylumCase> oldCaseDetails = callback.getCaseDetailsBefore().orElse(null);
+        CaseDetails<AsylumCase> newCaseDetails = callback.getCaseDetails();
+
+        if (oldCaseDetails != null) {
+            Optional<List<IdValue<WitnessDetails>>> optionalOldWitnesses = oldCaseDetails
+                .getCaseData().read(WITNESS_DETAILS);
+            Optional<List<IdValue<WitnessDetails>>> optionalNewWitnesses = newCaseDetails
+                .getCaseData().read(WITNESS_DETAILS);
+
+            List<IdValue<WitnessDetails>> oldWitnesses = optionalOldWitnesses.orElse(Collections.emptyList());
+            List<IdValue<WitnessDetails>> newWitnesses = optionalNewWitnesses.orElse(Collections.emptyList());
+
+            int o = 0;
+            int n = 0;
+            while (o < oldWitnesses.size()) {
+                while (n < newWitnesses.size()) {
+
+                    if (StringUtils.equals(
+                        oldWitnesses.get(o).getValue().buildWitnessFullName(),
+                        newWitnesses.get(n).getValue().buildWitnessFullName())) {
+
+                        newToOld.put(n, o);
+                    }
+                    n++;
+                }
+                n = 0;
+                o++;
+            }
+        }
+
+        return newToOld;
+    }
+
+
+    protected AsylumCase transferOldWitnessesToNewWitnesses(AsylumCase asylumCase,
+                                                            AsylumCase oldAsylumCase,
+                                                            List<IdValue<WitnessDetails>> witnesses,
+                                                            Map<Integer,Integer> newToOldIndexes) {
+
+        Map<Integer,DynamicMultiSelectList> previousWitnessSelections = new HashMap<>();
+        newToOldIndexes.forEach((n,o) -> previousWitnessSelections.put(
+            o,
+            oldAsylumCase.read(WITNESS_LIST_ELEMENT_N_FIELD.get(o), DynamicMultiSelectList.class).orElse(null)
+        ));
+
+        Map<Integer,List<String>> previousCategoriesPerWitnessSelections = new HashMap<>();
+        newToOldIndexes.forEach((n,o) -> {
+            boolean hasSpokenLanguage = oldAsylumCase.read(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(o), InterpreterLanguageRefData.class)
+                .map(language -> language.getLanguageRefData() != null || language.getLanguageManualEntryDescription() != null)
+                .orElse(false);
+            boolean hasSignLanguage = oldAsylumCase.read(WITNESS_N_INTERPRETER_SIGN_LANGUAGE.get(o), InterpreterLanguageRefData.class)
+                .map(language -> language.getLanguageRefData() != null || language.getLanguageManualEntryDescription() != null)
+                .orElse(false);
+
+            List<String> selection = new ArrayList<>();
+            if (hasSpokenLanguage) {
+                selection.add(SPOKEN);
+            }
+            if (hasSignLanguage) {
+                selection.add(SIGN);
+            }
+            previousCategoriesPerWitnessSelections.put(o, selection);
+        });
+
+        int i = 0;
+        while (i < witnesses.size()) {
+
+            String fullName = buildWitnessFullName(witnesses.get(i).getValue());
+
+            asylumCase.write(WITNESS_N_FIELD.get(i), witnesses.get(i).getValue());
+
+            DynamicMultiSelectList existingWitnessSelection = previousWitnessSelections.get(newToOldIndexes.get(i)) != null
+                ? previousWitnessSelections.get(newToOldIndexes.get(i))
+                : new DynamicMultiSelectList(Collections.emptyList(), List.of(new Value(fullName, fullName))
+            );
+
+            asylumCase.write(WITNESS_LIST_ELEMENT_N_FIELD.get(i), existingWitnessSelection);
+
+            List<String> existingCategoryPerWitnessSelection = Collections.emptyList();
+
+            if (newToOldIndexes.get(i) != null) {
+                existingCategoryPerWitnessSelection = previousCategoriesPerWitnessSelections.get(newToOldIndexes.get(i));
+            }
+
+            asylumCase.write(WITNESS_N_INTERPRETER_CATEGORY_FIELD.get(i), existingCategoryPerWitnessSelection);
+            i++;
+        }
+        while (i < 10) {
+            // clearing does not work, dummy fields have to be set and then hidden with ccd
+            asylumCase.write(WITNESS_N_FIELD.get(i), new WitnessDetails("", ""));
+            asylumCase.write(WITNESS_LIST_ELEMENT_N_FIELD.get(i), new DynamicMultiSelectList());
+            i++;
+        }
+        return asylumCase;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdaterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/InterpreterLanguagesDynamicListUpdaterTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -21,6 +22,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_DETAILS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_LIST_ELEMENT_1;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_LIST_ELEMENT_2;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.DRAFT_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
 
@@ -30,8 +32,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -64,7 +64,6 @@ class InterpreterLanguagesDynamicListUpdaterTest {
     public static final String SIGN_LANGUAGES = "SignLanguage";
     public static final String IS_CHILD_REQUIRED = "Y";
 
-    private InterpreterLanguagesDynamicListUpdater interpreterLanguagesDynamicListUpdater;
     @Mock
     private Callback<AsylumCase> callback;
     @Mock
@@ -75,8 +74,6 @@ class InterpreterLanguagesDynamicListUpdaterTest {
     private AsylumCase asylumCase;
     @Mock
     private AsylumCase asylumCaseBefore;
-    @Mock
-    private RefDataUserService refDataUserService;
     @Mock
     private CommonDataResponse commonDataResponse;
     @Mock
@@ -92,23 +89,26 @@ class InterpreterLanguagesDynamicListUpdaterTest {
     @Mock
     private DynamicMultiSelectList witnessListElement2;
 
+    private RefDataUserService refDataUserService;
+    private InterpreterLanguagesDynamicListUpdater interpreterLanguagesDynamicListUpdater;
+
     @BeforeEach
-    public void setUp() {
+    void setup() {
+        refDataUserService = mock(RefDataUserService.class);
         interpreterLanguagesDynamicListUpdater =
             new InterpreterLanguagesDynamicListUpdater(refDataUserService);
 
-        when(callback.getEvent()).thenReturn(Event.DRAFT_HEARING_REQUIREMENTS);
+        when(callback.getEvent()).thenReturn(DRAFT_HEARING_REQUIREMENTS);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
     }
 
-    @ParameterizedTest
-    @EnumSource(value = Event.class, names = {"DRAFT_HEARING_REQUIREMENTS", "UPDATE_HEARING_REQUIREMENTS"})
-    void should_populate_dynamic_list(Event event) {
+    @Test
+    void should_populate_dynamic_list() {
         List<CategoryValues> languages = List.of(categoryValues);
         List<Value> values = List.of(value);
 
-        when(callback.getEvent()).thenReturn(event);
+        when(callback.getEvent()).thenReturn(DRAFT_HEARING_REQUIREMENTS);
         when(callback.getPageId()).thenReturn(DRAFT_HEARING_REQUIREMENTS_PAGE_ID);
         when(refDataUserService.retrieveCategoryValues(INTERPRETER_LANGUAGES, IS_CHILD_REQUIRED))
             .thenReturn(commonDataResponse);
@@ -211,7 +211,7 @@ class InterpreterLanguagesDynamicListUpdaterTest {
 
                 boolean canHandle = interpreterLanguagesDynamicListUpdater.canHandle(callbackStage, callback);
 
-                if (List.of(Event.DRAFT_HEARING_REQUIREMENTS, Event.UPDATE_HEARING_REQUIREMENTS).contains(event)
+                if (event.equals(DRAFT_HEARING_REQUIREMENTS)
                     && callbackStage == PreSubmitCallbackStage.MID_EVENT) {
 
                     assertTrue(canHandle);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesDraftMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesDraftMidEventHandlerTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.DRAFT_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.SEND_DIRECTION;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.values;
@@ -21,12 +20,9 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubm
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -74,12 +70,11 @@ public class WitnessesDraftMidEventHandlerTest {
         when(callback.getPageId()).thenReturn(IS_WITNESSES_ATTENDING);
     }
 
-    @ParameterizedTest
-    @EnumSource(value = Event.class, names = { "DRAFT_HEARING_REQUIREMENTS", "UPDATE_HEARING_REQUIREMENTS"})
-    void should_add_error_when_witnesses_more_than_ten(Event event) {
+    @Test
+    void should_add_error_when_witnesses_more_than_ten() {
         List<WitnessDetails> elevenWitnesses = Collections.nCopies(11, witnessDetails);
 
-        when(callback.getEvent()).thenReturn(event);
+        when(callback.getEvent()).thenReturn(DRAFT_HEARING_REQUIREMENTS);
         when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
 
         PreSubmitCallbackResponse<AsylumCase> response = witnessesDraftMidEventHandler.handle(MID_EVENT, callback);
@@ -88,12 +83,11 @@ public class WitnessesDraftMidEventHandlerTest {
         assertTrue(response.getErrors().contains(WITNESSES_NUMBER_EXCEEDED_ERROR));
     }
 
-    @ParameterizedTest
-    @EnumSource(value = Event.class, names = { "DRAFT_HEARING_REQUIREMENTS", "UPDATE_HEARING_REQUIREMENTS"})
-    void should_not_add_error_when_witnesses_are_ten_or_less(Event event) {
+    @Test
+    void should_not_add_error_when_witnesses_are_ten_or_less() {
         List<WitnessDetails> elevenWitnesses = Collections.nCopies(10, witnessDetails);
 
-        when(callback.getEvent()).thenReturn(event);
+        when(callback.getEvent()).thenReturn(DRAFT_HEARING_REQUIREMENTS);
         when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
 
         PreSubmitCallbackResponse<AsylumCase> response = witnessesDraftMidEventHandler.handle(MID_EVENT, callback);
@@ -101,13 +95,12 @@ public class WitnessesDraftMidEventHandlerTest {
         assertTrue(response.getErrors().isEmpty());
     }
 
-    @ParameterizedTest
-    @EnumSource(value = Event.class, names = { "DRAFT_HEARING_REQUIREMENTS", "UPDATE_HEARING_REQUIREMENTS"})
-    void should_fill_witness_list_elements(Event event) {
+    @Test
+    void should_fill_witness_list_elements() {
         List<IdValue<WitnessDetails>> witnesses = Collections
             .nCopies(10, new IdValue<>("1", witnessDetails));
 
-        when(callback.getEvent()).thenReturn(event);
+        when(callback.getEvent()).thenReturn(DRAFT_HEARING_REQUIREMENTS);
         when(callback.getPageId()).thenReturn(IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID);
         when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnesses));
 
@@ -177,7 +170,7 @@ public class WitnessesDraftMidEventHandlerTest {
 
                 boolean canHandle = witnessesDraftMidEventHandler.canHandle(callbackStage, callback);
 
-                if (Set.of(DRAFT_HEARING_REQUIREMENTS, UPDATE_HEARING_REQUIREMENTS).contains(event)
+                if (event.equals(DRAFT_HEARING_REQUIREMENTS)
                     && callbackStage == MID_EVENT
                     && callback.getPageId().equals(IS_WITNESSES_ATTENDING)) {
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesDraftMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesDraftMidEventHandlerTest.java
@@ -45,7 +45,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
-public class WitnessesMidEventHandlerTest {
+public class WitnessesDraftMidEventHandlerTest {
 
     private static final String IS_WITNESSES_ATTENDING = "isWitnessesAttending";
     private static final String IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID = "isAnyWitnessInterpreterRequired";
@@ -62,11 +62,11 @@ public class WitnessesMidEventHandlerTest {
     private String witnessName = "name";
     private String witnessFamilyName = "lastName";
 
-    private WitnessesMidEventHandler witnessesMidEventHandler;
+    private WitnessesDraftMidEventHandler witnessesDraftMidEventHandler;
 
     @BeforeEach
     public void setup() {
-        witnessesMidEventHandler = new WitnessesMidEventHandler();
+        witnessesDraftMidEventHandler = new WitnessesDraftMidEventHandler();
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(witnessDetails.getWitnessName()).thenReturn(witnessName);
@@ -82,7 +82,7 @@ public class WitnessesMidEventHandlerTest {
         when(callback.getEvent()).thenReturn(event);
         when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
 
-        PreSubmitCallbackResponse<AsylumCase> response = witnessesMidEventHandler.handle(MID_EVENT, callback);
+        PreSubmitCallbackResponse<AsylumCase> response = witnessesDraftMidEventHandler.handle(MID_EVENT, callback);
 
         assertEquals(1, response.getErrors().size());
         assertTrue(response.getErrors().contains(WITNESSES_NUMBER_EXCEEDED_ERROR));
@@ -96,7 +96,7 @@ public class WitnessesMidEventHandlerTest {
         when(callback.getEvent()).thenReturn(event);
         when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
 
-        PreSubmitCallbackResponse<AsylumCase> response = witnessesMidEventHandler.handle(MID_EVENT, callback);
+        PreSubmitCallbackResponse<AsylumCase> response = witnessesDraftMidEventHandler.handle(MID_EVENT, callback);
 
         assertTrue(response.getErrors().isEmpty());
     }
@@ -111,7 +111,7 @@ public class WitnessesMidEventHandlerTest {
         when(callback.getPageId()).thenReturn(IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID);
         when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnesses));
 
-        PreSubmitCallbackResponse<AsylumCase> response = witnessesMidEventHandler.handle(MID_EVENT, callback);
+        PreSubmitCallbackResponse<AsylumCase> response = witnessesDraftMidEventHandler.handle(MID_EVENT, callback);
 
         DynamicMultiSelectList dynamicMultiSelectListEmpty = new DynamicMultiSelectList();
         DynamicMultiSelectList dynamicMultiSelectList = new DynamicMultiSelectList(Collections.emptyList(),
@@ -154,13 +154,13 @@ public class WitnessesMidEventHandlerTest {
     void handling_should_throw_if_cannot_actually_handle() {
 
         assertThatThrownBy(
-            () -> witnessesMidEventHandler.handle(ABOUT_TO_START, callback))
+            () -> witnessesDraftMidEventHandler.handle(ABOUT_TO_START, callback))
             .hasMessage("Cannot handle callback")
             .isExactlyInstanceOf(IllegalStateException.class);
 
         when(callback.getEvent()).thenReturn(SEND_DIRECTION);
         assertThatThrownBy(
-            () -> witnessesMidEventHandler.handle(ABOUT_TO_START, callback))
+            () -> witnessesDraftMidEventHandler.handle(ABOUT_TO_START, callback))
             .hasMessage("Cannot handle callback")
             .isExactlyInstanceOf(IllegalStateException.class);
     }
@@ -175,7 +175,7 @@ public class WitnessesMidEventHandlerTest {
 
             for (PreSubmitCallbackStage callbackStage : values()) {
 
-                boolean canHandle = witnessesMidEventHandler.canHandle(callbackStage, callback);
+                boolean canHandle = witnessesDraftMidEventHandler.canHandle(callbackStage, callback);
 
                 if (Set.of(DRAFT_HEARING_REQUIREMENTS, UPDATE_HEARING_REQUIREMENTS).contains(event)
                     && callbackStage == MID_EVENT

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesUpdateMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesUpdateMidEventHandlerTest.java
@@ -1,0 +1,468 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.SEND_DIRECTION;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUIREMENTS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.MID_EVENT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.values;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.InterpreterLanguagesDynamicListUpdater.INTERPRETER_LANGUAGES;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.InterpreterLanguagesDynamicListUpdater.SIGN;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.InterpreterLanguagesDynamicListUpdater.SIGN_LANGUAGES;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.InterpreterLanguagesDynamicListUpdater.SPOKEN;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicMultiSelectList;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageRefData;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.Value;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class WitnessesUpdateMidEventHandlerTest {
+
+    private static final String IS_WITNESSES_ATTENDING_PAGE_ID = "isWitnessesAttending";
+    private static final String IS_INTERPRETER_SERVICES_NEEDED_PAGE_ID = "isInterpreterServicesNeeded";
+    private static final String APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_PAGE_ID = "appellantInterpreterSpokenLanguage";
+    private static final String APPELLANT_INTERPRETER_SIGN_LANGUAGE_PAGE_ID = "appellantInterpreterSignLanguage";
+    private static final String WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID = "whichWitnessRequiresInterpreter";
+    private static final String IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID = "isAnyWitnessInterpreterRequired";
+    private static final String WITNESSES_NUMBER_EXCEEDED_ERROR = "Maximum number of witnesses is 10";
+
+    @Mock
+    private InterpreterLanguagesDynamicListUpdater interpreterLanguagesDynamicListUpdater;
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetailsBefore;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private AsylumCase oldAsylumCase;
+    @Mock
+    private WitnessDetails witnessDetails1;
+    @Mock
+    private WitnessDetails witnessDetails2;
+    @Mock
+    private WitnessDetails witnessDetails3;
+    @Mock
+    private WitnessDetails witnessDetailsA;
+    @Mock
+    private WitnessDetails witnessDetailsB;
+    @Mock
+    private InterpreterLanguageRefData spokenLanguages;
+    @Mock
+    private InterpreterLanguageRefData signLanguages;
+    @Mock
+    private InterpreterLanguageRefData witness1SpokenLanguages;
+    @Mock
+    private InterpreterLanguageRefData witness1SignLanguages;
+    @Mock
+    private DynamicMultiSelectList witnessListElement1;
+    @Mock
+    private DynamicMultiSelectList witnessListElement2;
+    @Mock
+    private DynamicMultiSelectList witnessListElement3;
+    @Mock
+    private DynamicMultiSelectList witnessListElement4;
+
+    MockedStatic<InterpreterLanguagesUtils> interpreterLanguagesUtils;
+
+    private WitnessesUpdateMidEventHandler witnessesUpdateMidEventHandler;
+
+    @BeforeEach
+    public void setup() {
+        interpreterLanguagesUtils = mockStatic(InterpreterLanguagesUtils.class);
+        witnessesUpdateMidEventHandler = new WitnessesUpdateMidEventHandler(interpreterLanguagesDynamicListUpdater);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getCaseDetailsBefore()).thenReturn(Optional.of(caseDetailsBefore));
+        when(caseDetailsBefore.getCaseData()).thenReturn(oldAsylumCase);
+        String witnessName1 = "1";
+        when(witnessDetails1.getWitnessName()).thenReturn(witnessName1);
+        String witnessFamilyName1 = "1";
+        when(witnessDetails1.getWitnessFamilyName()).thenReturn(witnessFamilyName1);
+        when(witnessDetails1.buildWitnessFullName()).thenReturn(witnessName1 + " " + witnessFamilyName1);
+        String witnessName2 = "2";
+        when(witnessDetails2.getWitnessName()).thenReturn(witnessName2);
+        String witnessFamilyName2 = "2";
+        when(witnessDetails2.getWitnessFamilyName()).thenReturn(witnessFamilyName2);
+        when(witnessDetails2.buildWitnessFullName()).thenReturn(witnessName2 + " " + witnessFamilyName2);
+        String witnessName3 = "3";
+        when(witnessDetails3.getWitnessName()).thenReturn(witnessName3);
+        String witnessFamilyName3 = "3";
+        when(witnessDetails3.getWitnessFamilyName()).thenReturn(witnessFamilyName3);
+        when(witnessDetails3.buildWitnessFullName()).thenReturn(witnessName3 + " " + witnessFamilyName3);
+        String witnessNameA = "A";
+        when(witnessDetailsA.getWitnessName()).thenReturn(witnessNameA);
+        String witnessFamilyNameA = "A";
+        when(witnessDetailsA.getWitnessFamilyName()).thenReturn(witnessFamilyNameA);
+        when(witnessDetailsA.buildWitnessFullName()).thenReturn(witnessNameA + " " + witnessFamilyNameA);
+        String witnessNameB = "B";
+        when(witnessDetailsB.getWitnessName()).thenReturn(witnessNameB);
+        String witnessFamilyNameB = "B";
+        when(witnessDetailsB.getWitnessFamilyName()).thenReturn(witnessFamilyNameB);
+        when(witnessDetailsB.buildWitnessFullName()).thenReturn(witnessNameB + " " + witnessFamilyNameB);
+
+    }
+
+    @AfterEach
+    public void close() {
+        interpreterLanguagesUtils.close();
+    }
+
+    @Test
+    void should_clear_fields_to_be_cleared_at_end_of_event() {
+        witnessesUpdateMidEventHandler.setFieldsToBeCleared(List.of(
+            WITNESS_LIST_ELEMENT_1,
+            WITNESS_1_INTERPRETER_SPOKEN_LANGUAGE,
+            WITNESS_1_INTERPRETER_SIGN_LANGUAGE)
+        );
+
+        when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUIREMENTS);
+
+        witnessesUpdateMidEventHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        verify(asylumCase, times(1)).clear(WITNESS_LIST_ELEMENT_1);
+        verify(asylumCase, times(1)).clear(WITNESS_1_INTERPRETER_SPOKEN_LANGUAGE);
+        verify(asylumCase, times(1)).clear(WITNESS_1_INTERPRETER_SIGN_LANGUAGE);
+    }
+
+    @Test
+    void should_add_error_when_witnesses_more_than_ten() {
+        List<IdValue<WitnessDetails>> elevenWitnesses = Collections
+            .nCopies(11, new IdValue<>("1", witnessDetails1));
+
+        when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUIREMENTS);
+        when(callback.getPageId()).thenReturn(IS_WITNESSES_ATTENDING_PAGE_ID);
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
+        when(oldAsylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
+
+        PreSubmitCallbackResponse<AsylumCase> response = witnessesUpdateMidEventHandler.handle(MID_EVENT, callback);
+
+        assertEquals(1, response.getErrors().size());
+        assertTrue(response.getErrors().contains(WITNESSES_NUMBER_EXCEEDED_ERROR));
+    }
+
+    @Test
+    void should_not_add_error_when_witnesses_are_ten_or_less() {
+        List<WitnessDetails> elevenWitnesses = Collections.nCopies(10, witnessDetails1);
+
+        when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUIREMENTS);
+        when(callback.getPageId()).thenReturn(IS_WITNESSES_ATTENDING_PAGE_ID);
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
+
+        PreSubmitCallbackResponse<AsylumCase> response = witnessesUpdateMidEventHandler.handle(MID_EVENT, callback);
+
+        assertTrue(response.getErrors().isEmpty());
+    }
+
+    @Test
+    void should_clear_fields_if_no_witnesses_attending() {
+        List<IdValue<WitnessDetails>> elevenWitnesses = Collections
+            .nCopies(10, new IdValue<>("1", witnessDetails1));
+
+        when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUIREMENTS);
+        when(callback.getPageId()).thenReturn(IS_WITNESSES_ATTENDING_PAGE_ID);
+        when(oldAsylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.empty());
+        when(asylumCase.read(IS_WITNESSES_ATTENDING, YesOrNo.class)).thenReturn(Optional.of(NO));
+
+        witnessesUpdateMidEventHandler.handle(MID_EVENT, callback);
+
+        interpreterLanguagesUtils.verify(() -> InterpreterLanguagesUtils.clearWitnessIndividualFields(asylumCase));
+        interpreterLanguagesUtils.verify(() -> InterpreterLanguagesUtils.clearWitnessInterpreterLanguageFields(asylumCase));
+    }
+
+    @Test
+    void should_skip_logic_if_appellant_interpreter_page_is_not_last_page() { // before whichWitnessRequiresInterpterer
+
+        // check if interpreter services are needed to establish whether to break out of the loop or not
+        // (i.e. leave it to a further page to run the logic since this wouldn't be the last page before witnesses
+        // mappings need to be evaluated)
+
+        List<IdValue<WitnessDetails>> elevenWitnesses = Collections
+            .nCopies(10, new IdValue<>("1", witnessDetails1));
+
+        when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUIREMENTS);
+        when(callback.getPageId()).thenReturn(IS_INTERPRETER_SERVICES_NEEDED_PAGE_ID);
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
+        when(oldAsylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
+
+        witnessesUpdateMidEventHandler.handle(MID_EVENT, callback);
+
+        verify(asylumCase, times(1)).read(IS_INTERPRETER_SERVICES_NEEDED, YesOrNo.class);
+    }
+
+    @Test
+    void should_skip_logic_if_appellant_spoken_language_page_is_not_last_page() { // before whichWitnessRequiresInterpterer
+
+        // check if logic is skipped (1st method to be called in all the logic is never called)
+        // (i.e. leave it to a further page to run the logic since this wouldn't be the last page before witnesses
+        // mappings need to be evaluated)
+
+        List<IdValue<WitnessDetails>> elevenWitnesses = Collections
+            .nCopies(10, new IdValue<>("1", witnessDetails1));
+
+        when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUIREMENTS);
+        when(callback.getPageId()).thenReturn(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_PAGE_ID);
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
+        when(oldAsylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
+        when(asylumCase.read(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(List.of(SPOKEN)));
+
+        witnessesUpdateMidEventHandler.handle(MID_EVENT, callback);
+
+        verify(oldAsylumCase, never()).read(WITNESS_LIST_ELEMENT_1, DynamicMultiSelectList.class);
+    }
+
+    @Test
+    void should_skip_logic_if_appellant_sign_language_page_is_not_last_page() { // before whichWitnessRequiresInterpterer
+
+        // check if logic is skipped (1st method to be called in all the logic is never called)
+        // (i.e. leave it to a further page to run the logic since this wouldn't be the last page before witnesses
+        // mappings need to be evaluated)
+
+        List<IdValue<WitnessDetails>> elevenWitnesses = Collections
+            .nCopies(10, new IdValue<>("1", witnessDetails1));
+
+        when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUIREMENTS);
+        when(callback.getPageId()).thenReturn(APPELLANT_INTERPRETER_SIGN_LANGUAGE_PAGE_ID);
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
+        when(oldAsylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(elevenWitnesses));
+        when(asylumCase.read(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(List.of(SIGN)));
+
+        witnessesUpdateMidEventHandler.handle(MID_EVENT, callback);
+
+        verify(oldAsylumCase, never()).read(WITNESS_LIST_ELEMENT_1, DynamicMultiSelectList.class);
+    }
+
+    @Test
+    void should_map_old_to_new_fields() {
+        // deleting witness3, adding witnessA, witness
+
+        // OLD WITNESSES
+        // witness1 [needs interpreter] SPOKEN + SIGN
+        // witness2 [no]
+        // witness3 [no]
+
+        // NEW WITNESSES
+        // witness1 [needs interpreter] SIGN (should maintain old selection)
+        // witness2 [needs interpreter] SPOKEN
+        // witnessA [no]
+        // witnessB [needs interpreter] SIGN
+
+        List<IdValue<WitnessDetails>> oldWitnesses = List.of(
+            new IdValue<>("1", witnessDetails1),
+            new IdValue<>("2", witnessDetails2),
+            new IdValue<>("3", witnessDetails3));
+
+        List<IdValue<WitnessDetails>> newWitnesses = List.of(
+            new IdValue<>("1", witnessDetails1),
+            new IdValue<>("2", witnessDetails2),
+            new IdValue<>("A", witnessDetailsA),
+            new IdValue<>("B", witnessDetailsB));
+
+        when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUIREMENTS);
+        when(callback.getPageId()).thenReturn(WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID);
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(newWitnesses));
+        when(oldAsylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(oldWitnesses));
+        when(asylumCase.read(IS_WITNESSES_ATTENDING, YesOrNo.class)).thenReturn(Optional.of(YES));
+
+        when(interpreterLanguagesDynamicListUpdater.generateDynamicList(INTERPRETER_LANGUAGES))
+                .thenReturn(spokenLanguages);
+        when(interpreterLanguagesDynamicListUpdater.generateDynamicList(SIGN_LANGUAGES))
+            .thenReturn(signLanguages);
+
+        when(oldAsylumCase.read(WITNESS_1_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class))
+            .thenReturn(Optional.of(witness1SpokenLanguages));
+        when(oldAsylumCase.read(WITNESS_1_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class))
+            .thenReturn(Optional.of(witness1SignLanguages));
+        when(asylumCase.read(WITNESS_LIST_ELEMENT_1, DynamicMultiSelectList.class)).thenReturn(Optional.of(witnessListElement1));
+        when(witnessListElement1.getValue()).thenReturn(List.of(new Value("lang", "lang")));
+        when(asylumCase.read(WITNESS_1_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(List.of(SIGN)));
+        when(asylumCase.read(WITNESS_LIST_ELEMENT_2, DynamicMultiSelectList.class)).thenReturn(Optional.of(witnessListElement2));
+        when(witnessListElement2.getValue()).thenReturn(List.of(new Value("lang", "lang")));
+        when(asylumCase.read(WITNESS_2_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(List.of(SPOKEN)));
+        when(asylumCase.read(WITNESS_LIST_ELEMENT_3, DynamicMultiSelectList.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(WITNESS_LIST_ELEMENT_4, DynamicMultiSelectList.class)).thenReturn(Optional.of(witnessListElement4));
+        when(witnessListElement4.getValue()).thenReturn(List.of(new Value("lang", "lang")));
+        when(asylumCase.read(WITNESS_4_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(List.of(SIGN)));
+
+        witnessesUpdateMidEventHandler.handle(MID_EVENT, callback);
+
+        verify(asylumCase).write(WITNESS_1_INTERPRETER_SIGN_LANGUAGE, witness1SignLanguages);
+        verify(asylumCase).write(WITNESS_2_INTERPRETER_SPOKEN_LANGUAGE, spokenLanguages);
+        verify(asylumCase).write(WITNESS_4_INTERPRETER_SIGN_LANGUAGE, signLanguages);
+        verify(asylumCase).clear(WITNESS_1_INTERPRETER_SPOKEN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_3_INTERPRETER_SPOKEN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_4_INTERPRETER_SPOKEN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_5_INTERPRETER_SPOKEN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_6_INTERPRETER_SPOKEN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_7_INTERPRETER_SPOKEN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_8_INTERPRETER_SPOKEN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_9_INTERPRETER_SPOKEN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_10_INTERPRETER_SPOKEN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_2_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_3_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_5_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_6_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_7_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_8_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_9_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_10_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).write(eq(WITNESS_3_INTERPRETER_LANGUAGE_CATEGORY), eq(Collections.emptyList()));
+        verify(asylumCase).write(eq(WITNESS_5_INTERPRETER_LANGUAGE_CATEGORY), eq(Collections.emptyList()));
+        verify(asylumCase).write(eq(WITNESS_6_INTERPRETER_LANGUAGE_CATEGORY), eq(Collections.emptyList()));
+        verify(asylumCase).write(eq(WITNESS_7_INTERPRETER_LANGUAGE_CATEGORY), eq(Collections.emptyList()));
+        verify(asylumCase).write(eq(WITNESS_8_INTERPRETER_LANGUAGE_CATEGORY), eq(Collections.emptyList()));
+        verify(asylumCase).write(eq(WITNESS_9_INTERPRETER_LANGUAGE_CATEGORY), eq(Collections.emptyList()));
+        verify(asylumCase).write(eq(WITNESS_10_INTERPRETER_LANGUAGE_CATEGORY), eq(Collections.emptyList()));
+
+        assertEquals(17, witnessesUpdateMidEventHandler.getFieldsToBeCleared().size());
+    }
+
+    //@Test
+    //void should_fill_witness_list_elements() {
+    //    List<IdValue<WitnessDetails>> witnesses = Collections
+    //        .nCopies(10, new IdValue<>("1", witnessDetails));
+    //
+    //    when(callback.getEvent()).thenReturn(DRAFT_HEARING_REQUIREMENTS);
+    //    when(callback.getPageId()).thenReturn(IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID);
+    //    when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnesses));
+    //
+    //    PreSubmitCallbackResponse<AsylumCase> response = witnessesUpdateMidEventHandler.handle(MID_EVENT, callback);
+    //
+    //    DynamicMultiSelectList dynamicMultiSelectListEmpty = new DynamicMultiSelectList();
+    //    DynamicMultiSelectList dynamicMultiSelectList = new DynamicMultiSelectList(Collections.emptyList(),
+    //        List.of(new Value("name lastName", "name lastName"))
+    //    );
+    //
+    //    verify(asylumCase, times(2)).write(eq(WITNESS_1), any(WitnessDetails.class));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_1), eq(dynamicMultiSelectListEmpty));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_1), eq(dynamicMultiSelectList));
+    //    verify(asylumCase, times(2)).write(eq(WITNESS_2), any(WitnessDetails.class));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_2), eq(dynamicMultiSelectListEmpty));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_2), eq(dynamicMultiSelectList));
+    //    verify(asylumCase, times(2)).write(eq(WITNESS_3), any(WitnessDetails.class));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_3), eq(dynamicMultiSelectListEmpty));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_3), eq(dynamicMultiSelectList));
+    //    verify(asylumCase, times(2)).write(eq(WITNESS_4), any(WitnessDetails.class));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_4), eq(dynamicMultiSelectListEmpty));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_4), eq(dynamicMultiSelectList));
+    //    verify(asylumCase, times(2)).write(eq(WITNESS_5), any(WitnessDetails.class));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_5), eq(dynamicMultiSelectListEmpty));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_5), eq(dynamicMultiSelectList));
+    //    verify(asylumCase, times(2)).write(eq(WITNESS_6), any(WitnessDetails.class));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_6), eq(dynamicMultiSelectListEmpty));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_6), eq(dynamicMultiSelectList));
+    //    verify(asylumCase, times(2)).write(eq(WITNESS_7), any(WitnessDetails.class));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_7), eq(dynamicMultiSelectListEmpty));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_7), eq(dynamicMultiSelectList));
+    //    verify(asylumCase, times(2)).write(eq(WITNESS_8), any(WitnessDetails.class));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_8), eq(dynamicMultiSelectListEmpty));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_8), eq(dynamicMultiSelectList));
+    //    verify(asylumCase, times(2)).write(eq(WITNESS_9), any(WitnessDetails.class));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_9), eq(dynamicMultiSelectListEmpty));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_9), eq(dynamicMultiSelectList));
+    //    verify(asylumCase, times(2)).write(eq(WITNESS_10), any(WitnessDetails.class));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_10), eq(dynamicMultiSelectListEmpty));
+    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_10), eq(dynamicMultiSelectList));
+    //}
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(
+            () -> witnessesUpdateMidEventHandler.handle(ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(SEND_DIRECTION);
+        assertThatThrownBy(
+            () -> witnessesUpdateMidEventHandler.handle(ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+        Set<String> pageIds = Set.of(IS_WITNESSES_ATTENDING_PAGE_ID,
+            IS_INTERPRETER_SERVICES_NEEDED_PAGE_ID,
+            APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_PAGE_ID,
+            APPELLANT_INTERPRETER_SIGN_LANGUAGE_PAGE_ID,
+            WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID,
+            IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID,
+            "");
+
+        for (String pageId : pageIds) {
+            for (Event event : Event.values()) {
+
+                when(callback.getEvent()).thenReturn(event);
+                when(callback.getPageId()).thenReturn(pageId);
+
+                for (PreSubmitCallbackStage callbackStage : values()) {
+
+                    boolean canHandle = witnessesUpdateMidEventHandler.canHandle(callbackStage, callback);
+
+                    if (event.equals(UPDATE_HEARING_REQUIREMENTS)
+                        && callbackStage == MID_EVENT
+                        && Set.of(IS_WITNESSES_ATTENDING_PAGE_ID,
+                        IS_INTERPRETER_SERVICES_NEEDED_PAGE_ID,
+                        APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_PAGE_ID,
+                        APPELLANT_INTERPRETER_SIGN_LANGUAGE_PAGE_ID,
+                        WHICH_WITNESS_REQUIRES_INTERPRETER_PAGE_ID,
+                        IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID).contains(callback.getPageId())
+                        || (callbackStage == ABOUT_TO_SUBMIT
+                            && callback.getEvent().equals(UPDATE_HEARING_REQUIREMENTS))) {
+
+                        assertTrue(canHandle);
+                    } else {
+                        assertFalse(canHandle);
+                    }
+                }
+
+                reset(callback);
+            }
+        }
+    }
+}
+
+

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesUpdateMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesUpdateMidEventHandlerTest.java
@@ -328,6 +328,7 @@ public class WitnessesUpdateMidEventHandlerTest {
 
         witnessesUpdateMidEventHandler.handle(MID_EVENT, callback);
 
+
         verify(asylumCase).write(WITNESS_1_INTERPRETER_SIGN_LANGUAGE, witness1SignLanguages);
         verify(asylumCase).write(WITNESS_2_INTERPRETER_SPOKEN_LANGUAGE, spokenLanguages);
         verify(asylumCase).write(WITNESS_4_INTERPRETER_SIGN_LANGUAGE, signLanguages);
@@ -359,53 +360,6 @@ public class WitnessesUpdateMidEventHandlerTest {
         assertEquals(17, witnessesUpdateMidEventHandler.getFieldsToBeCleared().size());
     }
 
-    //@Test
-    //void should_fill_witness_list_elements() {
-    //    List<IdValue<WitnessDetails>> witnesses = Collections
-    //        .nCopies(10, new IdValue<>("1", witnessDetails));
-    //
-    //    when(callback.getEvent()).thenReturn(DRAFT_HEARING_REQUIREMENTS);
-    //    when(callback.getPageId()).thenReturn(IS_ANY_WITNESS_INTERPRETER_REQUIRED_PAGE_ID);
-    //    when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnesses));
-    //
-    //    PreSubmitCallbackResponse<AsylumCase> response = witnessesUpdateMidEventHandler.handle(MID_EVENT, callback);
-    //
-    //    DynamicMultiSelectList dynamicMultiSelectListEmpty = new DynamicMultiSelectList();
-    //    DynamicMultiSelectList dynamicMultiSelectList = new DynamicMultiSelectList(Collections.emptyList(),
-    //        List.of(new Value("name lastName", "name lastName"))
-    //    );
-    //
-    //    verify(asylumCase, times(2)).write(eq(WITNESS_1), any(WitnessDetails.class));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_1), eq(dynamicMultiSelectListEmpty));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_1), eq(dynamicMultiSelectList));
-    //    verify(asylumCase, times(2)).write(eq(WITNESS_2), any(WitnessDetails.class));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_2), eq(dynamicMultiSelectListEmpty));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_2), eq(dynamicMultiSelectList));
-    //    verify(asylumCase, times(2)).write(eq(WITNESS_3), any(WitnessDetails.class));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_3), eq(dynamicMultiSelectListEmpty));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_3), eq(dynamicMultiSelectList));
-    //    verify(asylumCase, times(2)).write(eq(WITNESS_4), any(WitnessDetails.class));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_4), eq(dynamicMultiSelectListEmpty));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_4), eq(dynamicMultiSelectList));
-    //    verify(asylumCase, times(2)).write(eq(WITNESS_5), any(WitnessDetails.class));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_5), eq(dynamicMultiSelectListEmpty));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_5), eq(dynamicMultiSelectList));
-    //    verify(asylumCase, times(2)).write(eq(WITNESS_6), any(WitnessDetails.class));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_6), eq(dynamicMultiSelectListEmpty));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_6), eq(dynamicMultiSelectList));
-    //    verify(asylumCase, times(2)).write(eq(WITNESS_7), any(WitnessDetails.class));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_7), eq(dynamicMultiSelectListEmpty));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_7), eq(dynamicMultiSelectList));
-    //    verify(asylumCase, times(2)).write(eq(WITNESS_8), any(WitnessDetails.class));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_8), eq(dynamicMultiSelectListEmpty));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_8), eq(dynamicMultiSelectList));
-    //    verify(asylumCase, times(2)).write(eq(WITNESS_9), any(WitnessDetails.class));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_9), eq(dynamicMultiSelectListEmpty));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_9), eq(dynamicMultiSelectList));
-    //    verify(asylumCase, times(2)).write(eq(WITNESS_10), any(WitnessDetails.class));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_10), eq(dynamicMultiSelectListEmpty));
-    //    verify(asylumCase, times(1)).write(eq(WITNESS_LIST_ELEMENT_10), eq(dynamicMultiSelectList));
-    //}
 
     @Test
     void handling_should_throw_if_cannot_actually_handle() {


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-7642](https://tools.hmcts.net/jira/browse/RIA-7642)


### Change description ###
- Logic to retain the old witnesses and their language selections into the new list of witnesses, so that old witnesses' fields are prepopulated and new witnesses' fields are unselected but functional

E.G.
```
Witness1 = German
Witness2 = Polish
Witness3 = /
Witness4 = Japanese
Witness5 = Arabic
Witness6 = Turkish
```

DELETING WITNESS4

```
Witness1 = German
Witness2 = Polish
Witness3 = /
------------------------> [Witness4 = Japanese]
Witness(5)4 = Arabic
Witness(6)5 = Turkish
```

ADDING ANOTHER WITNESS NEEDING Finnish

```
Witness1 = German
Witness2 = Polish
Witness3 = /
Witness4 = Arabic
Witness5 = Turkish
[Witness6 = Finnish]   <------------------------
```

Witness4 no longer needs Japanese, but is ex-Witness5 (Arabic)
Witness5 no longer needs Arabic, but is ex-Witness6 (Turkish)
Witness6 no longer needs Turkish, but is a new witness needing Finnish


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
