### PR TITLE
RIA-7869 Allow unique identifying of flags based off witnesses

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7480-review-add-in-private-flag.json
+++ b/src/functionalTest/resources/scenarios/RIA-7480-review-add-in-private-flag.json
@@ -148,7 +148,7 @@
                 "name": "Evidence given in private",
                 "status": "Active",
                 "flagCode": "SM0004",
-                "hearingRelevant": "No"
+                "hearingRelevant": "Yes"
               }
             }
           ]

--- a/src/functionalTest/resources/scenarios/RIA-7483-7579-appellant-witness-case-level-case-flags.json
+++ b/src/functionalTest/resources/scenarios/RIA-7483-7579-appellant-witness-case-level-case-flags.json
@@ -16,8 +16,58 @@
             {
               "id": "1",
               "value": {
-                "witnessName": "AWitness",
-                "witnessFamilyName": "AFamilyName"
+                "witnessPartyId": "partyId1",
+                "witnessName": "AWitness1",
+                "witnessFamilyName": "AFamilyName1"
+              }
+            },
+            {
+              "id": "2",
+              "value": {
+                "witnessPartyId": "partyId2",
+                "witnessName": "AWitness2",
+                "witnessFamilyName": "AFamilyName2"
+              }
+            },
+            {
+              "id": "3",
+              "value": {
+                "witnessPartyId": "partyId3",
+                "witnessName": "AWitness3",
+                "witnessFamilyName": "AFamilyName3"
+              }
+            },
+            {
+              "id": "4",
+              "value": {
+                "witnessName": "AWitness4",
+                "witnessFamilyName": "AFamilyName4"
+              }
+            }
+          ],
+          "witnessLevelFlags": [
+            {
+              "id": "partyId1",
+              "value": {
+                "partyName": "AWitness1 AFamilyName1",
+                "roleOnCase": "Witness",
+                "details": []
+              }
+            },
+            {
+              "id": "partyId2",
+              "value": {
+                "partyName": "OldFirstName OldFamilyName",
+                "roleOnCase": "Witness",
+                "details": []
+              }
+            },
+            {
+              "id": "partyId0",
+              "value": {
+                "partyName": "AWitness0 AFamilyName0",
+                "roleOnCase": "Witness",
+                "details": []
               }
             }
           ]
@@ -37,8 +87,32 @@
           {
             "id": "1",
             "value": {
-              "witnessName": "AWitness",
-              "witnessFamilyName": "AFamilyName"
+              "witnessPartyId": "partyId1",
+              "witnessName": "AWitness1",
+              "witnessFamilyName": "AFamilyName1"
+            }
+          },
+          {
+            "id": "2",
+            "value": {
+              "witnessPartyId": "partyId2",
+              "witnessName": "AWitness2",
+              "witnessFamilyName": "AFamilyName2"
+            }
+          },
+          {
+            "id": "3",
+            "value": {
+              "witnessPartyId": "partyId3",
+              "witnessName": "AWitness3",
+              "witnessFamilyName": "AFamilyName3"
+            }
+          },
+          {
+            "id": "4",
+            "value": {
+              "witnessName": "AWitness4",
+              "witnessFamilyName": "AFamilyName4"
             }
           }
         ],
