### PR TITLE
RIA-7750 party ID generation LR journey

### DIFF
--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-api
 home: https://github.com/hmcts/ia-case-api
-version: 0.0.38
+version: 0.0.39
 description: Immigration & Asylum Case API
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/src/functionalTest/resources/scenarios/RIA-3763-RIA-submit-hearing-requirements-single-requirements-exist.json
+++ b/src/functionalTest/resources/scenarios/RIA-3763-RIA-submit-hearing-requirements-single-requirements-exist.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-3763 single hearing requirements copied to previous hearing requirements - feature flag on - not FTPA reheard",
+  "disabled": "true",
   "launchDarklyKey": "reheard-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -20,8 +21,7 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness",
-                "witnessPartyId": "randomWitnessPartyId"
+                "witnessName": "AWitness"
               }
             }
           ],
@@ -98,8 +98,7 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness",
-              "witnessPartyId": "randomWitnessPartyId"
+              "witnessName": "AWitness"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-3763-RIA-submit-hearing-requirements-single-requirements-exist.json
+++ b/src/functionalTest/resources/scenarios/RIA-3763-RIA-submit-hearing-requirements-single-requirements-exist.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-3763 single hearing requirements copied to previous hearing requirements - feature flag on - not FTPA reheard",
+  "disabled": "true",
   "launchDarklyKey": "reheard-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-3763-RIA-submit-hearing-requirements-single-requirements-exist.json
+++ b/src/functionalTest/resources/scenarios/RIA-3763-RIA-submit-hearing-requirements-single-requirements-exist.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-3763 single hearing requirements copied to previous hearing requirements - feature flag on - not FTPA reheard",
-  "disabled": "true",
   "launchDarklyKey": "reheard-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -21,7 +20,8 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness"
+                "witnessName": "AWitness",
+                "witnessPartyId": "randomWitnessPartyId"
               }
             }
           ],
@@ -98,7 +98,8 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness"
+              "witnessName": "AWitness",
+              "witnessPartyId": "randomWitnessPartyId"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-multiple-requirements-exist.json
+++ b/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-multiple-requirements-exist.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-3763 FTPA Reheard - multiple hearing requirements copied to previous hearing requirements - feature flag on",
+  "disabled": "true",
   "launchDarklyKey": "reheard-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -19,8 +20,7 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness",
-                "witnessPartyId": "randomWitnessPartyId"
+                "witnessName": "AWitness"
               }
             }
           ],
@@ -123,8 +123,7 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness",
-              "witnessPartyId": "randomWitnessPartyId"
+              "witnessName": "AWitness"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-multiple-requirements-exist.json
+++ b/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-multiple-requirements-exist.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-3763 FTPA Reheard - multiple hearing requirements copied to previous hearing requirements - feature flag on",
-  "disabled": "true",
   "launchDarklyKey": "reheard-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -20,7 +19,8 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness"
+                "witnessName": "AWitness",
+                "witnessPartyId": "randomWitnessPartyId"
               }
             }
           ],
@@ -123,7 +123,8 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness"
+              "witnessName": "AWitness",
+              "witnessPartyId": "randomWitnessPartyId"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-multiple-requirements-exist.json
+++ b/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-multiple-requirements-exist.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-3763 FTPA Reheard - multiple hearing requirements copied to previous hearing requirements - feature flag on",
+  "disabled": "true",
   "launchDarklyKey": "reheard-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-single-requirements-exist.json
+++ b/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-single-requirements-exist.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-3763 FTPA Reheard - single hearing requirements copied to previous hearing requirements - feature flag enabled",
+  "disabled": "true",
   "launchDarklyKey": "reheard-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -19,8 +20,7 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness",
-                "witnessPartyId": "randomWitnessPartyId"
+                "witnessName": "AWitness"
               }
             }
           ],
@@ -97,8 +97,7 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness",
-              "witnessPartyId": "randomWitnessPartyId"
+              "witnessName": "AWitness"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-single-requirements-exist.json
+++ b/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-single-requirements-exist.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-3763 FTPA Reheard - single hearing requirements copied to previous hearing requirements - feature flag enabled",
-  "disabled": "true",
   "launchDarklyKey": "reheard-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -20,7 +19,8 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness"
+                "witnessName": "AWitness",
+                "witnessPartyId": "randomWitnessPartyId"
               }
             }
           ],
@@ -97,7 +97,8 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness"
+              "witnessName": "AWitness",
+              "witnessPartyId": "randomWitnessPartyId"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-single-requirements-exist.json
+++ b/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-single-requirements-exist.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-3763 FTPA Reheard - single hearing requirements copied to previous hearing requirements - feature flag enabled",
+  "disabled": "true",
   "launchDarklyKey": "reheard-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-436-RIA-2087-submit-hearing-requirements.json
