### PR TITLE
RIA-7714 Added new event 'Respond to costs'

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7714_ho_respond_to_costs.json
+++ b/src/functionalTest/resources/scenarios/RIA-7714_ho_respond_to_costs.json
@@ -1,0 +1,120 @@
+{
+  "description": "RIA-7714: HO responds to costs applied by LR",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "HomeOfficeLart",
+    "input": {
+      "id": 7714,
+      "eventId": "respondToCosts",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "journeyType": "rep",
+          "appealType": "revocationOfProtection",
+          "appealGroundsRevocation": {
+            "values": [
+              "revocationRefugeeConvention",
+              "revocationHumanitarianProtection"
+            ]
+          },
+          "responseToApplicationTextArea": "Some explanation",
+          "typeOfHearingOption": "Yes",
+          "typeOfHearingExplanation": "Hearing explanation",
+          "respondToCostsList": {
+            "value": {
+              "code": "1",
+              "label": "Costs 1, Wasted costs, 13 Nov 2023"
+            },
+            "list_items": [
+              {
+                "code": "1",
+                "label": "Costs 1, Wasted costs, 13 Nov 2023"
+              }
+            ]
+          },
+          "appliesForCosts": [
+            {
+              "id": "1",
+              "value": {
+                "appliedCostsType": "Unreasonable costs",
+                "applyForCostsDecision": "Pending",
+                "respondentToCostsOrder": "Home office",
+                "applyForCostsHearingType": "No",
+                "scheduleOfCostsDocuments": [],
+                "applyForCostsCreationDate": "2023-11-13",
+                "applyForCostsApplicantType": "Legal representative",
+                "applyForCostsRespondentRole": "Respondent",
+                "argumentsAndEvidenceDetails": "",
+                "applyForCostsOotExplanation": "",
+                "ootUploadEvidenceDocuments": [],
+                "isApplyForCostsOot": "No",
+                "argumentsAndEvidenceDocuments": [
+                  {
+                    "id": "2f352b16-0ed9-4c2e-88c2-4bc091485504",
+                    "value": {
+                      "document_url": "http://dm-store:8080/documents/45ec3a85-8fad-4caa-81a5-6b3b5c3b3bb8",
+                      "document_filename": "test.pdf",
+                      "document_binary_url": "http://dm-store:8080/documents/45ec3a85-8fad-4caa-81a5-6b3b5c3b3bb8/binary"
+                    }
+                  }
+                ],
+                "applyForCostsHearingTypeExplanation": ""
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appealType": "revocationOfProtection",
+        "appealGroundsRevocation": {
+          "values": [
+            "revocationRefugeeConvention",
+            "revocationHumanitarianProtection"
+          ]
+        },
+        "appliesForCosts": [
+          {
+            "id": "1",
+            "value": {
+              "appliedCostsType": "Unreasonable costs",
+              "applyForCostsDecision": "Pending",
+              "respondentToCostsOrder": "Home office",
+              "applyForCostsHearingType": "No",
+              "scheduleOfCostsDocuments": [],
+              "applyForCostsCreationDate": "2023-11-13",
+              "applyForCostsApplicantType": "Legal representative",
+              "argumentsAndEvidenceDetails": "",
+              "responseToApplication": "Some explanation",
+              "responseHearingTypeExplanation": "Hearing explanation",
+              "responseHearingType": "Yes",
+              "applyForCostsRespondentRole": "Respondent",
+              "applyForCostsOotExplanation": "",
+              "ootUploadEvidenceDocuments": [],
+              "isApplyForCostsOot": "No",
+              "argumentsAndEvidenceDocuments": [
+                {
+                  "id": "2f352b16-0ed9-4c2e-88c2-4bc091485504",
+                  "value": {
+                    "document_url": "http://dm-store:8080/documents/45ec3a85-8fad-4caa-81a5-6b3b5c3b3bb8",
+                    "document_filename": "test.pdf",
+                    "document_binary_url": "http://dm-store:8080/documents/45ec3a85-8fad-4caa-81a5-6b3b5c3b3bb8/binary"
+                  }
+                }
+              ],
+              "applyForCostsHearingTypeExplanation": ""
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/src/functionalTest/resources/scenarios/RIA-7714_lr_respond_to_costs.json
+++ b/src/functionalTest/resources/scenarios/RIA-7714_lr_respond_to_costs.json
@@ -1,0 +1,120 @@
+{
+  "description": "RIA-7714: LR responds to costs applied by HO",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "LegalRepresentative",
+    "input": {
+      "id": 77141,
+      "eventId": "respondToCosts",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "journeyType": "rep",
+          "appealType": "revocationOfProtection",
+          "appealGroundsRevocation": {
+            "values": [
+              "revocationRefugeeConvention",
+              "revocationHumanitarianProtection"
+            ]
+          },
+          "responseToApplicationTextArea": "Some explanation",
+          "typeOfHearingOption": "Yes",
+          "typeOfHearingExplanation": "Hearing explanation",
+          "respondToCostsList": {
+            "value": {
+              "code": "1",
+              "label": "Costs 1, Wasted costs, 13 Nov 2023"
+            },
+            "list_items": [
+              {
+                "code": "1",
+                "label": "Costs 1, Wasted costs, 13 Nov 2023"
+              }
+            ]
+          },
+          "appliesForCosts": [
+            {
+              "id": "1",
+              "value": {
+                "appliedCostsType": "Unreasonable costs",
+                "applyForCostsDecision": "Pending",
+                "respondentToCostsOrder": "Legal representative",
+                "applyForCostsHearingType": "No",
+                "scheduleOfCostsDocuments": [],
+                "applyForCostsCreationDate": "2023-11-13",
+                "applyForCostsApplicantType": "Home office",
+                "applyForCostsRespondentRole": "Legal representative",
+                "argumentsAndEvidenceDetails": "",
+                "applyForCostsOotExplanation": "",
+                "ootUploadEvidenceDocuments": [],
+                "isApplyForCostsOot": "No",
+                "argumentsAndEvidenceDocuments": [
+                  {
+                    "id": "2f352b16-0ed9-4c2e-88c2-4bc091485504",
+                    "value": {
+                      "document_url": "http://dm-store:8080/documents/45ec3a85-8fad-4caa-81a5-6b3b5c3b3bb8",
+                      "document_filename": "test.pdf",
+                      "document_binary_url": "http://dm-store:8080/documents/45ec3a85-8fad-4caa-81a5-6b3b5c3b3bb8/binary"
+                    }
+                  }
+                ],
+                "applyForCostsHearingTypeExplanation": ""
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appealType": "revocationOfProtection",
+        "appealGroundsRevocation": {
+          "values": [
+            "revocationRefugeeConvention",
+            "revocationHumanitarianProtection"
+          ]
+        },
+        "appliesForCosts": [
+          {
+            "id": "1",
+            "value": {
+              "appliedCostsType": "Unreasonable costs",
+              "applyForCostsDecision": "Pending",
+              "respondentToCostsOrder": "Legal representative",
+              "applyForCostsHearingType": "No",
+              "scheduleOfCostsDocuments": [],
+              "applyForCostsCreationDate": "2023-11-13",
+              "applyForCostsApplicantType": "Home office",
+              "argumentsAndEvidenceDetails": "",
+              "responseToApplication": "Some explanation",
+              "responseHearingTypeExplanation": "Hearing explanation",
+              "responseHearingType": "Yes",
+              "applyForCostsRespondentRole": "Legal representative",
+              "applyForCostsOotExplanation": "",
+              "ootUploadEvidenceDocuments": [],
+              "isApplyForCostsOot": "No",
+              "argumentsAndEvidenceDocuments": [
+                {
+                  "id": "2f352b16-0ed9-4c2e-88c2-4bc091485504",
+                  "value": {
+                    "document_url": "http://dm-store:8080/documents/45ec3a85-8fad-4caa-81a5-6b3b5c3b3bb8",
+                    "document_filename": "test.pdf",
+                    "document_binary_url": "http://dm-store:8080/documents/45ec3a85-8fad-4caa-81a5-6b3b5c3b3bb8/binary"
+                  }
+                }
+              ],
+              "applyForCostsHearingTypeExplanation": ""
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ApplyForCosts.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ApplyForCosts.java
@@ -25,6 +25,12 @@ public class ApplyForCosts {
     private String applyForCostsOotExplanation;
     private List<IdValue<Document>> ootUploadEvidenceDocuments;
     private YesOrNo isApplyForCostsOot;
+    private String applyForCostsRespondentRole;
+    private String responseToApplication;
+    private YesOrNo responseHearingType;
+    private String responseHearingTypeExplanation; //only if type of hearing is yes
+    private List<IdValue<Document>> responseEvidence;
+
 
     public ApplyForCosts() {
         // noop -- for deserializer
@@ -43,7 +49,8 @@ public class ApplyForCosts {
             String respondentToCostsOrder,
             String applyForCostsOotExplanation,
             List<IdValue<Document>> ootUploadEvidenceDocuments,
-            YesOrNo isApplyForCostsOot
+            YesOrNo isApplyForCostsOot,
+            String applyForCostsRespondentRole
     ) {
         requireNonNull(appliedCostsType);
         requireNonNull(argumentsAndEvidenceDocuments);
@@ -74,6 +81,7 @@ public class ApplyForCosts {
         this.applyForCostsOotExplanation = applyForCostsOotExplanation;
         this.ootUploadEvidenceDocuments = ootUploadEvidenceDocuments;
         this.isApplyForCostsOot = isApplyForCostsOot;
+        this.applyForCostsRespondentRole = applyForCostsRespondentRole;
     }
 
 
@@ -135,11 +143,47 @@ public class ApplyForCosts {
         return applyForCostsOotExplanation;
     }
 
+    public String getApplyForCostsRespondentRole() {
+        return applyForCostsRespondentRole;
+    }
+
     public List<IdValue<Document>> getOotUploadEvidenceDocuments() {
         return ootUploadEvidenceDocuments;
     }
 
     public YesOrNo getIsApplyForCostsOot() {
         return isApplyForCostsOot;
+    }
+
+    public void setResponseToApplication(String responseToApplication) {
+        this.responseToApplication = responseToApplication;
+    }
+
+    public String getResponseToApplication() {
+        return responseToApplication;
+    }
+
+    public void setResponseHearingTypeExplanation(String responseHearingTypeExplanation) {
+        this.responseHearingTypeExplanation = responseHearingTypeExplanation;
+    }
+
+    public void setEvidence(List<IdValue<Document>> evidence) {
+        this.responseEvidence = evidence;
+    }
+
+    public String getResponseHearingTypeExplanation() {
+        return responseHearingTypeExplanation;
+    }
+
+    public List<IdValue<Document>> getResponseEvidence() {
+        return responseEvidence;
+    }
+
+    public YesOrNo getResponseHearingType() {
+        return responseHearingType;
+    }
+
+    public void setResponseHearingType(YesOrNo responseHearingType) {
+        this.responseHearingType = responseHearingType;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1856,7 +1856,24 @@ public enum AsylumCaseFieldDefinition {
             "applyForCostsOotExplanation", new TypeReference<String>(){}),
 
     OOT_UPLOAD_EVIDENCE_DOCUMENTS(
-            "ootUploadEvidenceDocuments", new TypeReference<List<IdValue<Document>>>(){});
+            "ootUploadEvidenceDocuments", new TypeReference<List<IdValue<Document>>>(){}),
+
+    RESPOND_TO_COSTS_LIST(
+        "respondToCostsList", new TypeReference<DynamicList>(){}),
+
+    RESPONSE_TO_APPLICATION_TEXT_AREA(
+        "responseToApplicationTextArea", new TypeReference<String>(){}),
+
+    RESPONSE_TO_APPLICATION_EVIDENCE(
+        "responseToApplicationEvidence", new TypeReference<List<IdValue<Document>>>(){}),
+
+    TYPE_OF_HEARING_OPTION(
+        "typeOfHearingOption", new TypeReference<YesOrNo>(){}),
+
+    TYPE_OF_HEARING_EXPLANATION(
+        "typeOfHearingExplanation", new TypeReference<String>(){}),
+
+    ;
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/Event.java
@@ -128,6 +128,7 @@ public enum Event {
     UPDATE_DETENTION_LOCATION("updateDetentionLocation"),
     APPLY_FOR_COSTS("applyForCosts"),
     TURN_ON_NOTIFICATIONS("turnOnNotifications"),
+    RESPOND_TO_COSTS("respondToCosts"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/RespondToCostsConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/RespondToCostsConfirmation.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+
+import static java.util.Objects.requireNonNull;
+
+@Component
+public class RespondToCostsConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    public boolean canHandle(
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callback, "callback must not be null");
+
+        return callback.getEvent() == Event.RESPOND_TO_COSTS;
+    }
+
+    public PostSubmitCallbackResponse handle(
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+        PostSubmitCallbackResponse postSubmitResponse =
+            new PostSubmitCallbackResponse();
+
+        postSubmitResponse.setConfirmationHeader("# You've responded to the costs application");
+        postSubmitResponse.setConfirmationBody(
+                "#### What happens next\n\n"
+                        + "You and the applicant will get an email notification confirming your response to the application.\n\n"
+                        + "You will be notified when the Tribunal has considered your response.\n\nYou can review your response in the [Costs tab](/cases/case-details/" + callback.getCaseDetails().getId() + "#Costs)."
+        );
+
+        return postSubmitResponse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RespondToCostsPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RespondToCostsPreparer.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.ApplyForCostsProvider;
+
+import java.util.List;
+
+@Component
+public class RespondToCostsPreparer implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final ApplyForCostsProvider applyForCostsProvider;
+
+    public RespondToCostsPreparer(ApplyForCostsProvider applyForCostsProvider) {
+        this.applyForCostsProvider = applyForCostsProvider;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_START
+               && callback.getEvent() == Event.RESPOND_TO_COSTS;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        PreSubmitCallbackResponse<AsylumCase> response = new PreSubmitCallbackResponse<>(asylumCase);
+
+        List<Value> applyForCostsList = applyForCostsProvider.getApplyForCosts(asylumCase);
+        if (applyForCostsList.isEmpty()) {
+            response.addError("You do not have any cost applications to respond to.");
+        } else {
+            DynamicList dynamicList = new DynamicList(applyForCostsList.get(0), applyForCostsList);
+            asylumCase.write(RESPOND_TO_COSTS_LIST, dynamicList);
+
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/applyforcosts/RespondToCostsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/applyforcosts/RespondToCostsHandler.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.applyforcosts;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class RespondToCostsHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    @Override
+    public boolean canHandle(PreSubmitCallbackStage callbackStage, Callback<AsylumCase> callback) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                && callback.getEvent() == Event.RESPOND_TO_COSTS;
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<AsylumCase> handle(PreSubmitCallbackStage callbackStage, Callback<AsylumCase> callback) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+        DynamicList applyForCostsDynamicList = asylumCase.read(RESPOND_TO_COSTS_LIST, DynamicList.class)
+                .orElseThrow(() -> new IllegalStateException("respondToCostsDynamicList is not present"));
+        String applicationId = applyForCostsDynamicList.getValue().getCode();
+
+        String response = asylumCase.read(RESPONSE_TO_APPLICATION_TEXT_AREA, String.class)
+                .orElseThrow(() -> new IllegalStateException("No response to application is present"));
+        Optional<List<IdValue<Document>>> evidenceDocuments = asylumCase.read(RESPONSE_TO_APPLICATION_EVIDENCE);
+        Optional<String> typeOfHearingExplanation = asylumCase.read(TYPE_OF_HEARING_EXPLANATION, String.class);
+        YesOrNo typeOfHearing = asylumCase.read(TYPE_OF_HEARING_OPTION, YesOrNo.class)
+                .orElseThrow(() -> new IllegalStateException("typeOfHearing is not present"));
+
+        Optional<List<IdValue<ApplyForCosts>>> mayBeApplyForCosts = asylumCase.read(APPLIES_FOR_COSTS);
+
+        mayBeApplyForCosts
+                .orElse(Collections.emptyList())
+                .stream()
+                .filter(applyForCosts -> applyForCosts.getId().equals(applicationId))
+                .forEach(applyForCostsIdValue -> {
+                    ApplyForCosts applyForCosts = applyForCostsIdValue.getValue();
+                    applyForCosts.setResponseToApplication(response);
+                    applyForCosts.setEvidence(evidenceDocuments.orElse(Collections.emptyList()));
+                    applyForCosts.setResponseHearingType(typeOfHearing);
+                    if (typeOfHearing == YesOrNo.YES) {
+                        applyForCosts.setResponseHearingTypeExplanation(typeOfHearingExplanation.orElseThrow(() -> new IllegalStateException("typeOfHearingExplanation is not present")));
+                    }
+                });
+
+        asylumCase.write(APPLIES_FOR_COSTS, mayBeApplyForCosts);
+        asylumCase.clear(RESPONSE_TO_APPLICATION_TEXT_AREA);
+        asylumCase.clear(RESPONSE_TO_APPLICATION_EVIDENCE);
+        asylumCase.clear(TYPE_OF_HEARING_EXPLANATION);
+        asylumCase.clear(TYPE_OF_HEARING_OPTION);
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ApplyForCostsAppender.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ApplyForCostsAppender.java
@@ -77,7 +77,8 @@ public class ApplyForCostsAppender {
                 resolveRespondentToCostsOrder(applicant, legalRepName),
                 applyForCostsOotExplanation,
                 ootUploadEvidenceDocuments,
-                isApplyForCostsOot
+                isApplyForCostsOot,
+                resolveRespondentRoleToCostsOrder(applicant)
         );
 
         final List<IdValue<ApplyForCosts>> allAppliesForCosts =
@@ -97,6 +98,14 @@ public class ApplyForCostsAppender {
     private String resolveRespondentToCostsOrder(String applicant, String legalRepName) {
         return switch (applicant) {
             case homeOffice -> legalRepName;
+            case legalRepresentative -> homeOffice;
+            default -> throw new IllegalStateException("Provided applicant is not valid");
+        };
+    }
+
+    private String resolveRespondentRoleToCostsOrder(String applicant) {
+        return switch (applicant) {
+            case homeOffice -> legalRepresentative;
             case legalRepresentative -> homeOffice;
             default -> throw new IllegalStateException("Provided applicant is not valid");
         };

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ApplyForCostsProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ApplyForCostsProvider.java
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.service;
+
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPLIES_FOR_COSTS;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacaseapi.domain.UserDetailsHelper;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+public class ApplyForCostsProvider {
+
+    private final UserDetails userDetails;
+    private final UserDetailsHelper userDetailsHelper;
+
+    public ApplyForCostsProvider(
+        UserDetails userDetails,
+        UserDetailsHelper userDetailsHelper
+    ) {
+        this.userDetails = userDetails;
+        this.userDetailsHelper = userDetailsHelper;
+    }
+
+    public List<Value> getApplyForCosts(AsylumCase asylumCase) {
+        String loggedInUser = userDetailsHelper.getLoggedInUserRoleLabel(userDetails).toString();
+
+        Optional<List<IdValue<ApplyForCosts>>> existingApplyForCosts =
+                asylumCase.read(APPLIES_FOR_COSTS);
+        final String user = loggedInUser.equals("Respondent") ? "Home office" : loggedInUser;
+
+        List<Value> applyForCostsForRespondent = new ArrayList<>();
+        AtomicInteger counter = new AtomicInteger(1);
+        existingApplyForCosts
+                .orElse(Collections.emptyList())
+                .stream()
+                .forEach(idValue -> {
+                    ApplyForCosts applyForCosts = idValue.getValue();
+                    if (applyForCosts.getApplyForCostsRespondentRole().equals(user) && applyForCosts.getResponseToApplication() == null) {
+                        applyForCostsForRespondent.add(
+                                new Value(idValue.getId(), "Costs " + counter + ", " + applyForCosts.getAppliedCostsType() + ", " + formatDate(applyForCosts.getApplyForCostsCreationDate())));
+                    }
+                    counter.getAndIncrement();
+                });
+
+        return applyForCostsForRespondent;
+    }
+
+    // format date string to pattern dd MMM YYYY
+    public String formatDate(String date) {
+        LocalDate localDate = LocalDate.parse(date);
+        return localDate.format(DateTimeFormatter.ofPattern("d MMM yyyy"));
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -213,6 +213,7 @@ security:
       - "createCaseLink"
       - "maintainCaseLinks"
       - "applyForCosts"
+      - "respondToCosts"
     caseworker-ia-caseofficer:
       - "moveToPaymentPending"
       - "sendDirection"
@@ -346,12 +347,14 @@ security:
       - "uploadAddendumEvidenceHomeOffice"
       - "makeAnApplication"
       - "applyForCosts"
+      - "respondToCosts"
     caseworker-ia-homeofficelart:
       - "uploadHomeOfficeAppealResponse"
       - "uploadAdditionalEvidenceHomeOffice"
       - "uploadAddendumEvidenceHomeOffice"
       - "makeAnApplication"
       - "applyForCosts"
+      - "respondToCosts"
     caseworker-ia-homeofficepou:
       - "sendDirection"
       - "uploadAdditionalEvidenceHomeOffice"
@@ -359,6 +362,7 @@ security:
       - "applyForFTPARespondent"
       - "makeAnApplication"
       - "applyForCosts"
+      - "respondToCosts"
     caseworker-ia-respondentofficer:
       - "uploadHomeOfficeBundle"
       - "uploadHomeOfficeAppealResponse"
@@ -367,6 +371,7 @@ security:
       - "applyForFTPARespondent"
       - "makeAnApplication"
       - "applyForCosts"
+      - "respondToCosts"
     citizen:
       - "startAppeal"
       - "editAppeal"

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ApplyForCostsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ApplyForCostsTest.java
@@ -23,6 +23,7 @@ class ApplyForCostsTest {
     private String applyForCostsHearingTypeExplanation = "Test explanation";
     private String applyForCostsDecision = "Test decision";
     private String applyForCostsApplicantType = "Test applicant type";
+    private String applyForCostsRespondentRole = "Test respondent type";
     private String respondentToCostsOrder = "Respondent test type";
     private String applyForCostsCreationDate = "2020-09-21";
     private String applyForCostsOotExplanation = "Test explanation";
@@ -46,7 +47,8 @@ class ApplyForCostsTest {
             respondentToCostsOrder,
             applyForCostsOotExplanation,
             ootUploadEvidenceDocuments,
-            isApplyForCostsOot
+            isApplyForCostsOot,
+            applyForCostsRespondentRole
     );
 
     @Test
@@ -60,6 +62,7 @@ class ApplyForCostsTest {
         assertEquals(applyForCostsDecision, applyForCosts.getApplyForCostsDecision());
         assertEquals(applyForCostsApplicantType, applyForCosts.getApplyForCostsApplicantType());
         assertEquals(applyForCostsCreationDate, applyForCosts.getApplyForCostsCreationDate());
+        assertEquals(applyForCostsRespondentRole, applyForCosts.getApplyForCostsRespondentRole());
     }
 
     @Test
@@ -77,7 +80,8 @@ class ApplyForCostsTest {
                 respondentToCostsOrder,
                 applyForCostsOotExplanation,
                 ootUploadEvidenceDocuments,
-                isApplyForCostsOot))
+                isApplyForCostsOot,
+                applyForCostsRespondentRole))
                 .isExactlyInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> new ApplyForCosts(
@@ -93,7 +97,8 @@ class ApplyForCostsTest {
                 respondentToCostsOrder,
                 applyForCostsOotExplanation,
                 ootUploadEvidenceDocuments,
-                isApplyForCostsOot))
+                isApplyForCostsOot,
+                applyForCostsRespondentRole))
                 .isExactlyInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> new ApplyForCosts(
@@ -109,7 +114,8 @@ class ApplyForCostsTest {
                 respondentToCostsOrder,
                 applyForCostsOotExplanation,
                 ootUploadEvidenceDocuments,
-                isApplyForCostsOot))
+                isApplyForCostsOot,
+                applyForCostsRespondentRole))
                 .isExactlyInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> new ApplyForCosts(
@@ -125,7 +131,8 @@ class ApplyForCostsTest {
                 respondentToCostsOrder,
                 applyForCostsOotExplanation,
                 ootUploadEvidenceDocuments,
-                isApplyForCostsOot))
+                isApplyForCostsOot,
+                applyForCostsRespondentRole))
                 .isExactlyInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> new ApplyForCosts(
@@ -141,7 +148,8 @@ class ApplyForCostsTest {
                 respondentToCostsOrder,
                 applyForCostsOotExplanation,
                 ootUploadEvidenceDocuments,
-                isApplyForCostsOot))
+                isApplyForCostsOot,
+                applyForCostsRespondentRole))
                 .isExactlyInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> new ApplyForCosts(
@@ -157,7 +165,8 @@ class ApplyForCostsTest {
                 respondentToCostsOrder,
                 applyForCostsOotExplanation,
                 ootUploadEvidenceDocuments,
-                isApplyForCostsOot))
+                isApplyForCostsOot,
+                applyForCostsRespondentRole))
                 .isExactlyInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> new ApplyForCosts(
@@ -173,7 +182,8 @@ class ApplyForCostsTest {
                 respondentToCostsOrder,
                 applyForCostsOotExplanation,
                 ootUploadEvidenceDocuments,
-                isApplyForCostsOot))
+                isApplyForCostsOot,
+                applyForCostsRespondentRole))
                 .isExactlyInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> new ApplyForCosts(
@@ -189,7 +199,8 @@ class ApplyForCostsTest {
                 null,
                 applyForCostsOotExplanation,
                 ootUploadEvidenceDocuments,
-                isApplyForCostsOot))
+                isApplyForCostsOot,
+                applyForCostsRespondentRole))
                 .isExactlyInstanceOf(NullPointerException.class);
 
         assertThatThrownBy(() -> new ApplyForCosts(
@@ -205,7 +216,8 @@ class ApplyForCostsTest {
                 respondentToCostsOrder,
                 null,
                 ootUploadEvidenceDocuments,
-                isApplyForCostsOot))
+                isApplyForCostsOot,
+                applyForCostsRespondentRole))
                 .isExactlyInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/ccd/EventTest.java
@@ -127,10 +127,11 @@ class EventTest {
         assertEquals("updateDetentionLocation", Event.UPDATE_DETENTION_LOCATION.toString());
         assertEquals("applyForCosts", Event.APPLY_FOR_COSTS.toString());
         assertEquals("turnOnNotifications", Event.TURN_ON_NOTIFICATIONS.toString());
+        assertEquals("respondToCosts", Event.RESPOND_TO_COSTS.toString());
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(124, Event.values().length);
+        assertEquals(125, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/applyForCosts/RespondToCostsConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/applyForCosts/RespondToCostsConfirmationTest.java
@@ -1,0 +1,96 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit.applyforcosts;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit.RespondToCostsConfirmation;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RespondToCostsConfirmationTest {
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    private RespondToCostsConfirmation respondToCostsConfirmation = new RespondToCostsConfirmation();
+
+
+    @Test
+    void should_return_confirmation() {
+        when(callback.getEvent()).thenReturn(Event.RESPOND_TO_COSTS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        PostSubmitCallbackResponse callbackResponse =
+                respondToCostsConfirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        assertThat(
+                callbackResponse.getConfirmationHeader().get())
+                .contains("# You've responded to the costs application");
+
+        assertThat(
+                callbackResponse.getConfirmationBody().get())
+                .contains(
+                        "#### What happens next\n\n"
+                                + "You and the applicant will get an email notification confirming your response to the application.\n\n"
+                                + "You will be notified when the Tribunal has considered your response.\n\nYou can review your response in the [Costs tab](/cases/case-details/" + callback.getCaseDetails().getId() + "#Costs).");
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+        assertThatThrownBy(() -> respondToCostsConfirmation.handle(callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            boolean canHandle = respondToCostsConfirmation.canHandle(callback);
+
+            if (event == Event.RESPOND_TO_COSTS) {
+
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+        assertThatThrownBy(() -> respondToCostsConfirmation.canHandle(null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> respondToCostsConfirmation.handle(null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RespondToCostsPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RespondToCostsPreparerTest.java
@@ -1,0 +1,121 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicList;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.Value;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.ApplyForCostsProvider;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class RespondToCostsPreparerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private ApplyForCostsProvider applyForCostsProvider;
+
+    private RespondToCostsPreparer respondToCostsPreparer;
+
+    @BeforeEach
+    public void setUp() {
+
+        respondToCostsPreparer = new RespondToCostsPreparer(applyForCostsProvider);
+        when(callback.getEvent()).thenReturn(Event.RESPOND_TO_COSTS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetails().getCaseData()).thenReturn(asylumCase);
+    }
+
+    @Test
+    void should_write_dynamic_list_to_the_field() {
+        List<Value> applyForCostsList = new ArrayList<>();
+        applyForCostsList.add(new Value("1", "Costs 1, Wasted costs, 13 Nov 2023"));
+        applyForCostsList.add(new Value("2", "Costs 2, Unreasonable costs, 10 Nov 2023"));
+        when(applyForCostsProvider.getApplyForCosts(asylumCase)).thenReturn(applyForCostsList);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            respondToCostsPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        verify(asylumCase, times(1)).write(RESPOND_TO_COSTS_LIST, new DynamicList(applyForCostsList.get(0), applyForCostsList));
+    }
+
+
+    @Test
+    void should_add_error_if_dynamic_list_is_empty() {
+
+        when(applyForCostsProvider.getApplyForCosts(asylumCase)).thenReturn(Collections.emptyList());
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                respondToCostsPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertThat(callbackResponse.getErrors()).containsExactly("You do not have any cost applications to respond to.");
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(
+            () -> respondToCostsPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = respondToCostsPreparer.canHandle(callbackStage, callback);
+
+                if (event == Event.RESPOND_TO_COSTS
+                    && callbackStage == PreSubmitCallbackStage.ABOUT_TO_START) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> respondToCostsPreparer.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> respondToCostsPreparer.canHandle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/applyforcosts/RespondToCostsHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/applyforcosts/RespondToCostsHandlerTest.java
@@ -1,0 +1,171 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.applyforcosts;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class RespondToCostsHandlerTest {
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    private String responseExplanation = "explanation";
+    private ApplyForCosts applyForCosts;
+    @InjectMocks
+    private RespondToCostsHandler respondToCostsHandler;
+    private List<IdValue<Document>> responseEvidenceDocuments =
+            List.of(new IdValue<>("1",
+                    new Document("http://localhost/documents/123456",
+                            "http://localhost/documents/123456",
+                            "DocumentName.pdf")));
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        respondToCostsHandler = new RespondToCostsHandler();
+
+        when(callback.getEvent()).thenReturn(RESPOND_TO_COSTS);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetails().getCaseData()).thenReturn(asylumCase);
+
+        applyForCosts = new ApplyForCosts(
+                "Wasted Costs",
+                "Evidence Details",
+                responseEvidenceDocuments,
+                responseEvidenceDocuments,
+                YesOrNo.YES,
+                "Hearing explanation",
+                "Pending",
+                "Home Office",
+                "2023-11-10",
+                "Legal Rep Name",
+                "OOT explanation",
+                responseEvidenceDocuments,
+                YesOrNo.NO,
+                "Legal Representative");
+        List<IdValue<ApplyForCosts>> existingAppliesForCosts = new ArrayList<>();
+        existingAppliesForCosts.add(new IdValue<>("1", applyForCosts));
+
+        List<Value> respondToCostsList = new ArrayList<>();
+        respondToCostsList.add(new Value("1", "Costs 1, Wasted costs, 10 Nov 2023"));
+        DynamicList dynamicList = new DynamicList(new Value("1", "Costs 1, Wasted costs, 10 Nov 2023"), respondToCostsList);
+
+        when(asylumCase.read(RESPOND_TO_COSTS_LIST, DynamicList.class)).thenReturn(Optional.of(dynamicList));
+        when(asylumCase.read(APPLIES_FOR_COSTS)).thenReturn(Optional.of(existingAppliesForCosts));
+        when(asylumCase.read(RESPONSE_TO_APPLICATION_TEXT_AREA, String.class)).thenReturn(Optional.of(responseExplanation));
+        when(asylumCase.read(RESPONSE_TO_APPLICATION_EVIDENCE)).thenReturn(Optional.of(responseEvidenceDocuments));
+        when(asylumCase.read(TYPE_OF_HEARING_OPTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(TYPE_OF_HEARING_EXPLANATION, String.class)).thenReturn(Optional.of(responseExplanation));
+    }
+
+    @Test
+    void should_add_response_evidence_hearingExplanation() {
+
+        PreSubmitCallbackResponse<AsylumCase> response = respondToCostsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(response);
+        assertThat(applyForCosts.getResponseToApplication().equals(responseExplanation));
+        assertThat(applyForCosts.getResponseHearingType().equals(YesOrNo.YES));
+        assertThat(applyForCosts.getResponseHearingTypeExplanation().equals(responseExplanation));
+        assertThat(applyForCosts.getResponseEvidence().equals(responseEvidenceDocuments));
+    }
+
+    @Test
+    void should_throw_exception_if_responseToApplicationTextArea_missing() {
+        when(asylumCase.read(RESPONSE_TO_APPLICATION_TEXT_AREA, String.class)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> respondToCostsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("No response to application is present");
+
+    }
+
+    @Test
+    void should_throw_exception_if_typeOfHearingOption_missing() {
+        when(asylumCase.read(TYPE_OF_HEARING_OPTION, YesOrNo.class)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> respondToCostsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("typeOfHearing is not present");
+
+    }
+
+    @Test
+    void should_throw_exception_if_typeOfHearingExplanation_missing() {
+        when(asylumCase.read(TYPE_OF_HEARING_EXPLANATION, String.class)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> respondToCostsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("typeOfHearingExplanation is not present");
+
+    }
+
+    @Test
+    void should_throw_exception_if_respondToCostsDynamicList_missing() {
+        when(asylumCase.read(RESPOND_TO_COSTS_LIST, DynamicList.class)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> respondToCostsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("respondToCostsDynamicList is not present");
+
+    }
+
+
+    @Test
+    void handling_should_throw_if_stage_is_incorrect_handle() {
+        assertThatThrownBy(() -> respondToCostsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void handling_should_throw_if_event_is_incorrect_handle() {
+        when(callback.getEvent()).thenReturn(END_APPEAL);
+        assertThatThrownBy(() -> respondToCostsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+        assertThatThrownBy(() -> respondToCostsHandler.canHandle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> respondToCostsHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> respondToCostsHandler.handle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> respondToCostsHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ApplyForCostsAppenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ApplyForCostsAppenderTest.java
@@ -53,6 +53,8 @@ class ApplyForCostsAppenderTest {
     private String applyForCostsDecision = "Test decision";
     private String applyForCostsApplicantType = "Home office";
     private String applyForCostsApplicantTypeLegalRep = "Legal representative";
+    private String applyForCostsRespondentRoleLr = "Legal representative";
+    private String applyForCostsRespondentRoleHo = "Home office";
     private String respondentToCostsOrder = "Test name of LegalRep";
     private String respondentToCostsOrderHomeOffice = "Home office";
     private String applyForCostsCreationDate = "2020-09-21";
@@ -117,6 +119,7 @@ class ApplyForCostsAppenderTest {
         assertEquals(applyForCostsApplicantType, allAppliesForCosts.get(0).getValue().getApplyForCostsApplicantType());
         assertEquals(applyForCostsCreationDate, allAppliesForCosts.get(0).getValue().getApplyForCostsCreationDate());
         assertEquals(respondentToCostsOrder, allAppliesForCosts.get(0).getValue().getRespondentToCostsOrder());
+        assertEquals(applyForCostsRespondentRoleLr, allAppliesForCosts.get(0).getValue().getApplyForCostsRespondentRole());
 
         assertEquals(existingApplyForCosts1, allAppliesForCosts.get(1).getValue());
         assertEquals(existingApplyForCosts2, allAppliesForCosts.get(2).getValue());
@@ -157,6 +160,7 @@ class ApplyForCostsAppenderTest {
         assertEquals(applyForCostsApplicantTypeLegalRep, allAppliesForCosts.get(0).getValue().getApplyForCostsApplicantType());
         assertEquals(applyForCostsCreationDate, allAppliesForCosts.get(0).getValue().getApplyForCostsCreationDate());
         assertEquals(respondentToCostsOrderHomeOffice, allAppliesForCosts.get(0).getValue().getRespondentToCostsOrder());
+        assertEquals(applyForCostsRespondentRoleHo, allAppliesForCosts.get(0).getValue().getApplyForCostsRespondentRole());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ApplyForCostsProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/ApplyForCostsProviderTest.java
@@ -1,0 +1,82 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.UserDetailsHelper;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class ApplyForCostsProviderTest {
+    @Mock
+    private UserDetails userDetails;
+    @Mock
+    private UserDetailsHelper userDetailsHelper;
+    private ApplyForCostsProvider applyForCostsProvider;
+    private String applyForCostsOotExplanation = "Test explanation";
+    private List<IdValue<Document>> evidence =
+            List.of(new IdValue<>("1",
+                    new Document("http://localhost/documents/123456",
+                            "http://localhost/documents/123456",
+                            "DocumentName.pdf")));
+    private YesOrNo isApplyForCostsOot = YesOrNo.YES;
+    private ApplyForCosts applyForCosts;
+    @Mock private AsylumCase asylumCase;
+
+    @BeforeEach
+    public void setUp() {
+        applyForCostsProvider =
+                new ApplyForCostsProvider(userDetails, userDetailsHelper);
+        applyForCosts = new ApplyForCosts(
+                "Wasted Costs",
+                "Evidence Details",
+                evidence,
+                evidence,
+                YesOrNo.YES,
+                "Hearing explanation",
+                "Pending",
+                "Home Office",
+                "2023-11-10",
+                "Legal Rep Name",
+                "OOT explanation",
+                evidence,
+                YesOrNo.NO,
+                "Legal representative");
+        List<IdValue<ApplyForCosts>> existingAppliesForCosts = new ArrayList<>();
+        existingAppliesForCosts.add(new IdValue<>("1", applyForCosts));
+
+        when(asylumCase.read(AsylumCaseFieldDefinition.APPLIES_FOR_COSTS)).thenReturn(Optional.of(existingAppliesForCosts));
+    }
+
+    @Test
+    void should_return_apply_costs_in_list_for_LegalRep_loggedIn() {
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.LEGAL_REPRESENTATIVE);
+
+        List<Value> applyForCostsForRespondent = applyForCostsProvider.getApplyForCosts(asylumCase);
+        assertNotNull(applyForCostsForRespondent);
+        assertThat(applyForCostsForRespondent.size()).isEqualTo(1);
+        assertThat(applyForCostsForRespondent.get(0).getLabel().equals("Costs 1, Wasted Costs, 10 Nov 2023"));
+    }
+
+    @Test
+    void should_return_empty_list_for_HO_loggedIn() {
+        when(userDetailsHelper.getLoggedInUserRoleLabel(userDetails)).thenReturn(UserRoleLabel.HOME_OFFICE_GENERIC);
+
+        List<Value> applyForCostsForRespondent = applyForCostsProvider.getApplyForCosts(asylumCase);
+        assertNotNull(applyForCostsForRespondent);
+        assertThat(applyForCostsForRespondent.size()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
- Preparer: to validate if user can trigger the event or not & if yes, then populate DynamicList for the dropdown.
- Handler: to set the field values on the applyForCosts object and clear the fields.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
