### PR TITLE
RIA-7922 Maintanance for witness fields

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -45,4 +45,9 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
         <cve>CVE-2023-41080</cve>
     </suppress>
+    <suppress>
+        <cve>CVE-2023-42794</cve>
+        <cve>CVE-2023-42795</cve>
+        <cve>CVE-2023-45648</cve>
+    </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/InterpreterLanguagesUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/InterpreterLanguagesUtils.java
@@ -207,16 +207,19 @@ public final class InterpreterLanguagesUtils {
             boolean signIsChosen = optionalSign.isPresent()
                                    && isInterpreterLanguagePopulated(optionalSign.get());
 
-            List<String> chosen = new ArrayList<>();
+            List<String> chosenLanguageType = new ArrayList<>();
             if (spokenIsChosen) {
-                chosen.add(SPOKEN_LANGUAGE_INTERPRETER.getValue());
+                chosenLanguageType.add(SPOKEN_LANGUAGE_INTERPRETER.getValue());
             }
             if (signIsChosen) {
-                chosen.add(SIGN_LANGUAGE_INTERPRETER.getValue());
+                chosenLanguageType.add(SIGN_LANGUAGE_INTERPRETER.getValue());
             }
 
-            if (!chosen.isEmpty()) {
-                asylumCase.write(WITNESS_N_INTERPRETER_CATEGORY_FIELD.get(i), chosen);
+            if (!chosenLanguageType.isEmpty()) {
+                asylumCase.write(WITNESS_N_INTERPRETER_CATEGORY_FIELD.get(i), chosenLanguageType);
+            } else {
+                asylumCase.clear(WITNESS_N_INTERPRETER_CATEGORY_FIELD.get(i));
+                asylumCase.clear(WITNESS_LIST_ELEMENT_N_FIELD.get(i));
             }
 
             i++;

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/InterpreterLanguagesUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/InterpreterLanguagesUtilsTest.java
@@ -5,14 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_1_INTERPRETER_LANGUAGE_CATEGORY;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_1_INTERPRETER_SIGN_LANGUAGE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_1_INTERPRETER_SPOKEN_LANGUAGE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_2_INTERPRETER_SIGN_LANGUAGE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_2_INTERPRETER_SPOKEN_LANGUAGE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_3_INTERPRETER_LANGUAGE_CATEGORY;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_3_INTERPRETER_SIGN_LANGUAGE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_3_INTERPRETER_SPOKEN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageCategory.SIGN_LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageCategory.SPOKEN_LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SIGN_LANGUAGE;
@@ -123,6 +116,38 @@ public class InterpreterLanguagesUtilsTest {
             .write(WITNESS_1_INTERPRETER_LANGUAGE_CATEGORY, List.of(
                 SPOKEN_LANGUAGE_INTERPRETER.getValue(), SIGN_LANGUAGE_INTERPRETER.getValue()));
         verify(asylumCase, times(1))
+            .clear(WITNESS_2_INTERPRETER_LANGUAGE_CATEGORY);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_LIST_ELEMENT_2);
+        verify(asylumCase, times(1))
             .write(WITNESS_3_INTERPRETER_LANGUAGE_CATEGORY, List.of(SPOKEN_LANGUAGE_INTERPRETER.getValue()));
+        verify(asylumCase, times(1))
+            .clear(WITNESS_4_INTERPRETER_LANGUAGE_CATEGORY);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_LIST_ELEMENT_4);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_5_INTERPRETER_LANGUAGE_CATEGORY);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_LIST_ELEMENT_5);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_6_INTERPRETER_LANGUAGE_CATEGORY);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_LIST_ELEMENT_6);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_7_INTERPRETER_LANGUAGE_CATEGORY);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_LIST_ELEMENT_7);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_8_INTERPRETER_LANGUAGE_CATEGORY);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_LIST_ELEMENT_8);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_9_INTERPRETER_LANGUAGE_CATEGORY);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_LIST_ELEMENT_9);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_10_INTERPRETER_LANGUAGE_CATEGORY);
+        verify(asylumCase, times(1))
+            .clear(WITNESS_LIST_ELEMENT_10);
     }
 }


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-7922](https://tools.hmcts.net/jira/browse/RIA-7922)


### Change description ###
- Made sure the fieldsToBeCleared list that collects fields to be cleared is emptied each time the user goes through the `whichWitnessRequiresInterpreter` page, otherwise it keeps stale data, as the class is a bean 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
