### PR TITLE
RIA-7752 party ID generation AIP journey

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -26,6 +26,7 @@
         <cve>CVE-2023-35116</cve>
         <cve>CVE-2023-2976</cve>
         <cve>CVE-2023-34981</cve>
+        <cve>CVE-2023-41080</cve>
     </suppress>
     <suppress>
         <cve>CVE-2023-20883</cve>

--- a/src/functionalTest/resources/scenarios/RIA-3763-RIA-submit-hearing-requirements-single-requirements-exist.json
+++ b/src/functionalTest/resources/scenarios/RIA-3763-RIA-submit-hearing-requirements-single-requirements-exist.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-3763 single hearing requirements copied to previous hearing requirements - feature flag on - not FTPA reheard",
-  "disabled": "true",
   "launchDarklyKey": "reheard-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-multiple-requirements-exist.json
+++ b/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-multiple-requirements-exist.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-3763 FTPA Reheard - multiple hearing requirements copied to previous hearing requirements - feature flag on",
-  "disabled": "true",
   "launchDarklyKey": "reheard-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-single-requirements-exist.json
+++ b/src/functionalTest/resources/scenarios/RIA-3763-submit-reheard-hearing-requirements-single-requirements-exist.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-3763 FTPA Reheard - single hearing requirements copied to previous hearing requirements - feature flag enabled",
-  "disabled": "true",
   "launchDarklyKey": "reheard-feature:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-436-RIA-2087-submit-hearing-requirements.json
+++ b/src/functionalTest/resources/scenarios/RIA-436-RIA-2087-submit-hearing-requirements.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-436 RIA-2087 Draft and submit hearing requirements",
-  "disabled": "true",
   "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-587-hearing-requirements-request-docmosis-enabled.json
+++ b/src/functionalTest/resources/scenarios/RIA-587-hearing-requirements-request-docmosis-enabled.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-587 Create hearing requirements request PDF (Docmosis enabled)",
-  "disabled": "true",
   "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-7507-submit-hearing-requirements-with-interpreter-sign-language.json
+++ b/src/functionalTest/resources/scenarios/RIA-7507-submit-hearing-requirements-with-interpreter-sign-language.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-7507 Draft and submit hearing requirements for appellant with sign language interpreter",
-  "disabled": "true",
   "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-7507-submit-hearing-requirements-with-interpreter-spoken-language.json