@@ -49,9 +123,25 @@
         },
         "witnessLevelFlags": [
           {
-            "id": "AWitness AFamilyName",
+            "id": "partyId1",
             "value": {
-              "partyName": "AWitness AFamilyName",
+              "partyName": "AWitness1 AFamilyName1",
+              "roleOnCase": "Witness",
+              "details": []
+            }
+          },
+          {
+            "id": "partyId2",
+            "value": {
+              "partyName": "AWitness2 AFamilyName2",
+              "roleOnCase": "Witness",
+              "details": []
+            }
+          },
+          {
+            "id": "partyId3",
+            "value": {
+              "partyName": "AWitness3 AFamilyName3",
               "roleOnCase": "Witness",
               "details": []
             }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1807,7 +1807,7 @@ public enum AsylumCaseFieldDefinition {
     }),
 
     WITNESS_LEVEL_FLAGS(
-        "witnessLevelFlags", new TypeReference<List<IdValue<StrategicCaseFlag>>>() {}),
+        "witnessLevelFlags", new TypeReference<List<PartyFlagIdValue>>() {}),
 
     CASE_LEVEL_FLAGS(
         "caseFlags", new TypeReference<StrategicCaseFlag>(){}),

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/CaseFlagValue.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/CaseFlagValue.java
@@ -5,7 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -21,8 +24,12 @@ public class CaseFlagValue {
     String name;
     String status;
     String flagCode;
+    String subTypeKey;
+    String flagComment;
+    String subTypeValue;
     YesOrNo hearingRelevant;
     String dateTimeCreated;
     String dateTimeModified;
-
+    List<IdValue<String>> path;
+    String otherDescription;
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/PartyFlagIdValue.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/PartyFlagIdValue.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+public class PartyFlagIdValue {
+
+    @JsonProperty("id")
+    private String partyId;
+    private StrategicCaseFlag value;
+
+    private PartyFlagIdValue() {
+        // noop -- for deserializer
+    }
+
+    public PartyFlagIdValue(
+        String partyId,
+        StrategicCaseFlag value
+    ) {
+        requireNonNull(partyId);
+        requireNonNull(value);
+
+        this.partyId = partyId;
+        this.value = value;
+    }
+
+    public String getPartyId() {
+        requireNonNull(partyId);
+        return partyId;
+    }
+
+    public StrategicCaseFlag getValue() {
+        requireNonNull(value);
+        return value;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/StrategicCaseFlag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/StrategicCaseFlag.java
@@ -25,16 +25,16 @@ public class StrategicCaseFlag {
     @JsonProperty("details")
     List<CaseFlagDetail> details;
 
-    public StrategicCaseFlag(String partyNameForDisplay, String roleOnCase) {
-        this.partyName = partyNameForDisplay;
+    public StrategicCaseFlag(String partyFullName, String roleOnCase) {
+        this.partyName = partyFullName;
         this.roleOnCase = roleOnCase;
         this.details = Collections.emptyList();
     }
 
-    public StrategicCaseFlag(String partyNameForDisplay, String roleOnCase, List<CaseFlagDetail> details) {
-        this.partyName = partyNameForDisplay;
+    public StrategicCaseFlag(String partyFullName, String roleOnCase, List<CaseFlagDetail> details) {
+        this.partyName = partyFullName;
         this.roleOnCase = roleOnCase;
-        this.details = details;
+        this.details = details == null ? Collections.emptyList() : details;
     }
 
     public StrategicCaseFlag() {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtils.java
@@ -50,6 +50,18 @@ public class HandlerUtils {
                 .ifPresent(response -> asylumCase.write(OTHER_DECISION_FOR_DISPLAY, response));
     }
 
+    public static String getAppellantFullName(AsylumCase asylumCase) {
+        return asylumCase.read(APPELLANT_NAME_FOR_DISPLAY, String.class).orElseGet(() -> {
+            final String appellantGivenNames = asylumCase
+                    .read(APPELLANT_GIVEN_NAMES, String.class)
+                    .orElseThrow(() -> new IllegalStateException("Appellant given names required"));
+            final String appellantFamilyName = asylumCase
+                    .read(APPELLANT_FAMILY_NAME, String.class)
+                    .orElseThrow(() -> new IllegalStateException("Appellant family name required"));
+            return appellantGivenNames + " " + appellantFamilyName;
+        });
+    }
+
     private static Optional<String> formatHearingAdjustmentResponse(
             AsylumCase asylumCase,
             AsylumCaseFieldDefinition responseDefinition,

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantCaseFlagsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantCaseFlagsHandler.java
@@ -40,28 +40,14 @@ class AppellantCaseFlagsHandler  {
         return caseFlagDetails;
     }
 
-    protected List<CaseFlagDetail> deactivateCaseFlag(
+    protected List<CaseFlagDetail> deactivateCaseFlags(
         List<CaseFlagDetail> caseFlagDetails,
         StrategicCaseFlagType caseFlagType,
         String dateTimeModified) {
-        if (hasActiveTargetCaseFlag(caseFlagDetails, caseFlagType)) {
-            caseFlagDetails = caseFlagDetails.stream().map(detail -> {
-                CaseFlagValue value = detail.getCaseFlagValue();
-                if (isActiveTargetCaseFlag(value, caseFlagType)) {
-                    return new CaseFlagDetail(detail.getId(), CaseFlagValue.builder()
-                        .flagCode(value.getFlagCode())
-                        .name(value.getName())
-                        .status("Inactive")
-                        .hearingRelevant(value.getHearingRelevant())
-                        .dateTimeModified(dateTimeModified)
-                        .build());
-                } else {
-                    return detail;
-                }
-            }).collect(Collectors.toList());
-        }
 
-        return caseFlagDetails;
+        return caseFlagDetails.stream()
+            .map(detail -> tryDeactivateCaseFlag(caseFlagType, dateTimeModified, detail))
+            .collect(Collectors.toList());
     }
 
     protected boolean hasActiveTargetCaseFlag(List<CaseFlagDetail> caseFlagDetails, StrategicCaseFlagType caseFlagType) {
@@ -80,6 +66,21 @@ class AppellantCaseFlagsHandler  {
             .orElseGet(() -> new StrategicCaseFlag(
                 HandlerUtils.getAppellantFullName(asylumCase),
                 StrategicCaseFlag.ROLE_ON_CASE_APPELLANT));
+    }
+
+    private CaseFlagDetail tryDeactivateCaseFlag(
+        StrategicCaseFlagType caseFlagType,String dateTimeModified, CaseFlagDetail detail) {
+        CaseFlagValue value = detail.getCaseFlagValue();
+
+        return isActiveTargetCaseFlag(value, caseFlagType)
+            ? new CaseFlagDetail(detail.getId(), CaseFlagValue.builder()
+                .flagCode(value.getFlagCode())
+                .name(value.getName())
+                .status("Inactive")
+                .hearingRelevant(value.getHearingRelevant())
+                .dateTimeModified(dateTimeModified)
+                .build())
+            : detail;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantCaseFlagsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantCaseFlagsHandler.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_LEVEL_FLAGS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CASE_FLAG_ID;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CaseFlagDetail;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CaseFlagValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlag;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
+
+class AppellantCaseFlagsHandler  {
+
+    protected List<CaseFlagDetail> activateCaseFlag(
+        AsylumCase asylumCase,
+        List<CaseFlagDetail> existingCaseFlagDetails,
+        StrategicCaseFlagType caseFlagType,
+        String dateTimeCreated) {
+
+        CaseFlagValue caseFlagValue = CaseFlagValue.builder()
+            .flagCode(caseFlagType.getFlagCode())
+            .name(caseFlagType.getName())
+            .status("Active")
+            .hearingRelevant(YesOrNo.YES)
+            .dateTimeCreated(dateTimeCreated)
+            .build();
+        String caseFlagId = asylumCase.read(CASE_FLAG_ID, String.class).orElse(UUID.randomUUID().toString());
+        List<CaseFlagDetail> caseFlagDetails = existingCaseFlagDetails.isEmpty()
+            ? new ArrayList<>()
+            : new ArrayList<>(existingCaseFlagDetails);
+        caseFlagDetails.add(new CaseFlagDetail(caseFlagId, caseFlagValue));
+
+        return caseFlagDetails;
+    }
+
+    protected List<CaseFlagDetail> deactivateCaseFlag(
+        List<CaseFlagDetail> caseFlagDetails,
+        StrategicCaseFlagType caseFlagType,
+        String dateTimeModified) {
+        if (hasActiveTargetCaseFlag(caseFlagDetails, caseFlagType)) {
+            caseFlagDetails = caseFlagDetails.stream().map(detail -> {
+                CaseFlagValue value = detail.getCaseFlagValue();
+                if (isActiveTargetCaseFlag(value, caseFlagType)) {
+                    return new CaseFlagDetail(detail.getId(), CaseFlagValue.builder()
+                        .flagCode(value.getFlagCode())
+                        .name(value.getName())
+                        .status("Inactive")
+                        .hearingRelevant(value.getHearingRelevant())
+                        .dateTimeModified(dateTimeModified)
+                        .build());
+                } else {
+                    return detail;
+                }
+            }).collect(Collectors.toList());
+        }
+
+        return caseFlagDetails;
+    }
+
+    protected boolean hasActiveTargetCaseFlag(List<CaseFlagDetail> caseFlagDetails, StrategicCaseFlagType caseFlagType) {
+        return caseFlagDetails
+            .stream()
+            .anyMatch(flagDetail -> isActiveTargetCaseFlag(flagDetail.getCaseFlagValue(), caseFlagType));
+    }
+
+    protected boolean isActiveTargetCaseFlag(CaseFlagValue value, StrategicCaseFlagType targetCaseFlagType) {
+        return Objects.equals(value.getFlagCode(), targetCaseFlagType.getFlagCode())
+            && Objects.equals(value.getStatus(), "Active");
+    }
+
+    protected StrategicCaseFlag getOrCreateAppellantCaseFlags(AsylumCase asylumCase) {
+        return asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class)
+            .orElseGet(() -> new StrategicCaseFlag(
+                HandlerUtils.getAppellantFullName(asylumCase),
+                StrategicCaseFlag.ROLE_ON_CASE_APPELLANT));
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CreateFlagHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CreateFlagHandler.java
@@ -3,13 +3,17 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CaseFlagDetail;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.PartyFlagIdValue;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlag;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
@@ -17,6 +21,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Slf4j
@@ -43,56 +48,69 @@ class CreateFlagHandler implements PreSubmitCallbackHandler<AsylumCase> {
             throw new IllegalStateException("Cannot handle callback");
         }
 
-        final AsylumCase asylumCase =
-            callback
-                .getCaseDetails()
-                .getCaseData();
+        final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
-        Optional<StrategicCaseFlag> existingCaseLevelFlags = asylumCase.read(CASE_LEVEL_FLAGS);
-        Optional<StrategicCaseFlag> existingAppellantLevelFlags = asylumCase.read(APPELLANT_LEVEL_FLAGS);
-        Optional<List<IdValue<StrategicCaseFlag>>> existingWitnessLevelFlags = asylumCase.read(WITNESS_LEVEL_FLAGS);
-        final Optional<List<IdValue<WitnessDetails>>> witnessDetails = asylumCase.read(WITNESS_DETAILS);
-
-        if (existingAppellantLevelFlags.isEmpty()
-            || existingAppellantLevelFlags.get().getPartyName() == null
-            || existingAppellantLevelFlags.get().getPartyName().isBlank()) {
-
-            final String appellantNameForDisplay =
-                asylumCase
-                    .read(APPELLANT_NAME_FOR_DISPLAY, String.class)
-                    .orElseThrow(() -> new IllegalStateException("appellantNameForDisplay is not present"));
-
-            asylumCase.write(APPELLANT_LEVEL_FLAGS, new StrategicCaseFlag(appellantNameForDisplay, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT));
-        } else {
-            log.info("Existing Appellant Level flags: {}", existingAppellantLevelFlags);
-        }
-
-        if (existingCaseLevelFlags.isEmpty()) {
-            asylumCase.write(CASE_LEVEL_FLAGS, new StrategicCaseFlag());
-        } else {
-            log.info("Existing Case Level flags: {}", existingCaseLevelFlags);
-        }
-
-        if (witnessDetails.isPresent()) {
-            if (existingWitnessLevelFlags.isEmpty() || existingWitnessLevelFlags.get().isEmpty()) {
-                asylumCase.write(WITNESS_LEVEL_FLAGS, mapWitnessesToFlag(witnessDetails.get()));
-            } else {
-                log.info("Existing Witness Level flags: {}", existingWitnessLevelFlags);
-            }
-        }
+        handleAppellantLevelFlags(asylumCase);
+        handleCaseLevelFlags(asylumCase);
+        handleWitnessLevelFlags(asylumCase);
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 
-    private List<IdValue<StrategicCaseFlag>> mapWitnessesToFlag(List<IdValue<WitnessDetails>> witnessDetails) {
-        return witnessDetails.stream().map(details -> {
-            String witnessName = details.getValue().buildWitnessFullName();
-            if (witnessName.isBlank()) {
-                return null;
-            } else {
-                StrategicCaseFlag caseFlag = new StrategicCaseFlag(witnessName, StrategicCaseFlag.ROLE_ON_CASE_WITNESS);
-                return new IdValue<>(witnessName, caseFlag);
-            }
-        }).filter(Objects::nonNull).collect(Collectors.toList());
+    private void handleAppellantLevelFlags(AsylumCase asylumCase) {
+        final String appellantFullName = HandlerUtils.getAppellantFullName(asylumCase);
+        asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class)
+            .ifPresentOrElse(existingAppellantLevelFlags -> {
+                    if (!Objects.equals(existingAppellantLevelFlags.getPartyName(), appellantFullName)) {
+                        StrategicCaseFlag updatedAppellantLevelFlags = new StrategicCaseFlag(appellantFullName,
+                            StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingAppellantLevelFlags.getDetails());
+                        asylumCase.write(APPELLANT_LEVEL_FLAGS, updatedAppellantLevelFlags);
+                    }
+                }, () -> asylumCase.write(APPELLANT_LEVEL_FLAGS, new StrategicCaseFlag(
+                    appellantFullName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT))
+            );
+    }
+
+    private void handleCaseLevelFlags(AsylumCase asylumCase) {
+        if (asylumCase.read(CASE_LEVEL_FLAGS).isEmpty()) {
+            asylumCase.write(CASE_LEVEL_FLAGS, new StrategicCaseFlag());
+        }
+    }
+
+    private void handleWitnessLevelFlags(AsylumCase asylumCase) {
+        Optional<List<PartyFlagIdValue>> witnessLevelFlagsOptional = asylumCase.read(WITNESS_LEVEL_FLAGS);
+        final Optional<List<IdValue<WitnessDetails>>> witnessDetailsOptional = asylumCase.read(WITNESS_DETAILS);
+
+        witnessDetailsOptional.ifPresent(idValues -> {
+            final List<WitnessDetails> witnessDetailsList = idValues.stream().map(IdValue::getValue).toList();
+            witnessLevelFlagsOptional.ifPresentOrElse(
+                existingWitnessFlags -> asylumCase
+                    .write(WITNESS_LEVEL_FLAGS, mapWitnessesToFlag(witnessDetailsList, existingWitnessFlags)),
+                () -> asylumCase
+                    .write(WITNESS_LEVEL_FLAGS, mapWitnessesToFlag(witnessDetailsList, Collections.emptyList()))
+            );
+        });
+    }
+
+    private List<PartyFlagIdValue> mapWitnessesToFlag(
+        List<WitnessDetails> witnessDetailsList, List<PartyFlagIdValue> existingWitnessFlags) {
+        Map<String, StrategicCaseFlag> idToFlagMap = existingWitnessFlags.isEmpty()
+            ? Collections.emptyMap()
+            : existingWitnessFlags.stream()
+                .collect(Collectors.toMap(PartyFlagIdValue::getPartyId, PartyFlagIdValue::getValue));
+
+        // Flags are created only for witnesses with party ID set to a non-null value
+        return witnessDetailsList.stream()
+            .filter(witnessDetails -> witnessDetails.getWitnessPartyId() != null)
+            .map(witnessDetails -> {
+                List<CaseFlagDetail> flagDetails = Collections.emptyList();
+                String witnessName = witnessDetails.buildWitnessFullName();
+                if (idToFlagMap.containsKey(witnessDetails.getWitnessPartyId())) {
+                    StrategicCaseFlag existingFlag = idToFlagMap.get(witnessDetails.getWitnessPartyId());
+                    flagDetails = existingFlag.getDetails();
+                }
+                return new PartyFlagIdValue(witnessDetails.getWitnessPartyId(), new StrategicCaseFlag(
+                    witnessName, StrategicCaseFlag.ROLE_ON_CASE_WITNESS, flagDetails));
+            }).collect(Collectors.toList());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EvidenceInPrivateCaseFlagsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EvidenceInPrivateCaseFlagsHandler.java
@@ -79,14 +79,14 @@ public class EvidenceInPrivateCaseFlagsHandler
         }
 
         if (!inCameraCourt && hasActiveTargetCaseFlag(existingCaseFlagDetails, CASE_GIVEN_IN_PRIVATE)) {
-            existingCaseFlagDetails = deactivateCaseFlag(
+            existingCaseFlagDetails = deactivateCaseFlags(
                 existingCaseFlagDetails, CASE_GIVEN_IN_PRIVATE, currentDateTime);
             caseDataUpdated = true;
         }
 
         if (isInCameraCourtAllowed.equals(CASE_REFUSED)
             && hasActiveTargetCaseFlag(existingCaseFlagDetails, CASE_GIVEN_IN_PRIVATE)) {
-            existingCaseFlagDetails = deactivateCaseFlag(
+            existingCaseFlagDetails = deactivateCaseFlags(
                 existingCaseFlagDetails, CASE_GIVEN_IN_PRIVATE, currentDateTime);
             caseDataUpdated = true;
         }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingRequirementsAppellantCaseFlagsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingRequirementsAppellantCaseFlagsHandler.java
@@ -1,11 +1,7 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_FAMILY_NAME;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_LEVEL_FLAGS;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_GIVEN_NAMES;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_NAME_FOR_DISPLAY;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CASE_FLAG_ID;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_HEARING_LOOP_NEEDED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_HEARING_ROOM_NEEDED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.HEARING_LOOP;
@@ -13,20 +9,12 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagTyp
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.REVIEW_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUIREMENTS;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.CaseFlagDetail;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.CaseFlagValue;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlag;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
@@ -36,7 +24,8 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
-class HearingRequirementsAppellantCaseFlagsHandler implements PreSubmitCallbackHandler<AsylumCase> {
+class HearingRequirementsAppellantCaseFlagsHandler
+        extends AppellantCaseFlagsHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
     private final DateProvider systemDateProvider;
 
@@ -65,117 +54,47 @@ class HearingRequirementsAppellantCaseFlagsHandler implements PreSubmitCallbackH
         }
 
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
-        Optional<StrategicCaseFlag> existingCaseflags = asylumCase
-                .read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class);
-        String appellantDisplayName = getAppellantDisplayName(existingCaseflags, asylumCase);
+        StrategicCaseFlag caseFlags = getOrCreateAppellantCaseFlags(asylumCase);
         boolean isHearingLoopNeeded = asylumCase.read(IS_HEARING_LOOP_NEEDED, YesOrNo.class)
             .map(hearingLoopNeeded -> YesOrNo.YES == hearingLoopNeeded).orElse(false);
         boolean isHearingRoomNeeded = asylumCase.read(IS_HEARING_ROOM_NEEDED, YesOrNo.class)
             .map(hearingRoomNeeded -> YesOrNo.YES == hearingRoomNeeded).orElse(false);
-        List<CaseFlagDetail> existingCaseFlagDetails = existingCaseflags
-            .map(StrategicCaseFlag::getDetails).orElse(Collections.emptyList());
+        List<CaseFlagDetail> existingCaseFlagDetails = caseFlags.getDetails();
+        String currentDateTime = systemDateProvider.nowWithTime().toString();
 
         boolean caseDataUpdated = false;
 
         if (isHearingLoopNeeded && !hasActiveTargetCaseFlag(existingCaseFlagDetails, HEARING_LOOP)) {
-            existingCaseFlagDetails = activateCaseFlag(asylumCase, existingCaseFlagDetails, HEARING_LOOP);
+            existingCaseFlagDetails = activateCaseFlag(
+                asylumCase, existingCaseFlagDetails, HEARING_LOOP, currentDateTime);
             caseDataUpdated = true;
         }
         if (isHearingRoomNeeded && !hasActiveTargetCaseFlag(existingCaseFlagDetails, STEP_FREE_WHEELCHAIR_ACCESS)) {
-            existingCaseFlagDetails = activateCaseFlag(asylumCase, existingCaseFlagDetails, STEP_FREE_WHEELCHAIR_ACCESS);
+            existingCaseFlagDetails = activateCaseFlag(
+                asylumCase, existingCaseFlagDetails, STEP_FREE_WHEELCHAIR_ACCESS, currentDateTime);
             caseDataUpdated = true;
         }
         if (!isHearingLoopNeeded && hasActiveTargetCaseFlag(existingCaseFlagDetails, HEARING_LOOP)) {
-            existingCaseFlagDetails = deactivateCaseFlag(existingCaseFlagDetails, HEARING_LOOP);
+            existingCaseFlagDetails = deactivateCaseFlag(existingCaseFlagDetails, HEARING_LOOP, currentDateTime);
             caseDataUpdated = true;
         }
         if (!isHearingRoomNeeded && hasActiveTargetCaseFlag(existingCaseFlagDetails, STEP_FREE_WHEELCHAIR_ACCESS)) {
-            existingCaseFlagDetails = deactivateCaseFlag(existingCaseFlagDetails, STEP_FREE_WHEELCHAIR_ACCESS);
+            existingCaseFlagDetails = deactivateCaseFlag(
+                existingCaseFlagDetails, STEP_FREE_WHEELCHAIR_ACCESS, currentDateTime);
             caseDataUpdated = true;
         }
 
         if (caseDataUpdated) {
-            if (appellantDisplayName == null) {
-                throw new IllegalStateException("Appellant full name is not present");
-            }
 
-            asylumCase.write(APPELLANT_LEVEL_FLAGS, new StrategicCaseFlag(
-                    appellantDisplayName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingCaseFlagDetails));
+            asylumCase.write(
+                APPELLANT_LEVEL_FLAGS,
+                new StrategicCaseFlag(
+                    caseFlags.getPartyName(),
+                    StrategicCaseFlag.ROLE_ON_CASE_APPELLANT,
+                    existingCaseFlagDetails));
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 
-    private List<CaseFlagDetail> activateCaseFlag(
-        AsylumCase asylumCase,
-        List<CaseFlagDetail> existingCaseFlagDetails,
-        StrategicCaseFlagType caseFlagType) {
-
-        CaseFlagValue caseFlagValue = CaseFlagValue.builder()
-                .flagCode(caseFlagType.getFlagCode())
-                .name(caseFlagType.getName())
-                .status("Active")
-                .hearingRelevant(YesOrNo.YES)
-                .dateTimeCreated(systemDateProvider.nowWithTime().toString())
-                .build();
-        String caseFlagId = asylumCase.read(CASE_FLAG_ID, String.class).orElse(UUID.randomUUID().toString());
-        List<CaseFlagDetail> caseFlagDetails = existingCaseFlagDetails.isEmpty()
-            ? new ArrayList<>()
-            : new ArrayList<>(existingCaseFlagDetails);
-        caseFlagDetails.add(new CaseFlagDetail(caseFlagId, caseFlagValue));
-
-        return caseFlagDetails;
-    }
-
-    private List<CaseFlagDetail> deactivateCaseFlag(
-            List<CaseFlagDetail> caseFlagDetails,
-            StrategicCaseFlagType caseFlagType) {
-        if (hasActiveTargetCaseFlag(caseFlagDetails, caseFlagType)) {
-            caseFlagDetails = caseFlagDetails.stream().map(detail -> {
-                CaseFlagValue value = detail.getCaseFlagValue();
-                if (isActiveTargetCaseFlag(value, caseFlagType)) {
-                    return new CaseFlagDetail(detail.getId(), CaseFlagValue.builder()
-                        .flagCode(value.getFlagCode())
-                        .name(value.getName())
-                        .status("Inactive")
-                        .hearingRelevant(value.getHearingRelevant())
-                        .dateTimeModified(systemDateProvider.nowWithTime().toString())
-                        .build());
-                } else {
-                    return detail;
-                }
-            }).collect(Collectors.toList());
-        }
-
-        return caseFlagDetails;
-    }
-
-    private boolean hasActiveTargetCaseFlag(List<CaseFlagDetail> caseFlagDetails, StrategicCaseFlagType caseFlagType) {
-        return caseFlagDetails
-            .stream()
-            .anyMatch(flagDetail -> isActiveTargetCaseFlag(flagDetail.getCaseFlagValue(), caseFlagType));
-    }
-
-    private boolean isActiveTargetCaseFlag(CaseFlagValue value, StrategicCaseFlagType targetCaseFlagType) {
-        return Objects.equals(value.getFlagCode(), targetCaseFlagType.getFlagCode())
-            && Objects.equals(value.getStatus(), "Active");
-    }
-
-    private String getAppellantDisplayName(Optional<StrategicCaseFlag> existingCaseFlags, AsylumCase asylumCase) {
-
-        return existingCaseFlags.isPresent()
-            ? existingCaseFlags.get().getPartyName()
-            : asylumCase
-                .read(APPELLANT_NAME_FOR_DISPLAY, String.class).orElseGet(() -> {
-                    final String appellantGivenNames =
-                        asylumCase
-                            .read(APPELLANT_GIVEN_NAMES, String.class).orElse(null);
-                    final String appellantFamilyName =
-                        asylumCase
-                            .read(APPELLANT_FAMILY_NAME, String.class).orElse(null);
-                    return !(appellantGivenNames == null || appellantFamilyName == null)
-                        ? appellantGivenNames + " " + appellantFamilyName
-                        : null;
-                });
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingRequirementsAppellantCaseFlagsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingRequirementsAppellantCaseFlagsHandler.java
@@ -75,11 +75,11 @@ class HearingRequirementsAppellantCaseFlagsHandler
             caseDataUpdated = true;
         }
         if (!isHearingLoopNeeded && hasActiveTargetCaseFlag(existingCaseFlagDetails, HEARING_LOOP)) {
-            existingCaseFlagDetails = deactivateCaseFlag(existingCaseFlagDetails, HEARING_LOOP, currentDateTime);
+            existingCaseFlagDetails = deactivateCaseFlags(existingCaseFlagDetails, HEARING_LOOP, currentDateTime);
             caseDataUpdated = true;
         }
         if (!isHearingRoomNeeded && hasActiveTargetCaseFlag(existingCaseFlagDetails, STEP_FREE_WHEELCHAIR_ACCESS)) {
-            existingCaseFlagDetails = deactivateCaseFlag(
+            existingCaseFlagDetails = deactivateCaseFlags(
                 existingCaseFlagDetails, STEP_FREE_WHEELCHAIR_ACCESS, currentDateTime);
             caseDataUpdated = true;
         }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantCaseFlagsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantCaseFlagsHandlerTest.java
@@ -1,0 +1,132 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_LEVEL_FLAGS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_NAME_FOR_DISPLAY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.HEARING_LOOP;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.STEP_FREE_WHEELCHAIR_ACCESS;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CaseFlagDetail;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CaseFlagValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlag;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AppellantCaseFlagsHandlerTest {
+
+    @Mock
+    private AsylumCase asylumCase;
+
+    private AppellantCaseFlagsHandler appellantCaseFlagsHandler;
+    private List<CaseFlagDetail> activeCaseFlagDetails;
+    private List<CaseFlagDetail> inactiveCaseFlagDetails;
+    private CaseFlagValue activeCaseFlagValue;
+    private CaseFlagValue inactiveCaseFlagValue;
+    private final String fullName = "fullName";
+
+    @BeforeEach
+    void setup() {
+        appellantCaseFlagsHandler = new AppellantCaseFlagsHandler();
+
+        activeCaseFlagValue = CaseFlagValue
+            .builder()
+            .flagCode(HEARING_LOOP.getFlagCode())
+            .name(HEARING_LOOP.getName())
+            .status("Active")
+            .build();
+        activeCaseFlagDetails = List.of(new CaseFlagDetail("123", activeCaseFlagValue));
+        inactiveCaseFlagValue = CaseFlagValue
+            .builder()
+            .flagCode(HEARING_LOOP.getFlagCode())
+            .name(HEARING_LOOP.getName())
+            .status("Inactive")
+            .build();
+        inactiveCaseFlagDetails = List.of(new CaseFlagDetail("123", inactiveCaseFlagValue));
+
+        when(asylumCase.read(APPELLANT_NAME_FOR_DISPLAY, String.class))
+            .thenReturn(Optional.of(fullName));
+    }
+
+    @Test
+    void hasActiveTargetCaseFlag_should_return_true() {
+        assertTrue(appellantCaseFlagsHandler.hasActiveTargetCaseFlag(activeCaseFlagDetails, HEARING_LOOP));
+    }
+
+    @Test
+    void hasActiveTargetCaseFlag_should_return_false() {
+        assertFalse(appellantCaseFlagsHandler.hasActiveTargetCaseFlag(Collections.emptyList(), HEARING_LOOP));
+        assertFalse(appellantCaseFlagsHandler.hasActiveTargetCaseFlag(inactiveCaseFlagDetails, HEARING_LOOP));
+        assertFalse(
+            appellantCaseFlagsHandler.hasActiveTargetCaseFlag(activeCaseFlagDetails, STEP_FREE_WHEELCHAIR_ACCESS));
+    }
+
+    @Test
+    void isActiveTargetCaseFlag_should_return_true() {
+        assertTrue(appellantCaseFlagsHandler.isActiveTargetCaseFlag(activeCaseFlagValue, HEARING_LOOP));
+    }
+
+    @Test
+    void isActiveTargetCaseFlag_should_return_false() {
+        assertFalse(appellantCaseFlagsHandler.isActiveTargetCaseFlag(inactiveCaseFlagValue, HEARING_LOOP));
+        assertFalse(
+            appellantCaseFlagsHandler.isActiveTargetCaseFlag(activeCaseFlagValue, STEP_FREE_WHEELCHAIR_ACCESS));
+    }
+
+    @Test
+    void getOrCreateAppellantCaseFlags_should_always_return_appellant_case_flag() {
+        StrategicCaseFlag appellantCaseFlag = new StrategicCaseFlag(
+            fullName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT);
+
+        StrategicCaseFlag actual = appellantCaseFlagsHandler.getOrCreateAppellantCaseFlags(asylumCase);
+        assertEquals(actual.getPartyName(), appellantCaseFlag.getPartyName());
+        assertEquals(actual.getRoleOnCase(), appellantCaseFlag.getRoleOnCase());
+
+        when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
+            .thenReturn(Optional.of(appellantCaseFlag));
+
+        actual = appellantCaseFlagsHandler.getOrCreateAppellantCaseFlags(asylumCase);
+        assertEquals(actual.getPartyName(), appellantCaseFlag.getPartyName());
+        assertEquals(actual.getRoleOnCase(), appellantCaseFlag.getRoleOnCase());
+    }
+
+    @Test
+    void should_activate_case_flag() {
+        boolean activatedWithExistingCaseFlag = appellantCaseFlagsHandler
+            .activateCaseFlag(asylumCase, activeCaseFlagDetails, STEP_FREE_WHEELCHAIR_ACCESS, "06-09-2023")
+            .stream()
+            .anyMatch(details -> Objects.equals(details.getCaseFlagValue().getStatus(), "Active"));
+        boolean activatedWithNoExistingCaseFlag = appellantCaseFlagsHandler
+            .activateCaseFlag(asylumCase, Collections.emptyList(), HEARING_LOOP, "06-09-2023")
+            .stream()
+            .anyMatch(details -> Objects.equals(details.getCaseFlagValue().getStatus(), "Active"));
+
+        assertTrue(activatedWithExistingCaseFlag);
+        assertTrue(activatedWithNoExistingCaseFlag);
+    }
+
+    @Test
+    void should_deactivate_case_flag() {
+        boolean deactivated = appellantCaseFlagsHandler
+            .deactivateCaseFlag(activeCaseFlagDetails, HEARING_LOOP, "06-09-2023")
+            .stream()
+            .anyMatch(details -> Objects.equals(details.getCaseFlagValue().getStatus(), "Inactive"));
+
+        assertTrue(deactivated);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantCaseFlagsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantCaseFlagsHandlerTest.java
@@ -122,7 +122,7 @@ class AppellantCaseFlagsHandlerTest {
     @Test
     void should_deactivate_case_flag() {
         boolean deactivated = appellantCaseFlagsHandler
-            .deactivateCaseFlag(activeCaseFlagDetails, HEARING_LOOP, "06-09-2023")
+            .deactivateCaseFlags(activeCaseFlagDetails, HEARING_LOOP, "06-09-2023")
             .stream()
             .anyMatch(details -> Objects.equals(details.getCaseFlagValue().getStatus(), "Inactive"));
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CreateFlagHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/CreateFlagHandlerTest.java
@@ -1,8 +1,13 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -11,16 +16,22 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CaseFlagDetail;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.CaseFlagValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.PartyFlagIdValue;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlag;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.WitnessDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
@@ -35,6 +46,12 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
 @SuppressWarnings("unchecked")
 class CreateFlagHandlerTest {
 
+    @Captor
+    private ArgumentCaptor<List<PartyFlagIdValue>> witnessFlagsCaptor;
+    @Captor
+    private ArgumentCaptor<StrategicCaseFlag> appellantFlagsCaptor;
+    @Captor
+    private ArgumentCaptor<StrategicCaseFlag> caseFlagsCaptor;
     @Mock
     private Callback<AsylumCase> callback;
     @Mock
@@ -46,11 +63,12 @@ class CreateFlagHandlerTest {
 
     private final String appellantNameForDisplay = "some-name";
 
-    private final String witnessName = "witnessName";
-    private final String witnessFamilyName = "witnessFamilyName";
-
-    private final StrategicCaseFlag appellantCaseFlag = new StrategicCaseFlag(appellantNameForDisplay, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT);
-    private final StrategicCaseFlag strategicCaseFlagEmpty = new StrategicCaseFlag();
+    private final String partyId1 = "witnessPartyId1";
+    private final String witnessName1 = "witnessName1";
+    private final String witnessFamilyName1 = "witnessFamilyName1";
+    private final String partyId2 = "witnessPartyId2";
+    private final String witnessName2 = "witnessName2";
+    private final String witnessFamilyName2 = "witnessFamilyName2";
 
     @BeforeEach
     public void setUp() {
@@ -59,28 +77,148 @@ class CreateFlagHandlerTest {
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(asylumCase.read(APPELLANT_NAME_FOR_DISPLAY, String.class)).thenReturn(Optional.of(appellantNameForDisplay));
 
+        String witnessName3 = "witnessName3";
+        String witnessFamilyName3 = "witnessFamilyName3";
         when(asylumCase.read(WITNESS_DETAILS))
-            .thenReturn(Optional.of(List.of(new IdValue<>(witnessName, new WitnessDetails(witnessName, witnessFamilyName)))));
+            .thenReturn(Optional.of(List.of(
+                new IdValue<>(witnessName1, new WitnessDetails(partyId1, witnessName1, witnessFamilyName1)),
+                new IdValue<>(witnessName2, new WitnessDetails(partyId2, witnessName2, witnessFamilyName2)),
+                new IdValue<>(witnessName3, new WitnessDetails(witnessName3, witnessFamilyName3)))));
 
         createFlagHandler = new CreateFlagHandler();
     }
 
     @Test
-    void should_write_to_case_flag_fields() {
+    void test_handle_appellant_level_flags() {
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse = createFlagHandler
+            .handle(ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase).write(eq(APPELLANT_LEVEL_FLAGS), appellantFlagsCaptor.capture());
+        assertTrue(appellantFlagsCaptor.getValue().getDetails().isEmpty());
+        assertEquals(StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, appellantFlagsCaptor.getValue().getRoleOnCase());
+        assertEquals(appellantNameForDisplay, appellantFlagsCaptor.getValue().getPartyName());
+
+        verify(asylumCase, times(1)).write(eq(APPELLANT_LEVEL_FLAGS), any());
+    }
+
+    @Test
+    void test_handle_appellant_level_flags_when_appellant_has_existing_flags() {
+
+        List<CaseFlagDetail> caseFlagDetails =
+            List.of(new CaseFlagDetail("flagId", CaseFlagValue.builder().build()));
+        StrategicCaseFlag appellantFlag = new StrategicCaseFlag(
+            appellantNameForDisplay, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, caseFlagDetails);
+        when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
+            .thenReturn(Optional.of(appellantFlag));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse = createFlagHandler
+            .handle(ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, never()).write(eq(APPELLANT_LEVEL_FLAGS), any());
+    }
+
+    @Test
+    void should_update_appellant_name_in_existing_flags() {
+
+        List<CaseFlagDetail> caseFlagDetails =
+            List.of(new CaseFlagDetail("flagId", CaseFlagValue.builder().build()));
+        StrategicCaseFlag appellantFlag = new StrategicCaseFlag(
+            "appellantOldName", StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, caseFlagDetails);
+        when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
+            .thenReturn(Optional.of(appellantFlag));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse = createFlagHandler
+            .handle(ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase).write(eq(APPELLANT_LEVEL_FLAGS), appellantFlagsCaptor.capture());
+        assertEquals("flagId", appellantFlagsCaptor.getValue().getDetails().get(0).getId());
+        assertEquals(StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, appellantFlagsCaptor.getValue().getRoleOnCase());
+        assertEquals(appellantNameForDisplay, appellantFlagsCaptor.getValue().getPartyName());
+
+        verify(asylumCase, times(1)).write(eq(APPELLANT_LEVEL_FLAGS), any());
+    }
+
+    @Test
+    void test_handle_witness_level_flags() {
+
+        final String fullName1 = witnessName1 + " " + witnessFamilyName1;
+        final String fullName2 = witnessName2 + " " + witnessFamilyName2;
+        final StrategicCaseFlag witnessFlag1 = new StrategicCaseFlag(
+            fullName1, StrategicCaseFlag.ROLE_ON_CASE_WITNESS, Collections.emptyList());
+        final StrategicCaseFlag witnessFlag2 = new StrategicCaseFlag(
+            fullName2, StrategicCaseFlag.ROLE_ON_CASE_WITNESS, Collections.emptyList());
+        final List<PartyFlagIdValue> expected = List.of(
+            new PartyFlagIdValue(partyId1, witnessFlag1), new PartyFlagIdValue(partyId2, witnessFlag2));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
             createFlagHandler.handle(ABOUT_TO_START, callback);
 
-        verify(asylumCase, times(1))
-            .write(APPELLANT_LEVEL_FLAGS, appellantCaseFlag);
-        verify(asylumCase, times(1))
-            .write(CASE_LEVEL_FLAGS, strategicCaseFlagEmpty);
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
 
-        String witnessFullName = witnessName + " " + witnessFamilyName;
-        List<IdValue<StrategicCaseFlag>> witnessCaseFlag = List
-                .of(new IdValue<>(witnessFullName, new StrategicCaseFlag(witnessFullName, StrategicCaseFlag.ROLE_ON_CASE_WITNESS)));
-        verify(asylumCase, times(1))
-                .write(WITNESS_LEVEL_FLAGS, witnessCaseFlag);
+        verify(asylumCase).write(eq(WITNESS_LEVEL_FLAGS), witnessFlagsCaptor.capture());
+        assertNotNull(witnessFlagsCaptor.getValue());
+        assertEquals(2, witnessFlagsCaptor.getValue().size());
+        assertTrue(witnessFlagsCaptor.getValue().contains(expected.get(0)));
+        assertTrue(witnessFlagsCaptor.getValue().contains(expected.get(1)));
+
+        verify(asylumCase, times(1)).write(eq(WITNESS_LEVEL_FLAGS), any());
+    }
+
+    @Test
+    void test_handle_witness_level_flags_when_some_witnesses_have_existing_flags() {
+
+        final List<CaseFlagDetail> caseFlagDetails =
+            List.of(new CaseFlagDetail("flagId", CaseFlagValue.builder().build()));
+        final String fullName1 = witnessName1 + " " + witnessFamilyName1;
+        final String fullName2 = witnessName2 + " " + witnessFamilyName2;
+        final StrategicCaseFlag witnessFlag1 = new StrategicCaseFlag(
+            fullName1, StrategicCaseFlag.ROLE_ON_CASE_WITNESS, caseFlagDetails);
+        final StrategicCaseFlag witnessFlag2 = new StrategicCaseFlag(
+            fullName2, StrategicCaseFlag.ROLE_ON_CASE_WITNESS, Collections.emptyList());
+        final List<PartyFlagIdValue> expected = List.of(
+            new PartyFlagIdValue(partyId1, witnessFlag1), new PartyFlagIdValue(partyId2, witnessFlag2));
+        when(asylumCase.read(WITNESS_LEVEL_FLAGS))
+            .thenReturn(Optional.of(List.of(new PartyFlagIdValue(partyId1, witnessFlag1))));
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            createFlagHandler.handle(ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase).write(eq(WITNESS_LEVEL_FLAGS), witnessFlagsCaptor.capture());
+        assertNotNull(witnessFlagsCaptor.getValue());
+        assertEquals(2, witnessFlagsCaptor.getValue().size());
+        assertTrue(witnessFlagsCaptor.getValue().contains(expected.get(0)));
+        assertTrue(witnessFlagsCaptor.getValue().contains(expected.get(1)));
+
+        verify(asylumCase, times(1)).write(eq(WITNESS_LEVEL_FLAGS), any());
+    }
+
+    @Test
+    void test_handle_case_level_flags() {
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse = createFlagHandler
+            .handle(ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase).write(eq(APPELLANT_LEVEL_FLAGS), caseFlagsCaptor.capture());
+        assertNotNull(caseFlagsCaptor.getValue());
+
+        verify(asylumCase, times(1)).write(eq(CASE_LEVEL_FLAGS), any());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EvidenceInPrivateCaseFlagsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EvidenceInPrivateCaseFlagsHandlerTest.java
@@ -24,15 +24,22 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_LEVEL_FLAGS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_NAME_FOR_DISPLAY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IN_CAMERA_COURT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_IN_CAMERA_COURT_ALLOWED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.CASE_GIVEN_IN_PRIVATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.REVIEW_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_ADJUSTMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
@@ -56,6 +63,8 @@ public class EvidenceInPrivateCaseFlagsHandlerTest {
     public void setUp() {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getCaseDetails().getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(APPELLANT_NAME_FOR_DISPLAY, String.class))
+            .thenReturn(Optional.of(appellantDisplayName));
         when(systemDateProvider.nowWithTime()).thenReturn(LocalDateTime.now());
 
         evidenceInPrivateCaseFlagsHandler = new EvidenceInPrivateCaseFlagsHandler(systemDateProvider);
@@ -69,10 +78,12 @@ public class EvidenceInPrivateCaseFlagsHandlerTest {
     void should_set_evidence_in_private_flag(Event event) {
         when(callback.getEvent()).thenReturn(event);
         when(asylumCase.read(IN_CAMERA_COURT, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
-        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class)).thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_GRANTED));
-        when(asylumCase.read(APPELLANT_NAME_FOR_DISPLAY, String.class)).thenReturn(Optional.of(appellantDisplayName));
+        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class))
+            .thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_GRANTED));
+        when(asylumCase.read(APPELLANT_NAME_FOR_DISPLAY, String.class))
+            .thenReturn(Optional.of(appellantDisplayName));
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -91,7 +102,7 @@ public class EvidenceInPrivateCaseFlagsHandlerTest {
         when(asylumCase.read(IN_CAMERA_COURT, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -103,20 +114,21 @@ public class EvidenceInPrivateCaseFlagsHandlerTest {
     void should_deactivate_evidence_in_private_flag() {
         when(callback.getEvent()).thenReturn(UPDATE_HEARING_ADJUSTMENTS);
         when(asylumCase.read(IN_CAMERA_COURT, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
-        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class)).thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_REFUSED));
+        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class))
+            .thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_REFUSED));
 
         List<CaseFlagDetail> existingFlags = List.of(new CaseFlagDetail("123", CaseFlagValue
-                .builder()
-                .flagCode(CASE_GIVEN_IN_PRIVATE.getFlagCode())
-                .name(CASE_GIVEN_IN_PRIVATE.getName())
-                .status("Active")
-                .build()));
+            .builder()
+            .flagCode(CASE_GIVEN_IN_PRIVATE.getFlagCode())
+            .name(CASE_GIVEN_IN_PRIVATE.getName())
+            .status("Active")
+            .build()));
         when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
-                .thenReturn(Optional.of(new StrategicCaseFlag(
-                        appellantDisplayName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingFlags)));
+            .thenReturn(Optional.of(new StrategicCaseFlag(
+                appellantDisplayName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingFlags)));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -128,10 +140,11 @@ public class EvidenceInPrivateCaseFlagsHandlerTest {
     void should_not_deactivate_flag_when_non_exists() {
         when(callback.getEvent()).thenReturn(UPDATE_HEARING_ADJUSTMENTS);
         when(asylumCase.read(IN_CAMERA_COURT, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
-        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class)).thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_REFUSED));
+        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class))
+            .thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_REFUSED));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -143,20 +156,21 @@ public class EvidenceInPrivateCaseFlagsHandlerTest {
     void should_not_deactivate_flag_when_an_inactive_one_exists() {
         when(callback.getEvent()).thenReturn(UPDATE_HEARING_ADJUSTMENTS);
         when(asylumCase.read(IN_CAMERA_COURT, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
-        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class)).thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_REFUSED));
+        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class))
+            .thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_REFUSED));
 
         List<CaseFlagDetail> existingFlags = List.of(new CaseFlagDetail("123", CaseFlagValue
-                .builder()
-                .flagCode(CASE_GIVEN_IN_PRIVATE.getFlagCode())
-                .name(CASE_GIVEN_IN_PRIVATE.getName())
-                .status("Inactive")
-                .build()));
+            .builder()
+            .flagCode(CASE_GIVEN_IN_PRIVATE.getFlagCode())
+            .name(CASE_GIVEN_IN_PRIVATE.getName())
+            .status("Inactive")
+            .build()));
         when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
-                .thenReturn(Optional.of(new StrategicCaseFlag(
-                        appellantDisplayName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingFlags)));
+            .thenReturn(Optional.of(new StrategicCaseFlag(
+                appellantDisplayName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingFlags)));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -172,20 +186,21 @@ public class EvidenceInPrivateCaseFlagsHandlerTest {
     void should_set_flag_when_an_inactive_one_exists(Event event) {
         when(callback.getEvent()).thenReturn(event);
         when(asylumCase.read(IN_CAMERA_COURT, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
-        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class)).thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_GRANTED));
+        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class))
+            .thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_GRANTED));
 
         List<CaseFlagDetail> existingFlags = List.of(new CaseFlagDetail("123", CaseFlagValue
-                .builder()
-                .flagCode(CASE_GIVEN_IN_PRIVATE.getFlagCode())
-                .name(CASE_GIVEN_IN_PRIVATE.getName())
-                .status("Inactive")
-                .build()));
+            .builder()
+            .flagCode(CASE_GIVEN_IN_PRIVATE.getFlagCode())
+            .name(CASE_GIVEN_IN_PRIVATE.getName())
+            .status("Inactive")
+            .build()));
         when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
-                .thenReturn(Optional.of(new StrategicCaseFlag(
-                        appellantDisplayName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingFlags)));
+            .thenReturn(Optional.of(new StrategicCaseFlag(
+                appellantDisplayName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingFlags)));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -201,20 +216,21 @@ public class EvidenceInPrivateCaseFlagsHandlerTest {
     void should_not_set_flag_when_an_active_one_exists(Event event) {
         when(callback.getEvent()).thenReturn(event);
         when(asylumCase.read(IN_CAMERA_COURT, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
-        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class)).thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_GRANTED));
+        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class))
+            .thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_GRANTED));
 
         List<CaseFlagDetail> existingFlags = List.of(new CaseFlagDetail("123", CaseFlagValue
-                .builder()
-                .flagCode(CASE_GIVEN_IN_PRIVATE.getFlagCode())
-                .name(CASE_GIVEN_IN_PRIVATE.getName())
-                .status("Active")
-                .build()));
+            .builder()
+            .flagCode(CASE_GIVEN_IN_PRIVATE.getFlagCode())
+            .name(CASE_GIVEN_IN_PRIVATE.getName())
+            .status("Active")
+            .build()));
         when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
