### PR TITLE
RIA-7792 clear witness list element fields

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -818,6 +818,36 @@ public enum AsylumCaseFieldDefinition {
     WITNESS_10(
         "witness10", new TypeReference<WitnessDetails>() {}),
 
+    WITNESS_LIST_ELEMENT_1(
+        "witnessListElement1", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_2(
+        "witnessListElement2", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_3(
+        "witnessListElement3", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_4(
+        "witnessListElement4", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_5(
+        "witnessListElement5", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_6(
+        "witnessListElement6", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_7(
+        "witnessListElement7", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_8(
+        "witnessListElement8", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_9(
+        "witnessListElement9", new TypeReference<DynamicMultiSelectList>() {}),
+
+    WITNESS_LIST_ELEMENT_10(
+        "witnessListElement10", new TypeReference<DynamicMultiSelectList>() {}),
+
     WITNESS_1_INTERPRETER_LANGUAGE_CATEGORY(
         "witness1InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/InterpreterLanguagesUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/InterpreterLanguagesUtils.java
@@ -51,6 +51,19 @@ public final class InterpreterLanguagesUtils {
         WITNESS_10_INTERPRETER_LANGUAGE_CATEGORY
     );
 
+    public static final List<AsylumCaseFieldDefinition> WITNESS_LIST_ELEMENT_N = List.of(
+        WITNESS_LIST_ELEMENT_1,
+        WITNESS_LIST_ELEMENT_2,
+        WITNESS_LIST_ELEMENT_3,
+        WITNESS_LIST_ELEMENT_4,
+        WITNESS_LIST_ELEMENT_5,
+        WITNESS_LIST_ELEMENT_6,
+        WITNESS_LIST_ELEMENT_7,
+        WITNESS_LIST_ELEMENT_8,
+        WITNESS_LIST_ELEMENT_9,
+        WITNESS_LIST_ELEMENT_10
+    );
+
     public static final List<AsylumCaseFieldDefinition> WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE = List.of(
         WITNESS_1_INTERPRETER_SPOKEN_LANGUAGE,
         WITNESS_2_INTERPRETER_SPOKEN_LANGUAGE,

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandler.java
@@ -4,6 +4,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_LIST_ELEMENT_N;
 import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_FIELD;
 import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_CATEGORY_FIELD;
 import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SIGN_LANGUAGE;
@@ -132,7 +133,18 @@ public class DraftHearingRequirementsHandler implements PreSubmitCallbackHandler
             persistWitnessInterpreterCategoryField(asylumCase);
         }
 
+        // WitnessListElement(s) are only needed for the AIP screens, they do not need to be written
+        clearAllWitnessListElementFields(asylumCase);
+
         return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    private void clearAllWitnessListElementFields(AsylumCase asylumCase) {
+        int i = 0;
+        while (i < 10) {
+            asylumCase.clear(WITNESS_LIST_ELEMENT_N.get(i));
+            i++;
+        }
     }
 
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesUpdateMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessesUpdateMidEventHandler.java
@@ -167,8 +167,12 @@ public class WitnessesUpdateMidEventHandler extends WitnessHandler
                         if (!isWitnessDeleted(inclusiveWitnessDetails.get(i))) {
                             if (witnessInterpreterCategories.contains(SPOKEN)) {
 
-                                if (witnessIsNewlyAdded || oldAsylumCase
-                                    .read(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(i)).isEmpty()) {
+                                Optional<InterpreterLanguageRefData> optionalLanguage = oldAsylumCase
+                                    .read(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(i));
+
+                                if (witnessIsNewlyAdded
+                                    || optionalLanguage.isEmpty()
+                                    || interpreterLanguageIsNull(optionalLanguage.get())) {
 
                                     asylumCase.write(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(i), spokenLanguages);
 
@@ -189,8 +193,12 @@ public class WitnessesUpdateMidEventHandler extends WitnessHandler
                             }
                             if (witnessInterpreterCategories.contains(SIGN)) {
 
-                                if (witnessIsNewlyAdded || oldAsylumCase
-                                    .read(WITNESS_N_INTERPRETER_SIGN_LANGUAGE.get(i)).isEmpty()) {
+                                Optional<InterpreterLanguageRefData> optionalLanguage = oldAsylumCase
+                                    .read(WITNESS_N_INTERPRETER_SIGN_LANGUAGE.get(i));
+
+                                if (witnessIsNewlyAdded
+                                    || optionalLanguage.isEmpty()
+                                    || interpreterLanguageIsNull(optionalLanguage.get())) {
 
                                     asylumCase.write(WITNESS_N_INTERPRETER_SIGN_LANGUAGE.get(i), signLanguages);
 
@@ -219,6 +227,11 @@ public class WitnessesUpdateMidEventHandler extends WitnessHandler
         }
 
         return response;
+    }
+
+    private boolean interpreterLanguageIsNull(InterpreterLanguageRefData interpreterLanguageRefData) {
+        return null == interpreterLanguageRefData.getLanguageRefData()
+               && null == interpreterLanguageRefData.getLanguageManualEntryDescription();
     }
 
     private void writeIndividualWitnessFields(AsylumCase asylumCase,
@@ -280,6 +293,7 @@ public class WitnessesUpdateMidEventHandler extends WitnessHandler
         }
 
         return oldLanguageField.isPresent()
+               && oldLanguageField.get().getLanguageManualEntry() != null
                && oldLanguageField.get().getLanguageManualEntry().contains(MANUAL_LANGUAGE_YES);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/DraftHearingRequirementsHandlerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_LIST_ELEMENT_N;
 import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_FIELD;
 import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_CATEGORY_FIELD;
 import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.InterpreterLanguagesUtils.WITNESS_N_INTERPRETER_SIGN_LANGUAGE;
@@ -77,6 +78,7 @@ class DraftHearingRequirementsHandlerTest {
         verify(asylumCase, times(1)).write(eq(AsylumCaseFieldDefinition.WITNESS_COUNT), eq(0));
         verify(asylumCase, times(1))
             .write(eq(AsylumCaseFieldDefinition.SUBMIT_HEARING_REQUIREMENTS_AVAILABLE), eq(YesOrNo.YES));
+        WITNESS_LIST_ELEMENT_N.forEach(witnessListElement -> verify(asylumCase, times(1)).clear(witnessListElement));
     }
 
     @Test
@@ -155,6 +157,8 @@ class DraftHearingRequirementsHandlerTest {
         WITNESS_N_INTERPRETER_CATEGORY_FIELD.forEach(field -> verify(asylumCase, times(1)).clear(field));
         WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.forEach(field -> verify(asylumCase, times(1)).clear(field));
         WITNESS_N_INTERPRETER_SIGN_LANGUAGE.forEach(field -> verify(asylumCase, times(1)).clear(field));
+        WITNESS_LIST_ELEMENT_N.forEach(field -> verify(asylumCase, times(1)).clear(field));
+        WITNESS_LIST_ELEMENT_N.forEach(witnessListElement -> verify(asylumCase, times(1)).clear(witnessListElement));
     }
 
     @Test
@@ -175,6 +179,7 @@ class DraftHearingRequirementsHandlerTest {
         verify(asylumCase, times(1))
             .write(eq(AsylumCaseFieldDefinition.SUBMIT_HEARING_REQUIREMENTS_AVAILABLE), eq(YesOrNo.YES));
         verify(asylumCase, times(0)).write(APPEAL_OUT_OF_COUNTRY, YesOrNo.NO);
+        WITNESS_LIST_ELEMENT_N.forEach(witnessListElement -> verify(asylumCase, times(1)).clear(witnessListElement));
     }
 
     @Test


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-7922](https://tools.hmcts.net/jira/browse/RIA-7922)


### Change description ###
- Added check against NPE in WitnessesUpdateMidEventHandler
- Added check for old language to be empty OR present with an object with null fields
- Cleared WitnessListElement(N) when submitting of `draftHearingRequirements` (field only used for AIP screens)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
