### PR TITLE
RIA-7779 LO Hearing type to be editable in the Edit appeal after subm…

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7779-edit-appeal-update-hearing-type-when-dc-appeal-type.json
+++ b/src/functionalTest/resources/scenarios/RIA-7779-edit-appeal-update-hearing-type-when-dc-appeal-type.json
@@ -1,0 +1,31 @@
+{
+  "description": "RIA-7779 edit appeal update hearing type when dc appeal type",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "editAppealAfterSubmit",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "appealType": "deprivation",
+          "rpDcAppealHearingOption": "decisionWithoutHearing",
+          "decisionHearingFeeOption": "decisionWithHearing"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "appealType": "deprivation",
+        "rpDcAppealHearingOption": "decisionWithoutHearing",
+        "decisionHearingFeeOption": "decisionWithoutHearing"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-7779


### Change description ###
- set the hearing type value to "decisionHearingFeeOption" field when the appeal is DC or RP with triggering "editAppealAfterSubmit" event
- added the unit test
- added the functional test


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
