### PR TITLE
SNI-4584 fix duplicate end appeal events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -297,6 +297,12 @@ dependencyManagement {
             entry 'json-smart'
         }
 
+        //CVE-2023-41080
+        dependencySet(group: 'org.apache.tomcat.embed', version: '10.1.13') {
+            entry 'tomcat-embed-core'
+            entry 'tomcat-embed-websocket'
+        }
+
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -297,12 +297,6 @@ dependencyManagement {
             entry 'json-smart'
         }
 
-        //CVE-2023-41080
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.8') {
-            entry 'tomcat-embed-core'
-            entry 'tomcat-embed-websocket'
-        }
-
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -298,7 +298,7 @@ dependencyManagement {
         }
 
         //CVE-2023-41080
-        dependencySet(group: 'org.apache.tomcat.embed', version: '10.1.13') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.8') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-websocket'
         }

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,5 +20,6 @@
     <suppress until="2023-09-30">
         <notes>Temporarily suppress vulnerability as no current fix</notes>
         <cve>CVE-2023-35116</cve>
+        <cve>CVE-2023-41080</cve>
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandler.java
@@ -68,7 +68,7 @@ public class EndAppealHandler implements PreSubmitCallbackHandler<AsylumCase> {
         if (callback.getEvent() == Event.END_APPEAL_AUTOMATICALLY) {
             if (paymentStatus == PaymentStatus.PAID) {
                 throw new IllegalStateException("Cannot auto end appeal as the payment is already made!");
-            } else if(callback.getCaseDetails().getState() == State.ENDED) {
+            } else if (callback.getCaseDetails().getState() == State.ENDED) {
                 throw new IllegalStateException("Appeal has already been ended!");
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandler.java
@@ -75,6 +75,7 @@ public class EndAppealHandler implements PreSubmitCallbackHandler<AsylumCase> {
                     && callback.getCaseDetails().getState() == State.ENDED) {
                 throw new IllegalStateException("Appeal has already been ended!");
             }
+        }
 
         asylumCase.write(END_APPEAL_DATE, dateProvider.now().toString());
         asylumCase.write(RECORD_APPLICATION_ACTION_DISABLED, YesOrNo.YES);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandler.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
@@ -65,14 +64,11 @@ public class EndAppealHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
         PaymentStatus paymentStatus = asylumCase.read(PAYMENT_STATUS, PaymentStatus.class)
                 .orElse(PaymentStatus.PAYMENT_PENDING);
-        final Optional<State> stateBeforeEndAppeal = asylumCase.read(STATE_BEFORE_END_APPEAL, State.class);
 
         if (callback.getEvent() == Event.END_APPEAL_AUTOMATICALLY) {
             if (paymentStatus == PaymentStatus.PAID) {
                 throw new IllegalStateException("Cannot auto end appeal as the payment is already made!");
-            } else if (stateBeforeEndAppeal.isPresent()
-                    && stateBeforeEndAppeal.get() == State.PENDING_PAYMENT
-                    && callback.getCaseDetails().getState() == State.ENDED) {
+            } else if(callback.getCaseDetails().getState() == State.ENDED) {
                 throw new IllegalStateException("Appeal has already been ended!");
             }
         }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandlerTest.java
@@ -155,7 +155,7 @@ class EndAppealHandlerTest {
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(callback.getEvent()).thenReturn(Event.END_APPEAL);
+        when(callback.getEvent()).thenReturn(Event.END_APPEAL_AUTOMATICALLY);
         when(caseDetails.getState()).thenReturn(State.ENDED);
 
         assertThatThrownBy(() -> endAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EndAppealHandlerTest.java
@@ -151,6 +151,19 @@ class EndAppealHandlerTest {
     }
 
     @Test
+    void should_throw_exception_if_state_is_already_ended() {
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.END_APPEAL);
+        when(caseDetails.getState()).thenReturn(State.ENDED);
+
+        assertThatThrownBy(() -> endAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+                .hasMessage("Appeal has already been ended!")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
     void handling_should_throw_if_cannot_actually_handle() {
         assertThatThrownBy(() -> endAppealHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
             .hasMessage("Cannot handle callback")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SNI-4584


### Change description ###
Do not trigger "endAppealAutomatically" case event if the appeal is already ended (when payment status is pending)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
