### PR TITLE
RIA-7837 Update witness flags when language manual

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7338-review-sign-language-appellant-flag.json
+++ b/src/functionalTest/resources/scenarios/RIA-7338-review-sign-language-appellant-flag.json
@@ -143,7 +143,7 @@
             {
               "id": "$/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-Ff]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/",
               "value": {
-                "name": "Sign Language",
+                "name": "Sign Language Interpreter",
                 "subTypeKey": "sign",
                 "subTypeValue": "International sign language",
                 "status": "Active",

--- a/src/functionalTest/resources/scenarios/RIA-7338-update-sign-language-appellant-flag.json
+++ b/src/functionalTest/resources/scenarios/RIA-7338-update-sign-language-appellant-flag.json
@@ -145,7 +145,7 @@
             {
               "id": "$/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-Ff]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/",
               "value": {
-                "name": "Sign Language",
+                "name": "Sign Language Interpreter",
                 "subTypeKey": "sign",
                 "subTypeValue": "International sign language",
                 "status": "Active",

--- a/src/functionalTest/resources/scenarios/RIA-7658-review-add-witness-interpreter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7658-review-add-witness-interpreter.json
@@ -159,7 +159,7 @@
                 {
                   "id": "$/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-Ff]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/",
                   "value": {
-                    "name": "Sign Language",
+                    "name": "Sign Language Interpreter",
                     "subTypeValue": "manual sign language",
                     "status": "Active",
                     "flagCode": "RA0042"

--- a/src/functionalTest/resources/scenarios/RIA-7658-update-witness-interpreter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7658-update-witness-interpreter.json
@@ -133,7 +133,7 @@
                 {
                   "id": "$/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-Ff]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/",
                   "value": {
-                    "name": "Sign Language",
+                    "name": "Sign Language Interpreter",
                     "subTypeValue": "manual sign language",
                     "status": "Active",
                     "flagCode": "RA0042"

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/StrategicCaseFlagType.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/StrategicCaseFlagType.java
@@ -8,7 +8,7 @@ public enum StrategicCaseFlagType {
     HEARING_LOOP("RA0043", "Hearing loop (hearing enhancement system)"),
     STEP_FREE_WHEELCHAIR_ACCESS("RA0019", "Step free / wheelchair access"),
     CASE_GIVEN_IN_PRIVATE("SM0004", "Evidence given in private"),
-    SIGN_LANGUAGE("RA0042", "Sign Language"),
+    SIGN_LANGUAGE_INTERPRETER("RA0042", "Sign Language Interpreter"),
     INTERPRETER_LANGUAGE_FLAG("PF0015", "Language Interpreter");
 
     @JsonValue

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantInterpreterLanguageFlagsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantInterpreterLanguageFlagsHandler.java
@@ -5,7 +5,6 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageCategory.SIGN_LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageCategory.SPOKEN_LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.INTERPRETER_LANGUAGE_FLAG;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.SIGN_LANGUAGE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.REVIEW_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
@@ -64,7 +63,7 @@ public class AppellantInterpreterLanguageFlagsHandler implements PreSubmitCallba
         String currentDateTime = systemDateProvider.nowWithTime().toString();
 
         handleInterpreterLanguage(asylumCase, INTERPRETER_LANGUAGE_FLAG, currentDateTime);
-        handleInterpreterLanguage(asylumCase, SIGN_LANGUAGE, currentDateTime);
+        handleInterpreterLanguage(asylumCase, StrategicCaseFlagType.SIGN_LANGUAGE_INTERPRETER, currentDateTime);
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessInterpreterLanguageFlagsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessInterpreterLanguageFlagsHandler.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_LEVEL_FLAGS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.INTERPRETER_LANGUAGE_FLAG;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.SIGN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.SIGN_LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.REVIEW_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
@@ -91,7 +91,7 @@ public class WitnessInterpreterLanguageFlagsHandler extends WitnessCaseFlagsHand
 
             Language selectedSignLanguage = witnessesSignLanguageMap.get(details.getWitnessPartyId());
             flagsUpdated |= tryUpdate(
-                strategicCaseFlagService, SIGN_LANGUAGE, currentDateTime, selectedSignLanguage);
+                strategicCaseFlagService, SIGN_LANGUAGE_INTERPRETER, currentDateTime, selectedSignLanguage);
 
             if (flagsUpdated) {
                 caseDataUpdated = true;

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantInterpreterLanguageFlagsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AppellantInterpreterLanguageFlagsHandlerTest.java
@@ -20,7 +20,6 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageCategory.SIGN_LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageCategory.SPOKEN_LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.INTERPRETER_LANGUAGE_FLAG;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.SIGN_LANGUAGE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.REVIEW_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
@@ -50,6 +49,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.CaseFlagValue;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicList;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.InterpreterLanguageRefData;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlag;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.Value;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
@@ -220,7 +220,7 @@ public class AppellantInterpreterLanguageFlagsHandlerTest {
         StrategicCaseFlag appellantLanguageFlag = partyFlagsCaptor.getValue();
         List<CaseFlagDetail> flagDetails = appellantLanguageFlag.getDetails();
         assertEquals(1, flagDetails.size());
-        assertEquals(SIGN_LANGUAGE.getFlagCode(), flagDetails.get(0).getValue().getFlagCode());
+        assertEquals(StrategicCaseFlagType.SIGN_LANGUAGE_INTERPRETER.getFlagCode(), flagDetails.get(0).getValue().getFlagCode());
         assertEquals("Active", flagDetails.get(0).getValue().getStatus());
         assertEquals(signLanguageValue.getCode(), flagDetails.get(0).getValue().getSubTypeKey());
     }
@@ -247,7 +247,7 @@ public class AppellantInterpreterLanguageFlagsHandlerTest {
         StrategicCaseFlag appellantLanguageFlag = partyFlagsCaptor.getValue();
         List<CaseFlagDetail> flagDetails = appellantLanguageFlag.getDetails();
         assertEquals(1, flagDetails.size());
-        assertEquals(SIGN_LANGUAGE.getFlagCode(), flagDetails.get(0).getValue().getFlagCode());
+        assertEquals(StrategicCaseFlagType.SIGN_LANGUAGE_INTERPRETER.getFlagCode(), flagDetails.get(0).getValue().getFlagCode());
         assertEquals("Active", flagDetails.get(0).getValue().getStatus());
         assertEquals(signLanguageValue.getLabel(), flagDetails.get(0).getValue().getSubTypeValue());
     }
@@ -263,8 +263,8 @@ public class AppellantInterpreterLanguageFlagsHandlerTest {
 
         List<CaseFlagDetail> existingFlags = List.of(new CaseFlagDetail("123", CaseFlagValue
             .builder()
-            .flagCode(SIGN_LANGUAGE.getFlagCode())
-            .name(SIGN_LANGUAGE.getName())
+            .flagCode(StrategicCaseFlagType.SIGN_LANGUAGE_INTERPRETER.getFlagCode())
+            .name(StrategicCaseFlagType.SIGN_LANGUAGE_INTERPRETER.getName())
             .subTypeKey(signLanguageValue.getCode())
             .subTypeValue(signLanguageValue.getLabel())
             .status("Active")
@@ -284,7 +284,7 @@ public class AppellantInterpreterLanguageFlagsHandlerTest {
         StrategicCaseFlag appellantLanguageFlag = partyFlagsCaptor.getValue();
         List<CaseFlagDetail> flagDetails = appellantLanguageFlag.getDetails();
         assertEquals(1, flagDetails.size());
-        assertEquals(SIGN_LANGUAGE.getFlagCode(), flagDetails.get(0).getValue().getFlagCode());
+        assertEquals(StrategicCaseFlagType.SIGN_LANGUAGE_INTERPRETER.getFlagCode(), flagDetails.get(0).getValue().getFlagCode());
         assertEquals("Inactive", flagDetails.get(0).getValue().getStatus());
         assertEquals(signLanguageValue.getCode(), flagDetails.get(0).getValue().getSubTypeKey());
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessInterpreterLanguageFlagsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/WitnessInterpreterLanguageFlagsHandlerTest.java
@@ -19,7 +19,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_DETAILS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.WITNESS_LEVEL_FLAGS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.INTERPRETER_LANGUAGE_FLAG;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.SIGN_LANGUAGE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.StrategicCaseFlagType.SIGN_LANGUAGE_INTERPRETER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.REVIEW_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
@@ -217,8 +217,8 @@ public class WitnessInterpreterLanguageFlagsHandlerTest {
 
         List<CaseFlagDetail> existingFlags = List.of(new CaseFlagDetail("123", CaseFlagValue
             .builder()
-            .flagCode(SIGN_LANGUAGE.getFlagCode())
-            .name(SIGN_LANGUAGE.getName())
+            .flagCode(SIGN_LANGUAGE_INTERPRETER.getFlagCode())
+            .name(SIGN_LANGUAGE_INTERPRETER.getName())
             .subTypeKey(signLanguageValue.getCode())
             .subTypeValue(signLanguageValue.getLabel())
             .status(ACTIVE_STATUS)


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-7837](https://tools.hmcts.net/jira/browse/RIA-7837)

### Change description ###
- Changed enum value (`Sign language` --> `Sign language interpreter`)
- Made sure InterpreterLanguageRefData only has enabled value (no dynamic list if language manually entered, no manual language if no manual language selected.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
