### PR TITLE
RIA-7699 - Fix for empty fields being present after Review Hearing req…

### DIFF
--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-api
 home: https://github.com/hmcts/ia-case-api
-version: 0.0.38
+version: 0.0.39
 description: Immigration & Asylum Case API
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/src/functionalTest/resources/scenarios/RIA-7699-Update-interpreter-booking-status-about-to-start.json
+++ b/src/functionalTest/resources/scenarios/RIA-7699-Update-interpreter-booking-status-about-to-start.json
@@ -10,6 +10,10 @@
       "caseData": {
         "template": "minimal-appeal-submitted.json",
         "replacements": {
+          "appellantInterpreterLanguageCategory": [
+            "signLanguageInterpreter",
+            "spokenLanguageInterpreter"
+          ],
           "witnessDetails": [
             {
               "id": "1",

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateInterpreterBookingStatusPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateInterpreterBookingStatusPreparer.java
@@ -161,11 +161,7 @@ public class UpdateInterpreterBookingStatusPreparer implements PreSubmitCallback
         Optional<List<String>> languageCategoriesOptional = asylumCase
             .read(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY);
 
-        if (!languageCategoriesOptional.isPresent()) {
-            return;
-        }
-
-        if (languageCategoriesOptional.get().contains(SPOKEN_LANGUAGE_INTERPRETER)) {
+        if (languageCategoriesOptional.isPresent() && languageCategoriesOptional.get().contains(SPOKEN_LANGUAGE_INTERPRETER)) {
             populateBookingStatusFieldsForAppellant(
                 APPELLANT_INTERPRETER_SPOKEN_LANGUAGE,
                 APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING,
@@ -176,7 +172,7 @@ public class UpdateInterpreterBookingStatusPreparer implements PreSubmitCallback
                 APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS);
         }
 
-        if (languageCategoriesOptional.get().contains(SIGN_LANGUAGE_INTERPRETER)) {
+        if (languageCategoriesOptional.isPresent() && languageCategoriesOptional.get().contains(SIGN_LANGUAGE_INTERPRETER)) {
             populateBookingStatusFieldsForAppellant(
                 APPELLANT_INTERPRETER_SIGN_LANGUAGE,
                 APPELLANT_INTERPRETER_SIGN_LANGUAGE_BOOKING,

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateInterpreterBookingStatusPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateInterpreterBookingStatusPreparer.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_LANGUAGE_CATEGORY;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_SIGN_LANGUAGE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_SIGN_LANGUAGE_BOOKING;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS;
@@ -91,6 +92,8 @@ import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
 public class UpdateInterpreterBookingStatusPreparer implements PreSubmitCallbackHandler<AsylumCase> {
+    public static final String SPOKEN_LANGUAGE_INTERPRETER = "spokenLanguageInterpreter";
+    public static final String SIGN_LANGUAGE_INTERPRETER = "signLanguageInterpreter";
     public static String APPELLANT = "Appellant";
     public static String WITNESS = "Witness";
     private AsylumCase asylumCase;
@@ -125,24 +128,44 @@ public class UpdateInterpreterBookingStatusPreparer implements PreSubmitCallback
         List<IdValue<WitnessDetails>> witnessesDetails = optionalWitnesses.orElse(Collections.emptyList());
 
         WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.forEach(language -> {
-            if (!asylumCase.read(language).isPresent()) {
+            if (isInterpreterPresent(language)) {
+                populateSpokenLanguageBookingStatusFieldsForWitness(language, witnessesDetails);
+            } else {
                 clearSpokenLanguageBookingStatusFieldsForWitness(language);
-                return;
             }
-            populateSpokenLanguageBookingStatusFieldsForWitness(language, witnessesDetails);
+
         });
 
         WITNESS_N_INTERPRETER_SIGN_LANGUAGE.forEach(language -> {
-            if (!asylumCase.read(language).isPresent()) {
+            if (isInterpreterPresent(language)) {
+                populateSignLanguageBookingStatusFieldsForWitness(language, witnessesDetails);
+            } else {
                 clearSignLanguageBookingStatusFieldsForWitness(language);
-                return;
             }
-            populateSignLanguageBookingStatusFieldsForWitness(language, witnessesDetails);
+
         });
     }
 
+    /**
+     * It is required to do null checks for the inner fields (languageRefData and languageManualEntryDescription) as well,
+     * as there appears to be a CCD bug where it creates empty interpreter language fields in the Review Hearing Requirements
+     * event which caused by COMPLEX type fields being set as READONLY.
+     */
+    private boolean isInterpreterPresent(AsylumCaseFieldDefinition language) {
+        return asylumCase.read(language).isPresent()
+            && (((InterpreterLanguageRefData) asylumCase.read(language).get()).getLanguageRefData() != null
+            || ((InterpreterLanguageRefData) asylumCase.read(language).get()).getLanguageManualEntryDescription() != null);
+    }
+
     private void populateOrClearAppellantSignAndSpokenInterpreterBookingFields() {
-        if (asylumCase.read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE).isPresent()) {
+        Optional<List<String>> languageCategoriesOptional = asylumCase
+            .read(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY);
+
+        if (!languageCategoriesOptional.isPresent()) {
+            return;
+        }
+
+        if (languageCategoriesOptional.get().contains(SPOKEN_LANGUAGE_INTERPRETER)) {
             populateBookingStatusFieldsForAppellant(
                 APPELLANT_INTERPRETER_SPOKEN_LANGUAGE,
                 APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING,
@@ -153,7 +176,7 @@ public class UpdateInterpreterBookingStatusPreparer implements PreSubmitCallback
                 APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING_STATUS);
         }
 
-        if (asylumCase.read(APPELLANT_INTERPRETER_SIGN_LANGUAGE).isPresent()) {
+        if (languageCategoriesOptional.get().contains(SIGN_LANGUAGE_INTERPRETER)) {
             populateBookingStatusFieldsForAppellant(
                 APPELLANT_INTERPRETER_SIGN_LANGUAGE,
                 APPELLANT_INTERPRETER_SIGN_LANGUAGE_BOOKING,

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateInterpreterBookingStatusPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateInterpreterBookingStatusPreparerTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -9,6 +11,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_LANGUAGE_CATEGORY;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_SIGN_LANGUAGE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_SIGN_LANGUAGE_BOOKING;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_INTERPRETER_SIGN_LANGUAGE_BOOKING_STATUS;
@@ -78,6 +81,9 @@ class UpdateInterpreterBookingStatusPreparerTest {
             Collections.emptyList(),
             "test manual language");
 
+        List<String> languageCategories = Arrays.asList("spokenLanguageInterpreter", "signLanguageInterpreter");
+
+        when(asylumCase.read(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategories));
         when(asylumCase.read(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE)).thenReturn(Optional.of(appellantSpokenRefData));
         when(asylumCase.read(APPELLANT_INTERPRETER_SIGN_LANGUAGE)).thenReturn(Optional.of(appellantSignRefData));
         when(asylumCase.read(APPELLANT_NAME_FOR_DISPLAY)).thenReturn(Optional.of("Test Appellant"));
@@ -112,6 +118,8 @@ class UpdateInterpreterBookingStatusPreparerTest {
 
     @Test
     void should_clear_appellant_interpreter_booking_status_fields_if_language_fields_not_set() {
+        when(asylumCase.read(APPELLANT_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(new ArrayList<>()));
+
         updateInterpreterBookingStatusPreparer.handle(ABOUT_TO_START, callback);
 
         verify(asylumCase).clear(eq(APPELLANT_INTERPRETER_SPOKEN_LANGUAGE_BOOKING));


### PR DESCRIPTION
It is required to do null checks for the inner fields as there appears to be a CCD bug where it creates empty interpreter language fields in the Review Hearing Requirements event which caused by COMPLEX type fields being set as READONLY.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
