### PR TITLE
RIA-7520-RIA-7526 Backend changes to handle edit pre submit suitabili…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1764,7 +1764,22 @@ public enum AsylumCaseFieldDefinition {
             "appealReadyForUtTransferOutcome", new TypeReference<String>(){}),
 
     PREVIOUS_DETENTION_LOCATION(
-            "previousDetentionLocation", new TypeReference<String>() {})
+            "previousDetentionLocation", new TypeReference<String>() {}),
+
+    SUITABILITY_HEARING_TYPE_YES_OR_NO(
+        "suitabilityHearingTypeYesOrNo", new TypeReference<YesOrNo>() {}),
+
+    SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_1(
+        "suitabilityAppellantAttendanceYesOrNo1", new TypeReference<YesOrNo>() {}),
+
+    SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_2(
+        "suitabilityAppellantAttendanceYesOrNo2", new TypeReference<YesOrNo>() {}),
+
+    SUITABILITY_INTERPRETER_SERVICES_YES_OR_NO(
+        "suitabilityInterpreterServicesYesOrNo", new TypeReference<YesOrNo>() {}),
+
+    SUITABILITY_INTERPRETER_SERVICES_LANGUAGE(
+        "suitabilityInterpreterServicesLanguage", new TypeReference<String>() {})
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealOutOfCountryEditAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealOutOfCountryEditAppealHandler.java
@@ -120,6 +120,7 @@ public class AppealOutOfCountryEditAppealHandler implements PreSubmitCallbackHan
 
                 clearOutOfCountryDecision(asylumCase);
                 asylumCase.clear(HOME_OFFICE_DECISION_DATE);