-                .thenReturn(Optional.of(new StrategicCaseFlag(
-                        appellantDisplayName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingFlags)));
+            .thenReturn(Optional.of(new StrategicCaseFlag(
+                appellantDisplayName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingFlags)));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -233,8 +249,8 @@ public class EvidenceInPrivateCaseFlagsHandlerTest {
                 boolean canHandle = evidenceInPrivateCaseFlagsHandler.canHandle(callbackStage, callback);
 
                 if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-                        && List.of(REVIEW_HEARING_REQUIREMENTS, UPDATE_HEARING_ADJUSTMENTS)
-                        .contains(callback.getEvent())) {
+                    && List.of(REVIEW_HEARING_REQUIREMENTS, UPDATE_HEARING_ADJUSTMENTS)
+                    .contains(callback.getEvent())) {
                     assertTrue(canHandle, "Can handle event " + event);
                 } else {
                     assertFalse(canHandle, "Cannot handle event " + event);
@@ -243,52 +259,36 @@ public class EvidenceInPrivateCaseFlagsHandlerTest {
         }
     }
 
-    @ParameterizedTest
-    @EnumSource(value = Event.class, names = {
-        "REVIEW_HEARING_REQUIREMENTS",
-        "UPDATE_HEARING_ADJUSTMENTS"
-    })
-    void should_throw_exception_when_appellant_name_is_missing(Event event) {
-        when(callback.getEvent()).thenReturn(event);
-        when(asylumCase.read(IN_CAMERA_COURT, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
-        when(asylumCase.read(IS_IN_CAMERA_COURT_ALLOWED, String.class)).thenReturn(Optional.of(EvidenceInPrivateCaseFlagsHandler.CASE_GRANTED));
-
-        assertThatThrownBy(() ->
-                evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
-                .hasMessage("Appellant full name is not present")
-                .isExactlyInstanceOf(IllegalStateException.class);
-    }
-
     @Test
     void should_not_allow_null_arguments() {
 
         assertThatThrownBy(() -> evidenceInPrivateCaseFlagsHandler.canHandle(null, callback))
-                .hasMessage("callbackStage must not be null")
-                .isExactlyInstanceOf(NullPointerException.class);
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> evidenceInPrivateCaseFlagsHandler.canHandle(ABOUT_TO_SUBMIT, null))
-                .hasMessage("callback must not be null")
-                .isExactlyInstanceOf(NullPointerException.class);
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> evidenceInPrivateCaseFlagsHandler.handle(null, callback))
-                .hasMessage("callbackStage must not be null")
-                .isExactlyInstanceOf(NullPointerException.class);
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> evidenceInPrivateCaseFlagsHandler.handle(ABOUT_TO_SUBMIT, null))
-                .hasMessage("callback must not be null")
-                .isExactlyInstanceOf(NullPointerException.class);
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
     }
 
     @Test
     void handler_throws_error_if_cannot_actually_handle() {
 
         assertThatThrownBy(() -> evidenceInPrivateCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
-                .hasMessage("Cannot handle callback")
-                .isExactlyInstanceOf(IllegalStateException.class);
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
 
         when(callback.getEvent()).thenReturn(Event.START_APPEAL);
         assertThatThrownBy(() -> evidenceInPrivateCaseFlagsHandler.handle(ABOUT_TO_SUBMIT, callback))
-                .hasMessage("Cannot handle callback")
-                .isExactlyInstanceOf(IllegalStateException.class);
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingRequirementsAppellantCaseFlagsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingRequirementsAppellantCaseFlagsHandlerTest.java
@@ -21,6 +21,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagTyp
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.STEP_FREE_WHEELCHAIR_ACCESS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.REVIEW_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUIREMENTS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
 import java.time.LocalDateTime;
@@ -67,6 +68,8 @@ public class HearingRequirementsAppellantCaseFlagsHandlerTest {
     public void setUp() {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(callback.getCaseDetails().getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(APPELLANT_NAME_FOR_DISPLAY, String.class))
+            .thenReturn(Optional.of(appellantDisplayName));
         when(systemDateProvider.nowWithTime()).thenReturn(LocalDateTime.now());
 
         hearingRequirementsAppellantCaseFlagsHandler =
@@ -158,7 +161,7 @@ public class HearingRequirementsAppellantCaseFlagsHandlerTest {
         when(asylumCase.read(IS_HEARING_ROOM_NEEDED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(asylumCase.read(APPELLANT_NAME_FOR_DISPLAY, String.class)).thenReturn(Optional.of(appellantDisplayName));
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -230,7 +233,7 @@ public class HearingRequirementsAppellantCaseFlagsHandlerTest {
         when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUIREMENTS);
         when(asylumCase.read(IS_HEARING_ROOM_NEEDED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -243,7 +246,7 @@ public class HearingRequirementsAppellantCaseFlagsHandlerTest {
         when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUIREMENTS);
         when(asylumCase.read(IS_HEARING_LOOP_NEEDED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -257,17 +260,17 @@ public class HearingRequirementsAppellantCaseFlagsHandlerTest {
         when(asylumCase.read(IS_HEARING_ROOM_NEEDED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
 
         List<CaseFlagDetail> existingFlags = List.of(new CaseFlagDetail("123", CaseFlagValue
-                .builder()
-                .flagCode(STEP_FREE_WHEELCHAIR_ACCESS.getFlagCode())
-                .name(STEP_FREE_WHEELCHAIR_ACCESS.getName())
-                .status("Inactive")
-                .build()));
+            .builder()
+            .flagCode(STEP_FREE_WHEELCHAIR_ACCESS.getFlagCode())
+            .name(STEP_FREE_WHEELCHAIR_ACCESS.getName())
+            .status("Inactive")
+            .build()));
         when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
             .thenReturn(Optional.of(new StrategicCaseFlag(
                 appellantDisplayName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingFlags)));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -285,17 +288,17 @@ public class HearingRequirementsAppellantCaseFlagsHandlerTest {
         when(asylumCase.read(IS_HEARING_ROOM_NEEDED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 
         List<CaseFlagDetail> existingFlags = List.of(new CaseFlagDetail("123", CaseFlagValue
-                .builder()
-                .flagCode(STEP_FREE_WHEELCHAIR_ACCESS.getFlagCode())
-                .name(STEP_FREE_WHEELCHAIR_ACCESS.getName())
-                .status("Inactive")
-                .build()));
+            .builder()
+            .flagCode(STEP_FREE_WHEELCHAIR_ACCESS.getFlagCode())
+            .name(STEP_FREE_WHEELCHAIR_ACCESS.getName())
+            .status("Inactive")
+            .build()));
         when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
             .thenReturn(Optional.of(new StrategicCaseFlag(
                 appellantDisplayName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingFlags)));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -313,17 +316,17 @@ public class HearingRequirementsAppellantCaseFlagsHandlerTest {
         when(asylumCase.read(IS_HEARING_LOOP_NEEDED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 
         List<CaseFlagDetail> existingFlags = List.of(new CaseFlagDetail("123", CaseFlagValue
-                .builder()
-                .flagCode(HEARING_LOOP.getFlagCode())
-                .name(HEARING_LOOP.getName())
-                .status("Active")
-                .build()));
+            .builder()
+            .flagCode(HEARING_LOOP.getFlagCode())
+            .name(HEARING_LOOP.getName())
+            .status("Active")
+            .build()));
         when(asylumCase.read(APPELLANT_LEVEL_FLAGS, StrategicCaseFlag.class))
             .thenReturn(Optional.of(new StrategicCaseFlag(
                 appellantDisplayName, StrategicCaseFlag.ROLE_ON_CASE_APPELLANT, existingFlags)));
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-                hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -342,29 +345,14 @@ public class HearingRequirementsAppellantCaseFlagsHandlerTest {
                 boolean canHandle = hearingRequirementsAppellantCaseFlagsHandler.canHandle(callbackStage, callback);
 
                 if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-                        && List.of(REVIEW_HEARING_REQUIREMENTS, UPDATE_HEARING_REQUIREMENTS)
-                        .contains(callback.getEvent())) {
+                    && List.of(REVIEW_HEARING_REQUIREMENTS, UPDATE_HEARING_REQUIREMENTS)
+                    .contains(callback.getEvent())) {
                     assertTrue(canHandle, "Can handle event " + event);
                 } else {
                     assertFalse(canHandle, "Cannot handle event " + event);
                 }
             }
         }
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = Event.class, names = {
-        "REVIEW_HEARING_REQUIREMENTS",
-        "UPDATE_HEARING_REQUIREMENTS"
-    })
-    void should_throw_exception_when_appellant_name_is_missing(Event event) {
-        when(callback.getEvent()).thenReturn(event);
-        when(asylumCase.read(IS_HEARING_ROOM_NEEDED, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
-
-        assertThatThrownBy(() ->
-            hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
-                .hasMessage("Appellant full name is not present")
-                .isExactlyInstanceOf(IllegalStateException.class);
     }
 
     @Test
@@ -390,7 +378,7 @@ public class HearingRequirementsAppellantCaseFlagsHandlerTest {
     @Test
     void handler_throws_error_if_cannot_actually_handle() {
 
-        assertThatThrownBy(() -> hearingRequirementsAppellantCaseFlagsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+        assertThatThrownBy(() -> hearingRequirementsAppellantCaseFlagsHandler.handle(ABOUT_TO_START, callback))
             .hasMessage("Cannot handle callback")
             .isExactlyInstanceOf(IllegalStateException.class);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7869


### Change description ###
* Some refactorings
* Create a class to enclose the ID-VALUE pair for witness level flags (for clarity and documentation of the use of the ID here as an identifier for the witness related to the flags)
* Update 'CreateFlagsHandler' to use this new class for Witness flags
* Use 'witnessPartyId' field as the ID for the witness level flags. This 'witnessPartyId' is set to the ID part of the witness level flags to create a 1:1 map between a witness and a witness level set of flags.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
