### PR TITLE
RIA-7837 Update caseflags for manual languages updated with manual languages

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/StrategicCaseFlagService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/StrategicCaseFlagService.java
@@ -164,8 +164,12 @@ public class StrategicCaseFlagService {
         }
 
         CaseFlagDetail existingFlagDetails = activeDetails.get(caseFlagType.getFlagCode());
-        return Objects.equals(existingFlagDetails.getValue().getSubTypeKey(), language.getLanguageCode())
-            || Objects.equals(existingFlagDetails.getValue().getSubTypeValue(), language.getLanguageText());
+        return (Objects.equals(existingFlagDetails.getValue().getSubTypeKey(), language.getLanguageCode())
+               && !Objects.isNull(existingFlagDetails.getValue().getSubTypeKey())
+               && !Objects.isNull(language.getLanguageCode()))
+            || (Objects.equals(existingFlagDetails.getValue().getSubTypeValue(), language.getLanguageText())
+                && !Objects.isNull(existingFlagDetails.getValue().getSubTypeValue())
+                && !Objects.isNull(language.getLanguageText()));
     }
 
 }


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-7837](https://tools.hmcts.net/jira/browse/RIA-7837)


### Change description ###
- Made sure flags get updated when a manual language gets updated with another manual language
(issue was that both old and new languages had null code/key, so null equalling null would make the condition return true when checking whether the language matched the flag)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