+                clearAdaSuitabilityFields(asylumCase);
             }
 
         } else {
@@ -179,6 +180,14 @@ public class AppealOutOfCountryEditAppealHandler implements PreSubmitCallbackHan
 
     private void clearRefusalOfProtection(AsylumCase asylumCase) {
         asylumCase.clear(DATE_CLIENT_LEAVE_UK);
+    }
+
+    private void clearAdaSuitabilityFields(AsylumCase asylumCase) {
+        asylumCase.clear(SUITABILITY_HEARING_TYPE_YES_OR_NO);
+        asylumCase.clear(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_1);
+        asylumCase.clear(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_2);
+        asylumCase.clear(SUITABILITY_INTERPRETER_SERVICES_YES_OR_NO);
+        asylumCase.clear(SUITABILITY_INTERPRETER_SERVICES_LANGUAGE);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetainedEditAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DetainedEditAppealHandler.java
@@ -43,6 +43,10 @@ public class DetainedEditAppealHandler implements PreSubmitCallbackHandler<Asylu
                 .getCaseData();
 
         YesOrNo appellantInDetention = asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class).orElse(NO);
+        YesOrNo isAda = asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class).orElse(NO);
+        YesOrNo adaSuitabilityHearingType = asylumCase.read(SUITABILITY_HEARING_TYPE_YES_OR_NO, YesOrNo.class).orElse(NO);
+        YesOrNo suitabilityAppellantAttendanceYesOrNo1 = asylumCase.read(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_1, YesOrNo.class).orElse(NO);
+        YesOrNo suitabilityAppellantAttendanceYesOrNo2 = asylumCase.read(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_2, YesOrNo.class).orElse(NO);
 
         if (appellantInDetention.equals(YES)) {
             //Clear all 'non-detained' fields when switching to a detained case
@@ -56,6 +60,29 @@ public class DetainedEditAppealHandler implements PreSubmitCallbackHandler<Asylu
             asylumCase.clear(CONTACT_PREFERENCE);
             asylumCase.clear(EMAIL);
             asylumCase.clear(MOBILE_NUMBER);
+
+            // For ADA cases, clear unused suitability attendance value after editing hearing type value
+            if (isAda.equals(YES)) {
+                if (adaSuitabilityHearingType.equals(YES)) {
+                    asylumCase.clear(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_2);
+                } else {
+                    asylumCase.clear(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_1);
+                }
+
+                // For either attendance value edited to 'No', clear interpreter screen fields
+                // Midevent will write old value to No by default
+                if ((suitabilityAppellantAttendanceYesOrNo1.equals(NO) && suitabilityAppellantAttendanceYesOrNo2.equals(NO))) {
+                    asylumCase.clear(SUITABILITY_INTERPRETER_SERVICES_YES_OR_NO);
+                    asylumCase.clear(SUITABILITY_INTERPRETER_SERVICES_LANGUAGE);
+                }
+            } else {
+                asylumCase.clear(SUITABILITY_HEARING_TYPE_YES_OR_NO);
+                asylumCase.clear(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_1);
+                asylumCase.clear(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_2);
+                asylumCase.clear(SUITABILITY_INTERPRETER_SERVICES_YES_OR_NO);
+                asylumCase.clear(SUITABILITY_INTERPRETER_SERVICES_LANGUAGE);
+            }
+
         } else if (appellantInDetention.equals(NO)) {
             // Clear all 'detained' fields when switching to non-detained case
             asylumCase.clear(DETENTION_STATUS);
@@ -76,6 +103,12 @@ public class DetainedEditAppealHandler implements PreSubmitCallbackHandler<Asylu
             asylumCase.clear(IS_ACCELERATED_DETAINED_APPEAL);
             asylumCase.clear(REMOVAL_ORDER_OPTIONS);
             asylumCase.clear(REMOVAL_ORDER_DATE);
+
+            asylumCase.clear(SUITABILITY_HEARING_TYPE_YES_OR_NO);
+            asylumCase.clear(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_1);
+            asylumCase.clear(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_2);
+            asylumCase.clear(SUITABILITY_INTERPRETER_SERVICES_YES_OR_NO);
+            asylumCase.clear(SUITABILITY_INTERPRETER_SERVICES_LANGUAGE);
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEvent.java
@@ -24,6 +24,8 @@ public class StartAppealMidEvent implements PreSubmitCallbackHandler<AsylumCase>
     private static final String HOME_OFFICE_DECISION_PAGE_ID = "homeOfficeDecision";
     private static final String OUT_OF_COUNTRY_PAGE_ID = "outOfCountry";
     private static final String DETENTION_FACILITY_PAGE_ID = "detentionFacility";
+    private static final String SUITABILITY_ATTENDANCE_PAGE_ID = "suitabilityAppellantAttendance";
+
 
     public boolean canHandle(
             PreSubmitCallbackStage callbackStage,
@@ -39,7 +41,8 @@ public class StartAppealMidEvent implements PreSubmitCallbackHandler<AsylumCase>
                     || callback.getEvent() == Event.UPDATE_DETENTION_LOCATION)
                && (callback.getPageId().equals(HOME_OFFICE_DECISION_PAGE_ID)
                     || callback.getPageId().equals(OUT_OF_COUNTRY_PAGE_ID)
-                    || callback.getPageId().equals(DETENTION_FACILITY_PAGE_ID));
+                    || callback.getPageId().equals(DETENTION_FACILITY_PAGE_ID)
+                    || callback.getPageId().equals(SUITABILITY_ATTENDANCE_PAGE_ID));
     }
 
     public PreSubmitCallbackResponse<AsylumCase> handle(
@@ -102,6 +105,17 @@ public class StartAppealMidEvent implements PreSubmitCallbackHandler<AsylumCase>
             if (isAda && !detentionFacilityValue.equals("immigrationRemovalCentre")) {
                 response.addError("You cannot update the detention location to a " +  detentionFacilityValue + " because this is an accelerated detained appeal.");
             }
+        }
+
+        if (callback.getPageId().equals(SUITABILITY_ATTENDANCE_PAGE_ID) && callback.getEvent() == Event.EDIT_APPEAL) {
+            boolean suitabilityHearingType = asylumCase.read(SUITABILITY_HEARING_TYPE_YES_OR_NO, YesOrNo.class).orElse(YesOrNo.NO).equals(YesOrNo.YES);
+
+            if (suitabilityHearingType) {
+                asylumCase.write(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_2, YesOrNo.NO);
+            } else {
+                asylumCase.write(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_1, YesOrNo.NO);
+            }
+
         }
 
         return response;

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealOutOfCountryEditAppealHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealOutOfCountryEditAppealHandlerTest.java
@@ -156,7 +156,7 @@ class AppealOutOfCountryEditAppealHandlerTest {
         verify(asylumCase, Mockito.times(1)).clear(CUSTODIAL_SENTENCE);
         verify(asylumCase, Mockito.times(1)).clear(IRC_NAME);
         verify(asylumCase, Mockito.times(1)).clear(PRISON_NAME);
-
+        clearAdaSuitabilityFields(asylumCase);
     }
 
     @ParameterizedTest
