### PR TITLE
RIA-7618 Adding record remission decision event to doc and notif gene…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandler.java
@@ -105,7 +105,8 @@ public class GenerateDocumentHandler implements PreSubmitCallbackHandler<AsylumC
             Event.UPLOAD_HOME_OFFICE_APPEAL_RESPONSE,
             Event.ASYNC_STITCHING_COMPLETE,
             Event.RECORD_OUT_OF_TIME_DECISION,
-            Event.REQUEST_RESPONDENT_EVIDENCE
+            Event.REQUEST_RESPONDENT_EVIDENCE,
+            Event.RECORD_REMISSION_DECISION
         );
         if (isEmStitchingEnabled) {
             allowedEvents.add(Event.SUBMIT_CASE);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -190,8 +190,10 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
                 Event.UPDATE_DETENTION_LOCATION,
                 Event.GENERATE_HEARING_BUNDLE,
                 Event.SEND_DECISION_AND_REASONS,
-                Event.END_APPEAL_AUTOMATICALLY
-        );
+                Event.END_APPEAL_AUTOMATICALLY,
+                Event.RECORD_REMISSION_DECISION
+
+            );
         if (!isSaveAndContinueEnabled) {
             //eventsToHandle.add(Event.BUILD_CASE);
         }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -194,7 +194,6 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
                 Event.RECORD_REMISSION_DECISION,
                 Event.MARK_APPEAL_PAID
         );
-
         if (!isSaveAndContinueEnabled) {
             //eventsToHandle.add(Event.BUILD_CASE);
         }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandlerTest.java
@@ -303,7 +303,8 @@ class GenerateDocumentHandlerTest {
                         UPLOAD_HOME_OFFICE_APPEAL_RESPONSE,
                         ASYNC_STITCHING_COMPLETE,
                         RECORD_OUT_OF_TIME_DECISION,
-                        REQUEST_RESPONDENT_EVIDENCE
+                        REQUEST_RESPONDENT_EVIDENCE,
+                        RECORD_REMISSION_DECISION
 
                     ).contains(event)) {
 
@@ -403,7 +404,8 @@ class GenerateDocumentHandlerTest {
                         UPLOAD_HOME_OFFICE_APPEAL_RESPONSE,
                         ASYNC_STITCHING_COMPLETE,
                         RECORD_OUT_OF_TIME_DECISION,
-                        REQUEST_RESPONDENT_EVIDENCE
+                        REQUEST_RESPONDENT_EVIDENCE,
+                        RECORD_REMISSION_DECISION
                     );
 
                 if (callbackStage.equals(PreSubmitCallbackStage.ABOUT_TO_SUBMIT)


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7618

### Change description ###

- Adding event 'Record Remission Decision' to doc and notification generations

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
