### PR TITLE
RIA-7278 RIA-7706 Enable internal notification for requestResponseAmend event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -204,8 +204,9 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
                 Event.UPDATE_HEARING_REQUIREMENTS,
                 Event.MAINTAIN_CASE_LINKS,
                 Event.CREATE_CASE_LINK,
-                Event.UPLOAD_ADDITIONAL_EVIDENCE
-        );
+                Event.UPLOAD_ADDITIONAL_EVIDENCE,
+                Event.REQUEST_RESPONSE_AMEND
+                );
 
         if (!isSaveAndContinueEnabled) {
             //eventsToHandle.add(Event.BUILD_CASE);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandlerTest.java
@@ -146,7 +146,8 @@ class SendNotificationHandlerTest {
             Event.MARK_APPEAL_AS_DETAINED,
             Event.CREATE_CASE_LINK,
             Event.MAINTAIN_CASE_LINKS,
-            Event.MARK_AS_READY_FOR_UT_TRANSFER
+            Event.MARK_AS_READY_FOR_UT_TRANSFER,
+            Event.REQUEST_RESPONSE_AMEND
         ).forEach(event -> {
 
             AsylumCase expectedUpdatedCase = mock(AsylumCase.class);
@@ -305,8 +306,9 @@ class SendNotificationHandlerTest {
                         Event.CREATE_CASE_LINK,
                         Event.MAINTAIN_CASE_LINKS,
                         Event.MARK_AS_READY_FOR_UT_TRANSFER,
-                        Event.UPDATE_DETENTION_LOCATION
-                    ).contains(event)) {
+                        Event.UPDATE_DETENTION_LOCATION,
+                        Event.REQUEST_RESPONSE_AMEND
+                            ).contains(event)) {
 
                     assertTrue(canHandle);
                 } else {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7706
https://tools.hmcts.net/jira/browse/RIA-7278


### Change description ###
* Enabled requestResponseAmend event to internal events to handle
* Updated SendNotificationHandlerTest


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
