### PR TITLE
RIA-7792 Clear witness languages when category list does not contain …

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -50,5 +50,6 @@
         <cve>CVE-2023-42795</cve>
         <cve>CVE-2023-45648</cve>
         <cve>CVE-2023-5072</cve>
+        <cve>CVE-2023-31582</cve>
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandler.java
@@ -105,6 +105,7 @@ public class UpdateHearingRequirementsHandler extends WitnessHandler
 
             filterOutDeletedFieldsAndCompress(inclusiveWitnessDetails, asylumCase);
             filterOutDeletedWitnessesAndCompress(nonDeletedWitnesses, asylumCase);
+            clearLanguagesAccordingToCategories(asylumCase);
         }
 
         asylumCase.write(DISABLE_OVERVIEW_PAGE, YES);
@@ -139,6 +140,22 @@ public class UpdateHearingRequirementsHandler extends WitnessHandler
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    private void clearLanguagesAccordingToCategories(AsylumCase asylumCase) {
+        int i = 0;
+        while (i < 10) {
+            Optional<List<String>> categoriesOpt = asylumCase.read(WITNESS_N_INTERPRETER_CATEGORY_FIELD.get(i));
+            List<String> categories = categoriesOpt.orElse(Collections.emptyList());
+
+            if (!categories.contains(SPOKEN_LANGUAGE_INTERPRETER.getValue())) {
+                asylumCase.clear(WITNESS_N_INTERPRETER_SPOKEN_LANGUAGE.get(i));
+            }
+            if (!categories.contains(SIGN_LANGUAGE_INTERPRETER.getValue())) {
+                asylumCase.clear(WITNESS_N_INTERPRETER_SIGN_LANGUAGE.get(i));
+            }
+            i++;
+        }
     }
 
     private void changeUpdateHearingsApplicationsToCompleted(AsylumCase asylumCase) {

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandlerTest.java
@@ -512,13 +512,29 @@ public class UpdateHearingRequirementsHandlerTest {
         verify(asylumCase).clear(WITNESS_1_INTERPRETER_SIGN_LANGUAGE);
         verify(asylumCase).clear(WITNESS_2_INTERPRETER_SPOKEN_LANGUAGE);
         verify(asylumCase).clear(WITNESS_3);
+        verify(asylumCase).clear(WITNESS_3_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_3_INTERPRETER_SPOKEN_LANGUAGE);
         verify(asylumCase).clear(WITNESS_4);
+        verify(asylumCase).clear(WITNESS_4_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_4_INTERPRETER_SPOKEN_LANGUAGE);
         verify(asylumCase).clear(WITNESS_5);
+        verify(asylumCase).clear(WITNESS_5_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_5_INTERPRETER_SPOKEN_LANGUAGE);
         verify(asylumCase).clear(WITNESS_6);
+        verify(asylumCase).clear(WITNESS_6_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_6_INTERPRETER_SPOKEN_LANGUAGE);
         verify(asylumCase).clear(WITNESS_7);
+        verify(asylumCase).clear(WITNESS_7_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_7_INTERPRETER_SPOKEN_LANGUAGE);
         verify(asylumCase).clear(WITNESS_8);
+        verify(asylumCase).clear(WITNESS_8_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_8_INTERPRETER_SPOKEN_LANGUAGE);
         verify(asylumCase).clear(WITNESS_9);
+        verify(asylumCase).clear(WITNESS_9_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_9_INTERPRETER_SPOKEN_LANGUAGE);
         verify(asylumCase).clear(WITNESS_10);
+        verify(asylumCase).clear(WITNESS_10_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_10_INTERPRETER_SPOKEN_LANGUAGE);
     }
 
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateHearingRequirementsHandlerTest.java
@@ -509,6 +509,8 @@ public class UpdateHearingRequirementsHandlerTest {
         verify(asylumCase).write(eq(WITNESS_DETAILS), anyList());
 
         verify(asylumCase).write(WITNESS_COUNT, 2);
+        verify(asylumCase).clear(WITNESS_1_INTERPRETER_SIGN_LANGUAGE);
+        verify(asylumCase).clear(WITNESS_2_INTERPRETER_SPOKEN_LANGUAGE);
         verify(asylumCase).clear(WITNESS_3);
         verify(asylumCase).clear(WITNESS_4);
         verify(asylumCase).clear(WITNESS_5);


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-7922](https://tools.hmcts.net/jira/browse/RIA-7922)


### Change description ###
- Made `UpdateHearingRequirementsHandler` forcefully clear spoken language fields if 'spoken' isn't a selected category or sign language fields if 'sign' isn't a selected category

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
