### PR TITLE
RIA-7364 Add decideAnApplication event to document generation events

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandler.java
@@ -110,7 +110,8 @@ public class GenerateDocumentHandler implements PreSubmitCallbackHandler<AsylumC
             Event.MARK_APPEAL_PAID,
             Event.REQUEST_RESPONSE_REVIEW,
             Event.REQUEST_HEARING_REQUIREMENTS_FEATURE,
-            Event.MARK_APPEAL_AS_ADA
+            Event.MARK_APPEAL_AS_ADA,
+            Event.DECIDE_AN_APPLICATION
         );
         if (isEmStitchingEnabled) {
             allowedEvents.add(Event.SUBMIT_CASE);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/GenerateDocumentHandlerTest.java
@@ -308,7 +308,8 @@ class GenerateDocumentHandlerTest {
                         MARK_APPEAL_PAID,
                         REQUEST_RESPONSE_REVIEW,
                         REQUEST_HEARING_REQUIREMENTS_FEATURE,
-                        MARK_APPEAL_AS_ADA
+                        MARK_APPEAL_AS_ADA,
+                        DECIDE_AN_APPLICATION
                     ).contains(event)) {
 
                     assertTrue(canHandle);
@@ -412,7 +413,8 @@ class GenerateDocumentHandlerTest {
                         MARK_APPEAL_PAID,
                         REQUEST_RESPONSE_REVIEW,
                         REQUEST_HEARING_REQUIREMENTS_FEATURE,
-                        MARK_APPEAL_AS_ADA
+                        MARK_APPEAL_AS_ADA,
+                        DECIDE_AN_APPLICATION
                     );
 
                 if (callbackStage.equals(PreSubmitCallbackStage.ABOUT_TO_SUBMIT)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7364


### Change description ###
* Added decideAnApplication even to document generation events


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