+++ b/src/functionalTest/resources/scenarios/RIA-7507-submit-hearing-requirements-with-interpreter-spoken-language.json
@@ -1,6 +1,5 @@
 {
   "description": "RIA-7507 Draft and submit hearing requirements for appellant with spoken language interpreter",
-  "disabled": "true",
   "enabled": "{$featureFlag.isSubmitHearingRequirementsEnabled}",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",

--- a/src/functionalTest/resources/scenarios/RIA-7752-aip-party-id-generation-edit-appeal-out-of-country-with-sponsor.json
+++ b/src/functionalTest/resources/scenarios/RIA-7752-aip-party-id-generation-edit-appeal-out-of-country-with-sponsor.json
@@ -1,0 +1,36 @@
+{
+  "description": "RIA-7752 AIP journey party ID generation when appeal is out of country with sponsor for edit appeal",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Citizen",
+    "input": {
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json",
+        "replacements": {
+          "appellantInUk": "No",
+          "journeyType": "aip",
+          "hasSponsor": "Yes",
+          "sponsorGivenNames": "test",
+          "sponsorFamilyName": "some-name"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json",
+      "replacements": {
+        "appellantInUk": "No",
+        "journeyType": "aip",
+        "hasSponsor": "Yes",
+        "sendDirectionActionAvailable": "No",
+        "appellantPartyId": "$/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-Ff]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/",
+        "sponsorPartyId": "$/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-Ff]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7752-aip-party-id-generation-edit-appeal.json
+++ b/src/functionalTest/resources/scenarios/RIA-7752-aip-party-id-generation-edit-appeal.json
@@ -1,0 +1,31 @@
+{
+  "description": "RIA-7752 AIP journey party ID generation for edit appeal",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Citizen",
+    "input": {
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json",
+        "replacements": {
+          "appellantInUk": "Yes",
+          "journeyType": "aip"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json",
+      "replacements": {
+        "appellantInUk": "Yes",
+        "journeyType": "aip",
+        "sendDirectionActionAvailable": "No",
+        "appellantPartyId": "$/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-Ff]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7752-aip-party-id-generation-start-appeal-out-of-country-with-sponsor.json
+++ b/src/functionalTest/resources/scenarios/RIA-7752-aip-party-id-generation-start-appeal-out-of-country-with-sponsor.json
@@ -1,0 +1,37 @@
+{
+  "description": "RIA-7752 AIP journey party ID generation when appeal is out of country with sponsor for start appeal",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Citizen",
+    "input": {
+      "eventId": "startAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json",
+        "replacements": {
+          "appellantInUk": "No",
+          "journeyType": "aip",
+          "hasSponsor": "Yes",
+          "sponsorGivenNames": "test",
+          "sponsorFamilyName": "some-name"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json",
+      "replacements": {
+        "appellantInUk": "No",
+        "journeyType": "aip",
+        "hasSponsor": "Yes",
+        "appealReferenceNumber": "DRAFT",
+        "sendDirectionActionAvailable": "No",
+        "appellantPartyId": "$/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-Ff]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/",
+        "sponsorPartyId": "$/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-Ff]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7752-aip-party-id-generation-start-appeal.json
+++ b/src/functionalTest/resources/scenarios/RIA-7752-aip-party-id-generation-start-appeal.json
@@ -1,0 +1,32 @@
+{
+  "description": "RIA-7752 AIP journey party ID generation for start appeal",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Citizen",
+    "input": {
+      "eventId": "startAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-aip-appeal-submitted.json",
+        "replacements": {
+          "appellantInUk": "Yes",
+          "journeyType": "aip"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-aip-appeal-submitted.json",
+      "replacements": {
+        "appellantInUk": "Yes",
+        "journeyType": "aip",
+        "appealReferenceNumber": "DRAFT",
+        "sendDirectionActionAvailable": "No",
+        "appellantPartyId": "$/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-Ff]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealOutOfCountryEditAppealAipHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealOutOfCountryEditAppealAipHandler.java
@@ -39,6 +39,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_GIVEN_NAMES;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_MOBILE_NUMBER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_NAME_FOR_DISPLAY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_PARTY_ID;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_SUBSCRIPTIONS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SUBSCRIPTIONS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.UPLOAD_THE_NOTICE_OF_DECISION_DOCS;
@@ -319,6 +320,7 @@ public class AppealOutOfCountryEditAppealAipHandler implements PreSubmitCallback
         asylumCase.clear(SPONSOR_AUTHORISATION);
         asylumCase.clear(SPONSOR_NAME_FOR_DISPLAY);
         asylumCase.clear(SPONSOR_ADDRESS_FOR_DISPLAY);
+        asylumCase.clear(SPONSOR_PARTY_ID);
     }
 
     private void clearAipDecisionType(AsylumCase asylumCase) {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealOutOfCountryEditAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealOutOfCountryEditAppealHandler.java
@@ -26,6 +26,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_GIVEN_NAMES;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_MOBILE_NUMBER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_NAME_FOR_DISPLAY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_PARTY_ID;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
@@ -140,6 +141,7 @@ public class AppealOutOfCountryEditAppealHandler implements PreSubmitCallbackHan
         asylumCase.clear(SPONSOR_AUTHORISATION);
         asylumCase.clear(SPONSOR_NAME_FOR_DISPLAY);
         asylumCase.clear(SPONSOR_ADDRESS_FOR_DISPLAY);
+        asylumCase.clear(SPONSOR_PARTY_ID);
     }
 
     private void clearOutOfCountryDecision(AsylumCase asylumCase) {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PartyIdHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PartyIdHandler.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.HearingPartyIdGenerator;
 
@@ -72,12 +73,14 @@ public class PartyIdHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
     private void setLegalRepPartyId(AsylumCase asylumCase) {
 
-        if (asylumCase.read(LEGAL_REP_INDIVIDUAL_PARTY_ID, String.class).orElse("").isEmpty()) {
-            asylumCase.write(LEGAL_REP_INDIVIDUAL_PARTY_ID, HearingPartyIdGenerator.generate());
-        }
+        if (!HandlerUtils.isAipJourney(asylumCase)) {
+            if (asylumCase.read(LEGAL_REP_INDIVIDUAL_PARTY_ID, String.class).orElse("").isEmpty()) {
+                asylumCase.write(LEGAL_REP_INDIVIDUAL_PARTY_ID, HearingPartyIdGenerator.generate());
+            }
 
-        if (asylumCase.read(LEGAL_REP_ORGANISATION_PARTY_ID, String.class).orElse("").isEmpty()) {
-            asylumCase.write(LEGAL_REP_ORGANISATION_PARTY_ID, HearingPartyIdGenerator.generate());
+            if (asylumCase.read(LEGAL_REP_ORGANISATION_PARTY_ID, String.class).orElse("").isEmpty()) {
+                asylumCase.write(LEGAL_REP_ORGANISATION_PARTY_ID, HearingPartyIdGenerator.generate());
+            }
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealOutOfCountryEditAppealAipHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealOutOfCountryEditAppealAipHandlerTest.java
@@ -514,6 +514,7 @@ class AppealOutOfCountryEditAppealAipHandlerTest {
         verify(asylumCase, times(1)).clear(SPONSOR_MOBILE_NUMBER);
         verify(asylumCase, times(1)).clear(AIP_SPONSOR_MOBILE_NUMBER_FOR_DISPLAY);
         verify(asylumCase, times(1)).clear(SPONSOR_AUTHORISATION);
+        verify(asylumCase, times(1)).clear(SPONSOR_PARTY_ID);
     }
 
     private void verifyUnclearedFields(AsylumCase asylumCase) {

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealOutOfCountryEditAppealHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppealOutOfCountryEditAppealHandlerTest.java
@@ -33,6 +33,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_GIVEN_NAMES;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_MOBILE_NUMBER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_NAME_FOR_DISPLAY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SPONSOR_PARTY_ID;
 
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -354,6 +355,7 @@ class AppealOutOfCountryEditAppealHandlerTest {
         verify(asylumCase, times(1)).clear(SPONSOR_AUTHORISATION);
         verify(asylumCase, times(1)).clear(SPONSOR_NAME_FOR_DISPLAY);
         verify(asylumCase, times(1)).clear(SPONSOR_ADDRESS_FOR_DISPLAY);
+        verify(asylumCase, times(1)).clear(SPONSOR_PARTY_ID);
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7752


### Change description ###
- Party ID generation for appellant and sponsor by using JAVA UUID when the appeal is AIP journey
- Add the unit test for AIP journey
- Resume the functional tests of "draftHearingRequirement" event because the PR of https://github.com/hmcts/ia-case-documents-api/pull/662 has been merged to branch
- Temporarily suppress the CVE problem


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
