### PR TITLE
RIA-7478 Added ignore 'document_hash' property for Document.java

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/field/Document.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/field/Document.java
@@ -2,12 +2,15 @@ package uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+//Ignoring unknown property 'document_hash' for now until we are integrating it later.
+@JsonIgnoreProperties(ignoreUnknown = true)
 @EqualsAndHashCode
 @ToString
 public class Document {


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-7478


### Change description ###
Added ignore 'document_hash' property for Document.java


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ x ] Does this PR introduce a breaking change