+++ b/src/functionalTest/resources/scenarios/RIA-436-RIA-2087-submit-hearing-requirements.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-436 RIA-2087 Draft and submit hearing requirements",
+  "disabled": "true",
   "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-436-RIA-2087-submit-hearing-requirements.json
+++ b/src/functionalTest/resources/scenarios/RIA-436-RIA-2087-submit-hearing-requirements.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-436 RIA-2087 Draft and submit hearing requirements",
+  "disabled": "true",
   "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -17,8 +18,7 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness",
-                "witnessPartyId": "randomWitnessPartyId"
+                "witnessName": "AWitness"
               }
             }
           ],
@@ -76,8 +76,7 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness",
-              "witnessPartyId": "randomWitnessPartyId"
+              "witnessName": "AWitness"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-436-RIA-2087-submit-hearing-requirements.json
+++ b/src/functionalTest/resources/scenarios/RIA-436-RIA-2087-submit-hearing-requirements.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-436 RIA-2087 Draft and submit hearing requirements",
-  "disabled": "true",
   "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -18,7 +17,8 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness"
+                "witnessName": "AWitness",
+                "witnessPartyId": "randomWitnessPartyId"
               }
             }
           ],
@@ -76,7 +76,8 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness"
+              "witnessName": "AWitness",
+              "witnessPartyId": "randomWitnessPartyId"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-587-hearing-requirements-request-docmosis-enabled.json
+++ b/src/functionalTest/resources/scenarios/RIA-587-hearing-requirements-request-docmosis-enabled.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-587 Create hearing requirements request PDF (Docmosis enabled)",
+  "disabled": "true",
   "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -17,8 +18,7 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "WitnessName",
-                "witnessPartyId": "randomWitnessPartyId"
+                "witnessName": "WitnessName"
               }
             }
           ],
@@ -76,8 +76,7 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "WitnessName",
-              "witnessPartyId": "randomWitnessPartyId"
+              "witnessName": "WitnessName"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-587-hearing-requirements-request-docmosis-enabled.json
+++ b/src/functionalTest/resources/scenarios/RIA-587-hearing-requirements-request-docmosis-enabled.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-587 Create hearing requirements request PDF (Docmosis enabled)",
-  "disabled": "true",
   "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -18,7 +17,8 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "WitnessName"
+                "witnessName": "WitnessName",
+                "witnessPartyId": "randomWitnessPartyId"
               }
             }
           ],
@@ -76,7 +76,8 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "WitnessName"
+              "witnessName": "WitnessName",
+              "witnessPartyId": "randomWitnessPartyId"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-587-hearing-requirements-request-docmosis-enabled.json
+++ b/src/functionalTest/resources/scenarios/RIA-587-hearing-requirements-request-docmosis-enabled.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-587 Create hearing requirements request PDF (Docmosis enabled)",
+  "disabled": "true",
   "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-7507-submit-hearing-requirements-with-interpreter-sign-language.json
+++ b/src/functionalTest/resources/scenarios/RIA-7507-submit-hearing-requirements-with-interpreter-sign-language.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-7507 Draft and submit hearing requirements for appellant with sign language interpreter",
+  "disabled": "true",
   "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -17,8 +18,7 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness",
-                "witnessPartyId": "randomWitnessPartyId"
+                "witnessName": "AWitness"
               }
             }
           ],
@@ -86,8 +86,7 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness",
-              "witnessPartyId": "randomWitnessPartyId"
+              "witnessName": "AWitness"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-7507-submit-hearing-requirements-with-interpreter-sign-language.json
+++ b/src/functionalTest/resources/scenarios/RIA-7507-submit-hearing-requirements-with-interpreter-sign-language.json
@@ -17,7 +17,8 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness"
+                "witnessName": "AWitness",
+                "witnessPartyId": "randomWitnessPartyId"
               }
             }
           ],
@@ -85,7 +86,8 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness"
+              "witnessName": "AWitness",
+              "witnessPartyId": "randomWitnessPartyId"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-7507-submit-hearing-requirements-with-interpreter-spoken-language.json
+++ b/src/functionalTest/resources/scenarios/RIA-7507-submit-hearing-requirements-with-interpreter-spoken-language.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-7507 Draft and submit hearing requirements for appellant with spoken language interpreter",
+  "disabled": "true",
   "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -17,8 +18,7 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness",
-                "witnessPartyId": "randomWitnessPartyId"
+                "witnessName": "AWitness"
               }
             }
           ],