@@ -188,6 +188,7 @@ class AppealOutOfCountryEditAppealHandlerTest {
         verify(asylumCase, times(1)).read(
             OUT_OF_COUNTRY_DECISION_TYPE, OutOfCountryDecisionType.class);
         clearHumanRightsDecision(asylumCase);
+        clearAdaSuitabilityFields(asylumCase);
 
         verify(asylumCase, Mockito.times(1)).write(APPELLANT_IN_DETENTION, YesOrNo.NO);
         verify(asylumCase, Mockito.times(1)).clear(IS_ACCELERATED_DETAINED_APPEAL);
@@ -229,6 +230,7 @@ class AppealOutOfCountryEditAppealHandlerTest {
             OUT_OF_COUNTRY_DECISION_TYPE, OutOfCountryDecisionType.class);
         clearHumanRightsDecision(asylumCase);
         clearRefusalOfProtection(asylumCase);
+        clearAdaSuitabilityFields(asylumCase);
 
         verify(asylumCase, Mockito.times(1)).write(APPELLANT_IN_DETENTION, YesOrNo.NO);
         verify(asylumCase, Mockito.times(1)).clear(IS_ACCELERATED_DETAINED_APPEAL);
@@ -273,6 +275,7 @@ class AppealOutOfCountryEditAppealHandlerTest {
             OUT_OF_COUNTRY_DECISION_TYPE, OutOfCountryDecisionType.class);
         clearHumanRightsDecision(asylumCase);
         clearRefusalOfProtection(asylumCase);
+        clearAdaSuitabilityFields(asylumCase);
 
         verify(asylumCase, Mockito.times(1)).write(APPELLANT_IN_DETENTION, YesOrNo.NO);
         verify(asylumCase, Mockito.times(1)).clear(IS_ACCELERATED_DETAINED_APPEAL);
@@ -316,6 +319,7 @@ class AppealOutOfCountryEditAppealHandlerTest {
             OUT_OF_COUNTRY_DECISION_TYPE, OutOfCountryDecisionType.class);
         clearHumanRightsDecision(asylumCase);
         clearRefusalOfProtection(asylumCase);
+        clearAdaSuitabilityFields(asylumCase);
 
         verify(asylumCase, Mockito.times(1)).write(APPELLANT_IN_DETENTION, YesOrNo.NO);
         verify(asylumCase, Mockito.times(1)).clear(IS_ACCELERATED_DETAINED_APPEAL);
@@ -404,6 +408,14 @@ class AppealOutOfCountryEditAppealHandlerTest {
         verify(asylumCase, times(1)).clear(SPONSOR_AUTHORISATION);
         verify(asylumCase, times(1)).clear(SPONSOR_NAME_FOR_DISPLAY);
         verify(asylumCase, times(1)).clear(SPONSOR_ADDRESS_FOR_DISPLAY);
+    }
+
+    private void clearAdaSuitabilityFields(AsylumCase asylumCase) {
+        verify(asylumCase, times(1)).clear(SUITABILITY_HEARING_TYPE_YES_OR_NO);
+        verify(asylumCase, times(1)).clear(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_1);
+        verify(asylumCase, times(1)).clear(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_2);
+        verify(asylumCase, times(1)).clear(SUITABILITY_INTERPRETER_SERVICES_YES_OR_NO);
+        verify(asylumCase, times(1)).clear(SUITABILITY_INTERPRETER_SERVICES_LANGUAGE);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEventTest.java
@@ -46,6 +46,7 @@ class StartAppealMidEventTest {
     private static final String HOME_OFFICE_DECISION_PAGE_ID = "homeOfficeDecision";
     private static final String OUT_OF_COUNTRY_PAGE_ID = "outOfCountry";
     private static final String DETENTION_FACILITY_PAGE_ID = "detentionFacility";
+    private static final String SUITABILITY_ATTENDANCE_PAGE_ID = "suitabilityAppellantAttendance";
 
     @Mock
     private Callback<AsylumCase> callback;
@@ -303,5 +304,37 @@ class StartAppealMidEventTest {
         verify(asylumCase, times(1)).clear(SPONSOR_AUTHORISATION);
 
 
+    }
+
+    @Test
+    void should_write_no_value_for_appellant_attendance_2_field_when_hearing_type_is_yes() {
+        when(callback.getEvent()).thenReturn(Event.EDIT_APPEAL);
+        when(callback.getPageId()).thenReturn(SUITABILITY_ATTENDANCE_PAGE_ID);
+
+        when(asylumCase.read(SUITABILITY_HEARING_TYPE_YES_OR_NO, YesOrNo.class))
+            .thenReturn(Optional.of(YesOrNo.YES));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            startAppealMidEvent.handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        assertNotNull(callback);
+        assertEquals(asylumCase, callbackResponse.getData());
+        verify(asylumCase, times(1)).write(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_2, YesOrNo.NO);
+    }
+
+    @Test
+    void should_write_no_value_for_appellant_attendance_1_field_when_hearing_type_is_no() {
+        when(callback.getEvent()).thenReturn(Event.EDIT_APPEAL);
+        when(callback.getPageId()).thenReturn(SUITABILITY_ATTENDANCE_PAGE_ID);
+
+        when(asylumCase.read(SUITABILITY_HEARING_TYPE_YES_OR_NO, YesOrNo.class))
+            .thenReturn(Optional.of(YesOrNo.NO));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            startAppealMidEvent.handle(PreSubmitCallbackStage.MID_EVENT, callback);
+
+        assertNotNull(callback);
+        assertEquals(asylumCase, callbackResponse.getData());
+        verify(asylumCase, times(1)).write(SUITABILITY_APPELLANT_ATTENDANCE_YES_OR_NO_1, YesOrNo.NO);
     }
 }


### PR DESCRIPTION
…ty fields

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7520
https://tools.hmcts.net/jira/browse/RIA-7526

### Change description ###

Handling following scenarios:
- Edit between detained and non-detained -> Detained fields will be cleared including all suitability fields
- Edit between ADA and detained Non-ADA -> ADA fields will be cleared including all suitability fields
- Edit between Suitability screen 'Appellant attendance' Yes and No -> the 'Interpreter Services' fields should be cleared
- Edit between in-country and out of country appeal -> All in country fields will be cleared including the suitability fields

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