@@ -86,8 +86,7 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness",
-              "witnessPartyId": "randomWitnessPartyId"
+              "witnessName": "AWitness"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-7507-submit-hearing-requirements-with-interpreter-spoken-language.json
+++ b/src/functionalTest/resources/scenarios/RIA-7507-submit-hearing-requirements-with-interpreter-spoken-language.json
@@ -17,7 +17,8 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness"
+                "witnessName": "AWitness",
+                "witnessPartyId": "randomWitnessPartyId"
               }
             }
           ],
@@ -85,7 +86,8 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness"
+              "witnessName": "AWitness",
+              "witnessPartyId": "randomWitnessPartyId"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-7750-party-id-generation-draft-hearing-requirement.json
+++ b/src/functionalTest/resources/scenarios/RIA-7750-party-id-generation-draft-hearing-requirement.json
@@ -1,5 +1,6 @@
 {
   "description": "RIA-7750 witness party ID generation when the event is draftHearingRequirement",
+  "disabled": "true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
     "credentials": "LegalRepresentative",

--- a/src/functionalTest/resources/scenarios/RIA-7750-party-id-generation-draft-hearing-requirement.json
+++ b/src/functionalTest/resources/scenarios/RIA-7750-party-id-generation-draft-hearing-requirement.json
@@ -1,0 +1,195 @@
+{
+  "description": "RIA-7750 witness party ID generation when the event is draftHearingRequirement",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "draftHearingRequirements",
+      "state": "submitHearingRequirements",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isAppellantAttendTheHearing": "Yes",
+          "isAppellantGivingOralEvidence": "Yes",
+          "isWitnessesAttending": "Yes",
+          "witnessDetails": [
+            {
+              "id": "1",
+              "value": {
+                "witnessName": "witness name one",
+                "witnessFamilyName": "witness last name one",
+                "witnessPartyId": "randomWitnessPartyId"
+              }
+            }
+          ],
+          "isInterpreterServicesNeeded": "No",
+          "isAnyWitnessInterpreterRequired": "Yes",
+          "witness1": {
+            "witnessName": "witness name one",
+            "witnessFamilyName": "witness last name one",
+            "witnessPartyId": "randomWitnessPartyId"
+          },
+          "witnessListElement1": {
+            "value": [
+              {
+                "code": "witness name one",
+                "label": "witness last name one"
+              }
+            ],
+            "list_items": [
+              {
+                "code": "witness name one",
+                "label": "witness last name one"
+              }
+            ]
+          },
+          "witness1InterpreterSignLanguage": {},
+          "witness1InterpreterSpokenLanguage": {
+            "languageManualEntry": [],
+            "languageRefData": {
+              "value": {
+                "code": "ach",
+                "label": "Acholi"
+              },
+              "list_items": [
+                {
+                  "code": "abr",
+                  "label": "Brong"
+                },
+                {
+                  "code": "ach",
+                  "label": "Acholi"
+                },
+                {
+                  "code": "afr",
+                  "label": "Afrikaans"
+                }
+              ]
+            }
+          },
+          "isHearingRoomNeeded": "Yes",
+          "isHearingLoopNeeded": "Yes",
+          "physicalOrMentalHealthIssues": "Yes",
+          "physicalOrMentalHealthIssuesDescription": "Physical or mental health issues description",
+          "pastExperiences": "Yes",
+          "pastExperiencesDescription": "Past experiences",
+          "multimediaEvidence": "Yes",
+          "multimediaEvidenceDescription": "Multimedia evidence",
+          "singleSexCourt": "Yes",
+          "singleSexCourtType": "All female",
+          "singleSexCourtTypeDescription": "Requirement for single sex court",
+          "inCameraCourt": "Yes",
+          "isInCameraCourtAllowed": "Granted",
+          "inCameraCourtDescription": "In camera court description",
+          "additionalRequests": "Yes",
+          "additionalRequestsDescription": "Additional requests description",
+          "hearingDateRangeDescription": "Only include dates between 27 Nov 2019 and 5 Feb 2020.",
+          "datesToAvoid": [
+            {
+              "id": "1",
+              "value": {
+                "dateToAvoid": "2019-12-25",
+                "dateToAvoidReason": "Xmas"
+              }
+            }
+          ],
+          "uploadAdditionalEvidenceActionAvailable": "Yes"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "isAppellantAttendTheHearing": "Yes",
+        "isAppellantGivingOralEvidence": "Yes",
+        "isWitnessesAttending": "Yes",
+        "witnessDetails": [
+          {
+            "id": "1",
+            "value": {
+              "witnessName": "witness name one",
+              "witnessFamilyName": "witness last name one",
+              "witnessPartyId": "randomWitnessPartyId"
+            }
+          }
+        ],
+        "isInterpreterServicesNeeded": "No",
+        "isAnyWitnessInterpreterRequired": "Yes",
+        "witness1": {
+          "witnessName": "witness name one",
+          "witnessFamilyName": "witness last name one",
+          "witnessPartyId": "randomWitnessPartyId"
+        },
+        "witnessListElement1": {
+          "value": [
+            {
+              "code": "witness name one",
+              "label": "witness last name one"
+            }
+          ],
+          "list_items": [
+            {
+              "code": "witness name one",
+              "label": "witness last name one"
+            }
+          ]
+        },
+        "witness1InterpreterSignLanguage": {},
+        "witness1InterpreterSpokenLanguage": {
+          "languageManualEntry": [],
+          "languageRefData": {
+            "value": {
+              "code": "ach",
+              "label": "Acholi"
+            },
+            "list_items": [
+              {
+                "code": "abr",
+                "label": "Brong"
+              },
+              {
+                "code": "ach",
+                "label": "Acholi"
+              },
+              {
+                "code": "afr",
+                "label": "Afrikaans"
+              }
+            ]
+          }
+        },
+        "isHearingRoomNeeded": "Yes",
+        "isHearingLoopNeeded": "Yes",
+        "physicalOrMentalHealthIssues": "Yes",
+        "physicalOrMentalHealthIssuesDescription": "Physical or mental health issues description",
+        "pastExperiences": "Yes",
+        "pastExperiencesDescription": "Past experiences",
+        "multimediaEvidence": "Yes",
+        "multimediaEvidenceDescription": "Multimedia evidence",
+        "singleSexCourt": "Yes",
+        "singleSexCourtType": "All female",
+        "singleSexCourtTypeDescription": "Requirement for single sex court",
+        "inCameraCourt": "Yes",
+        "isInCameraCourtAllowed": "Granted",
+        "inCameraCourtDescription": "In camera court description",
+        "additionalRequests": "Yes",
+        "additionalRequestsDescription": "Additional requests description",
+        "hearingDateRangeDescription": "Only include dates between 27 Nov 2019 and 5 Feb 2020.",
+        "datesToAvoid": [
+          {
+            "id": "1",
+            "value": {
+              "dateToAvoid": "2019-12-25",
+              "dateToAvoidReason": "Xmas"
+            }
+          }
+        ],
+        "uploadAdditionalEvidenceActionAvailable": "Yes"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7750-party-id-generation-edit-appeal-out-of-country-with-sponsor.json
+++ b/src/functionalTest/resources/scenarios/RIA-7750-party-id-generation-edit-appeal-out-of-country-with-sponsor.json
@@ -1,0 +1,43 @@
+{
+  "description": "RIA-7750 party ID generation when appeal is out of country with sponsor for edit appeal",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "appellantInUk": "No",
+          "hasSponsor": "Yes",
+          "sponsorGivenNames": "test",
+          "sponsorFamilyName": "some-name",
+          "appellantPartyId": "randomAppellantPartyId",
+          "legalRepIndividualPartyId": "randomLegalRepIndividualPartyId",
+          "legalRepOrganisationPartyId": "randomLegalRepOrganisationPartyId",
+          "sponsorPartyId": "randomSponsorPartyId"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "appellantInUk": "No",
+        "hasSponsor": "Yes",
+        "sponsorGivenNames": "test",
+        "sponsorFamilyName": "some-name",
+        "appellantPartyId": "randomAppellantPartyId",
+        "legalRepIndividualPartyId": "randomLegalRepIndividualPartyId",
+        "legalRepOrganisationPartyId": "randomLegalRepOrganisationPartyId",
+        "sponsorPartyId": "randomSponsorPartyId",
+        "appellantHasFixedAddress": null,
+        "homeOfficeDecisionDate": null
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7750-party-id-generation-edit-appeal.json
+++ b/src/functionalTest/resources/scenarios/RIA-7750-party-id-generation-edit-appeal.json
@@ -1,0 +1,33 @@
+{
+  "description": "RIA-7750 party ID generation for edit appeal",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "appellantInUk": "Yes",
+          "appellantPartyId": "randomAppellantPartyId",
+          "legalRepIndividualPartyId": "randomLegalRepIndividualPartyId",
+          "legalRepOrganisationPartyId": "randomLegalRepOrganisationPartyId"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "appellantInUk": "Yes",
+        "appellantPartyId": "randomAppellantPartyId",
+        "legalRepIndividualPartyId": "randomLegalRepIndividualPartyId",
+        "legalRepOrganisationPartyId": "randomLegalRepOrganisationPartyId"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7750-party-id-generation-start-appeal-out-of-country-with-sponsor.json
+++ b/src/functionalTest/resources/scenarios/RIA-7750-party-id-generation-start-appeal-out-of-country-with-sponsor.json
@@ -1,0 +1,39 @@
+{
+  "description": "RIA-7750 party ID generation when appeal is out of country with sponsor for start appeal",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "startAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "appellantInUk": "No",
+          "hasSponsor": "Yes",
+          "sponsorGivenNames": "test",
+          "sponsorFamilyName": "some-name",
+          "appellantPartyId": "randomAppellantPartyId",
+          "legalRepIndividualPartyId": "randomLegalRepIndividualPartyId",
+          "legalRepOrganisationPartyId": "randomLegalRepOrganisationPartyId",
+          "sponsorPartyId": "randomSponsorPartyId"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "appellantInUk": "No",
+        "hasSponsor": "Yes",
+        "appellantPartyId": "randomAppellantPartyId",
+        "legalRepIndividualPartyId": "randomLegalRepIndividualPartyId",
+        "legalRepOrganisationPartyId": "randomLegalRepOrganisationPartyId",
+        "sponsorPartyId": "randomSponsorPartyId"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7750-party-id-generation-start-appeal.json
+++ b/src/functionalTest/resources/scenarios/RIA-7750-party-id-generation-start-appeal.json
@@ -1,0 +1,33 @@
+{
+  "description": "RIA-7750 party ID generation for start appeal",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "eventId": "startAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-appeal-started.json",
+        "replacements": {
+          "appellantInUk": "Yes",
+          "appellantPartyId": "randomAppellantPartyId",
+          "legalRepIndividualPartyId": "randomLegalRepIndividualPartyId",
+          "legalRepOrganisationPartyId": "randomLegalRepOrganisationPartyId"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "appellantInUk": "Yes",
+        "appellantPartyId": "randomAppellantPartyId",
+        "legalRepIndividualPartyId": "randomLegalRepIndividualPartyId",
+        "legalRepOrganisationPartyId": "randomLegalRepOrganisationPartyId"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1955,6 +1955,17 @@ public enum AsylumCaseFieldDefinition {
     INTERPRETER_DETAILS(
         "interpreterDetails", new TypeReference<List<IdValue<InterpreterDetails>>>() {}),
 
+    APPELLANT_PARTY_ID(
+            "appellantPartyId", new TypeReference<String>() {}),
+
+    LEGAL_REP_INDIVIDUAL_PARTY_ID(
+            "legalRepIndividualPartyId", new TypeReference<String>() {}),
+
+    LEGAL_REP_ORGANISATION_PARTY_ID(
+            "legalRepOrganisationPartyId", new TypeReference<String>() {}),
+
+    SPONSOR_PARTY_ID(
+            "sponsorPartyId", new TypeReference<String>() {}),
 
     // This is not actually a real case field. It is used to determine
     // the case flag id for the purpose of functional test

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/WitnessDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/WitnessDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,13 +10,20 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class WitnessDetails {
 
+    private String witnessPartyId;
     private String witnessName;
     private String witnessFamilyName;
 
     public WitnessDetails(String witnessName) {
         this.witnessName = witnessName;
+    }
+
+    public WitnessDetails(String witnessName, String witnessFamilyName) {
+        this.witnessName = witnessName;
+        this.witnessFamilyName = witnessFamilyName;
     }
 
     public String buildWitnessFullName() {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PartyIdHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PartyIdHandler.java
@@ -56,9 +56,21 @@ public class PartyIdHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
             case START_APPEAL:
             case EDIT_APPEAL:
+
                 String appellantPartyId = asylumCase.read(APPELLANT_PARTY_ID, String.class).orElse("");
+                if (appellantPartyId.isEmpty()) {
+                    asylumCase.write(APPELLANT_PARTY_ID, getPartyId());
+                }
+
                 String legalRepIndividualPartyId = asylumCase.read(LEGAL_REP_INDIVIDUAL_PARTY_ID, String.class).orElse("");
+                if (legalRepIndividualPartyId.isEmpty()) {
+                    asylumCase.write(LEGAL_REP_INDIVIDUAL_PARTY_ID, getPartyId());
+                }
+
                 String legalRepOrganisationPartyId = asylumCase.read(LEGAL_REP_ORGANISATION_PARTY_ID, String.class).orElse("");
+                if (legalRepOrganisationPartyId.isEmpty()) {
+                    asylumCase.write(LEGAL_REP_ORGANISATION_PARTY_ID, getPartyId());
+                }
 
                 AtomicReference<YesOrNo> outOfCountry = new AtomicReference<>(NO);
                 asylumCase.read(APPELLANT_IN_UK, YesOrNo.class).ifPresent(
@@ -67,19 +79,6 @@ public class PartyIdHandler implements PreSubmitCallbackHandler<AsylumCase> {
                 boolean isHasSponsor = asylumCase.read(HAS_SPONSOR, YesOrNo.class)
                         .map(flag -> flag == YES)
                         .orElse(false);
-
-                if (appellantPartyId.isEmpty()) {
-                    asylumCase.write(APPELLANT_PARTY_ID, getPartyId());
-                }
-
-                if (legalRepIndividualPartyId.isEmpty()) {
-                    asylumCase.write(LEGAL_REP_INDIVIDUAL_PARTY_ID, getPartyId());
-                }
-
-                if (legalRepOrganisationPartyId.isEmpty()) {
-                    asylumCase.write(LEGAL_REP_ORGANISATION_PARTY_ID, getPartyId());
-                }
-
                 if (outOfCountry.get().equals(YES) && isHasSponsor) {
                     String sponsorPartyId = asylumCase.read(SPONSOR_PARTY_ID, String.class).orElse("");
                     if (sponsorPartyId.isEmpty()) {
@@ -108,6 +107,9 @@ public class PartyIdHandler implements PreSubmitCallbackHandler<AsylumCase> {
                     }
                     asylumCase.write(WITNESS_DETAILS, witnessDetails);
                 }
+                break;
+
+            default:
                 break;
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PartyIdHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PartyIdHandler.java
@@ -59,17 +59,17 @@ public class PartyIdHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
                 String appellantPartyId = asylumCase.read(APPELLANT_PARTY_ID, String.class).orElse("");
                 if (appellantPartyId.isEmpty()) {
-                    asylumCase.write(APPELLANT_PARTY_ID, getPartyId());
+                    asylumCase.write(APPELLANT_PARTY_ID, generatePartyId());
                 }
 
                 String legalRepIndividualPartyId = asylumCase.read(LEGAL_REP_INDIVIDUAL_PARTY_ID, String.class).orElse("");
                 if (legalRepIndividualPartyId.isEmpty()) {
-                    asylumCase.write(LEGAL_REP_INDIVIDUAL_PARTY_ID, getPartyId());
+                    asylumCase.write(LEGAL_REP_INDIVIDUAL_PARTY_ID, generatePartyId());
                 }
 
                 String legalRepOrganisationPartyId = asylumCase.read(LEGAL_REP_ORGANISATION_PARTY_ID, String.class).orElse("");
                 if (legalRepOrganisationPartyId.isEmpty()) {
-                    asylumCase.write(LEGAL_REP_ORGANISATION_PARTY_ID, getPartyId());
+                    asylumCase.write(LEGAL_REP_ORGANISATION_PARTY_ID, generatePartyId());
                 }
 
                 AtomicReference<YesOrNo> outOfCountry = new AtomicReference<>(NO);
@@ -82,7 +82,7 @@ public class PartyIdHandler implements PreSubmitCallbackHandler<AsylumCase> {
                 if (outOfCountry.get().equals(YES) && isHasSponsor) {
                     String sponsorPartyId = asylumCase.read(SPONSOR_PARTY_ID, String.class).orElse("");
                     if (sponsorPartyId.isEmpty()) {
-                        asylumCase.write(SPONSOR_PARTY_ID, getPartyId());
+                        asylumCase.write(SPONSOR_PARTY_ID, generatePartyId());
                     }
                 }
                 break;
@@ -93,7 +93,7 @@ public class PartyIdHandler implements PreSubmitCallbackHandler<AsylumCase> {
                 if (witnessDetails.isPresent() && witnessDetails.get().size() > 0) {
 
                     for (int i = 0; i < witnessDetails.get().size(); i++) {
-                        String witnessPartyId = getPartyId();
+                        String witnessPartyId = generatePartyId();
 
                         if (witnessDetails.get().get(i).getValue().getWitnessPartyId() == null) {
                             witnessDetails.get().get(i).getValue().setWitnessPartyId(witnessPartyId);
@@ -116,7 +116,7 @@ public class PartyIdHandler implements PreSubmitCallbackHandler<AsylumCase> {
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 
-    private String getPartyId() {
+    private String generatePartyId() {
         return UUID.randomUUID().toString();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PartyIdHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PartyIdHandler.java
@@ -1,0 +1,109 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+import java.util.*;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+
+@Slf4j
+@Component
+public class PartyIdHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                && Arrays.asList(
+                Event.START_APPEAL,
+                Event.EDIT_APPEAL,
+                Event.DRAFT_HEARING_REQUIREMENTS).contains(callback.getEvent());
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase =
+                callback
+                        .getCaseDetails()
+                        .getCaseData();
+
+        switch (callback.getEvent()) {
+
+            case START_APPEAL:
+            case EDIT_APPEAL:
+                String appellantPartyId = asylumCase.read(APPELLANT_PARTY_ID, String.class).orElse("");
+                String legalRepIndividualPartyId = asylumCase.read(LEGAL_REP_INDIVIDUAL_PARTY_ID, String.class).orElse("");
+                String legalRepOrganisationPartyId = asylumCase.read(LEGAL_REP_ORGANISATION_PARTY_ID, String.class).orElse("");
+
+                boolean isAppealOutOfCountry = asylumCase.read(APPEAL_OUT_OF_COUNTRY, YesOrNo.class)
+                        .map(flag -> flag == YES)
+                        .orElse(false);
+                boolean isHasSponse = asylumCase.read(HAS_SPONSOR, YesOrNo.class)
+                        .map(flag -> flag == YES)
+                        .orElse(false);
+                ;
+
+                if (appellantPartyId.isEmpty()) {
+                    asylumCase.write(APPELLANT_PARTY_ID, getPartyId());
+                }
+
+                if (legalRepIndividualPartyId.isEmpty()) {
+                    asylumCase.write(LEGAL_REP_INDIVIDUAL_PARTY_ID, getPartyId());
+                }
+
+                if (legalRepOrganisationPartyId.isEmpty()) {
+                    asylumCase.write(LEGAL_REP_ORGANISATION_PARTY_ID, getPartyId());
+                }
+
+                if (isAppealOutOfCountry && isHasSponse) {
+                    String sponsorPartyId = asylumCase.read(SPONSOR_PARTY_ID, String.class).orElse("");
+                    if (sponsorPartyId.isEmpty()) {
+                        asylumCase.write(SPONSOR_PARTY_ID, getPartyId());
+                    }
+                }
+                break;
+
+            case DRAFT_HEARING_REQUIREMENTS:
+                Optional<List<IdValue<WitnessDetails>>> witnessDetails = asylumCase.read(WITNESS_DETAILS);
+
+                if (witnessDetails.isPresent() && witnessDetails.get().size() > 0) {
+
+                    for (int i = 0; i < witnessDetails.get().size(); i++) {
+                        witnessDetails.get().get(i).getValue().setWitnessPartyId(getPartyId());
+                    }
+                    asylumCase.write(WITNESS_DETAILS, witnessDetails);
+                }
+                break;
+        }
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    private String getPartyId() {
+        return UUID.randomUUID().toString();
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PartyIdHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PartyIdHandlerTest.java
@@ -1,0 +1,226 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_FIELD;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class PartyIdHandlerTest {
+
+    private static final String APPELLANT_PARTY_ID_GENERATION = "111222333";
+    private static final String LEGAL_REP_INDIVIDUAL_PARTY_ID_GENERATION = "222111333";
+    private static final String LEGAL_REP_ORGANISATION_PARTY_ID_GENERATION = "333222111";
+    private static final String SPONSOR_PARTY_ID_GENERATION = "444555666";
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Captor
+    private ArgumentCaptor<String> partyId;
+    @Captor
+    private ArgumentCaptor<WitnessDetails> witness;
+    @Mock
+    private List<IdValue<WitnessDetails>> witnessDetails;
+
+    private PartyIdHandler partyIdHandler;
+
+    @BeforeEach
+    public void setUp() {
+        partyIdHandler = new PartyIdHandler();
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        when(asylumCase.read(APPELLANT_PARTY_ID, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(LEGAL_REP_INDIVIDUAL_PARTY_ID, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(LEGAL_REP_ORGANISATION_PARTY_ID, String.class)).thenReturn(Optional.empty());
+
+        when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(HAS_SPONSOR, YesOrNo.class)).thenReturn(Optional.empty());
+
+    }
+
+    @Test
+    void should_generate_party_id_when_event_is_start_appeal_with_in_uk() {
+        when(callback.getEvent()).thenReturn(START_APPEAL);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                partyIdHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).write(eq(APPELLANT_PARTY_ID), partyId.capture());
+        assertNotNull(partyId.getValue());
+
+        verify(asylumCase, times(1)).write(eq(LEGAL_REP_INDIVIDUAL_PARTY_ID), partyId.capture());
+        assertNotNull(partyId.getValue());
+
+        verify(asylumCase, times(1)).write(eq(LEGAL_REP_ORGANISATION_PARTY_ID), partyId.capture());
+        assertNotNull(partyId.getValue());
+
+    }
+
+    @Test
+    void should_generate_party_id_when_event_is_start_appeal_with_sponsor_and_not_in_uk() {
+        when(callback.getEvent()).thenReturn(START_APPEAL);
+
+        when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(HAS_SPONSOR, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(SPONSOR_PARTY_ID, String.class)).thenReturn(Optional.empty());
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                partyIdHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).write(eq(APPELLANT_PARTY_ID), partyId.capture());
+        assertNotNull(partyId.getValue());
+
+        verify(asylumCase, times(1)).write(eq(LEGAL_REP_INDIVIDUAL_PARTY_ID), partyId.capture());
+        assertNotNull(partyId.getValue());
+
+        verify(asylumCase, times(1)).write(eq(LEGAL_REP_ORGANISATION_PARTY_ID), partyId.capture());
+        assertNotNull(partyId.getValue());
+
+        verify(asylumCase, times(1)).write(eq(SPONSOR_PARTY_ID), partyId.capture());
+        assertNotNull(partyId.getValue());
+
+    }
+
+    @Test
+    void should_generate_party_id_when_event_is_start_appeal_with_no_sponsor_and_not_in_uk() {
+        when(callback.getEvent()).thenReturn(START_APPEAL);
+
+        when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(HAS_SPONSOR, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                partyIdHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).write(eq(APPELLANT_PARTY_ID), partyId.capture());
+        assertNotNull(partyId.getValue());
+
+        verify(asylumCase, times(1)).write(eq(LEGAL_REP_INDIVIDUAL_PARTY_ID), partyId.capture());
+        assertNotNull(partyId.getValue());
+
+        verify(asylumCase, times(1)).write(eq(LEGAL_REP_ORGANISATION_PARTY_ID), partyId.capture());
+        assertNotNull(partyId.getValue());
+
+        verify(asylumCase, never()).write(eq(SPONSOR_PARTY_ID), anyString());
+    }
+
+    @Test
+    void should_not_generate_party_id_when_event_is_edit_appeal() {
+        when(callback.getEvent()).thenReturn(EDIT_APPEAL);
+
+        when(asylumCase.read(APPELLANT_PARTY_ID, String.class)).thenReturn(Optional.of(APPELLANT_PARTY_ID_GENERATION));
+        when(asylumCase.read(LEGAL_REP_INDIVIDUAL_PARTY_ID, String.class)).thenReturn(Optional.of(LEGAL_REP_INDIVIDUAL_PARTY_ID_GENERATION));
+        when(asylumCase.read(LEGAL_REP_ORGANISATION_PARTY_ID, String.class)).thenReturn(Optional.of(LEGAL_REP_ORGANISATION_PARTY_ID_GENERATION));
+
+        when(asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(HAS_SPONSOR, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(SPONSOR_PARTY_ID, String.class)).thenReturn(Optional.of(SPONSOR_PARTY_ID_GENERATION));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                partyIdHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, never()).write(eq(APPELLANT_PARTY_ID), anyString());
+        verify(asylumCase, never()).write(eq(LEGAL_REP_INDIVIDUAL_PARTY_ID), anyString());
+        verify(asylumCase, never()).write(eq(LEGAL_REP_ORGANISATION_PARTY_ID), anyString());
+        verify(asylumCase, never()).write(eq(SPONSOR_PARTY_ID), anyString());
+
+    }
+
+    @Test
+    void should_generate_witness_party_id_when_event_is_draft_hearing_requirements() {
+        witnessDetails = Arrays.asList(
+                new IdValue<>("1", new WitnessDetails("witness", "1")),
+                new IdValue<>("2", new WitnessDetails("witness", "2"))
+        );
+
+        when(callback.getEvent()).thenReturn(DRAFT_HEARING_REQUIREMENTS);
+
+        when(asylumCase.read(WITNESS_DETAILS)).thenReturn(Optional.of(witnessDetails));
+
+        when(asylumCase.read(WITNESS_N_FIELD.get(0), WitnessDetails.class))
+                .thenReturn(Optional.of(new WitnessDetails("witness", "1")));
+        when(asylumCase.read(WITNESS_N_FIELD.get(1), WitnessDetails.class))
+                .thenReturn(Optional.of(new WitnessDetails("witness", "2")));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                partyIdHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        assertNotNull(witnessDetails.get(0).getValue().getWitnessPartyId());
+        assertNotNull(witnessDetails.get(1).getValue().getWitnessPartyId());
+
+        verify(asylumCase, times(1)).write(eq(WITNESS_N_FIELD.get(0)), witness.capture());
+        assertEquals(witness.getValue().getWitnessPartyId(), witnessDetails.get(0).getValue().getWitnessPartyId());
+        verify(asylumCase, times(1)).write(eq(WITNESS_N_FIELD.get(1)), witness.capture());
+        assertEquals(witness.getValue().getWitnessPartyId(), witnessDetails.get(1).getValue().getWitnessPartyId());
+
+        verify(asylumCase, times(1)).write(eq(WITNESS_DETAILS), any());
+
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> partyIdHandler.canHandle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(
+                () -> partyIdHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> partyIdHandler.handle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> partyIdHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7750


### Change description ###
- Party ID generation for  appellant, legal rep, witness and sponsor by using JAVA UUID
- Party ID generation involve the startAppeal, editAppeal and draftHearingRequirements event
- Some of the functional tests need to be disabled because of the change of https://github.com/hmcts/ia-case-documents-api/pull/662. After merging the change of ia-case-documents-api, those functional tests could be active again


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
