### PR TITLE
RIA-7986 Enable automatic handling of hearing request and disable whe…

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7986-list-case-without-hearing-requirements-automatically-failed.json
+++ b/src/functionalTest/resources/scenarios/RIA-7986-list-case-without-hearing-requirements-automatically-failed.json
@@ -1,0 +1,31 @@
+{
+  "description": "RIA-7986 List case without hearing requirements automatically (Failed request)",
+  "request": {
+    "uri": "/asylum/ccdSubmitted",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 7986,
+      "eventId": "listCaseWithoutHearingRequirements",
+      "state": "listed",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "uploadAdditionalEvidenceActionAvailable": "Yes",
+          "listCaseHearingLength": "90",
+          "caseManagementLocation": {
+            "region": "1",
+            "baseLocation": "366559"
+          },
+          "manualCreHearingRequired": "Yes"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "confirmation": {
+      "header": "",
+      "body": "![Hearing could not be listed](https://raw.githubusercontent.com/hmcts/ia-appeal-frontend/master/app/assets/images/hearingCouldNotBeListed.png)### What happens next\n\nThe hearing could not be auto-requested. Please manually request the hearing via the [Hearings tab](/cases/case-details/7986/hearings)"
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7986-list-case-without-hearing-requirements-automatically-succeeded.json
+++ b/src/functionalTest/resources/scenarios/RIA-7986-list-case-without-hearing-requirements-automatically-succeeded.json
@@ -1,0 +1,31 @@
+{
+  "description": "RIA-7986 List case without hearing requirements automatically (Succeeded request)",
+  "request": {
+    "uri": "/asylum/ccdSubmitted",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 7986,
+      "eventId": "listCaseWithoutHearingRequirements",
+      "state": "listed",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "uploadAdditionalEvidenceActionAvailable": "Yes",
+          "listCaseHearingLength": "90",
+          "caseManagementLocation": {
+            "region": "1",
+            "baseLocation": "366559"
+          },
+          "manualCreHearingRequired": "No"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "confirmation": {
+      "header": "# Hearing listed",
+      "body": "#### What happens next\n\nThe hearing request has been created and is visible on the [Hearings tab](/cases/case-details/7986/hearings)"
+    }
+  }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/iacaseapi/component/RecordAttendeesAndDurationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/iacaseapi/component/RecordAttendeesAndDurationTest.java
@@ -8,6 +8,7 @@ import static uk.gov.hmcts.reform.iacaseapi.component.testutils.fixtures.CaseDet
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
+import com.launchdarkly.sdk.LDValue;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -62,6 +63,12 @@ public class RecordAttendeesAndDurationTest extends SpringBootIntegrationTest im
     @Test
     @WithMockUser(authorities = {"caseworker-ia", "caseworker-ia-admofficer"})
     public void returns_confirmation_page_content() {
+
+        LDValue defaultValue = LDValue.parse("{\"epimsIds\":[]}");
+
+        when(userDetailsProvider.getUserDetails()).thenReturn(userDetails);
+        when(featureToggler.getJsonValue("auto-hearing-request-locations-list", defaultValue))
+            .thenReturn(defaultValue);
 
         addServiceAuthStub(server);
         PostSubmitCallbackResponseForTest response = iaCaseApiClient.ccdSubmitted(callback()

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1998,6 +1998,9 @@ public enum AsylumCaseFieldDefinition {
     MANUAL_UPDATE_HEARING_REQUIRED(
         "manualUpdHearingRequired", new TypeReference<YesOrNo>(){}),
 
+    MANUAL_CREATE_HEARING_REQUIRED(
+        "manualCreHearingRequired", new TypeReference<YesOrNo>(){}),
+
     UPDATE_HMC_REQUEST_SUCCESS(
             "updateHmcRequestSuccess", new TypeReference<YesOrNo>() {}),
     NEXT_HEARING_FORMAT(

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/ListCaseWithoutHearingRequirementsAutomaticallyConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/ListCaseWithoutHearingRequirementsAutomaticallyConfirmation.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_CREATE_HEARING_REQUIRED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.LIST_CASE_WITHOUT_HEARING_REQUIREMENTS;
+
+import java.util.Objects;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.LocationBasedFeatureToggler;
+
+
+@Component
+public class ListCaseWithoutHearingRequirementsAutomaticallyConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
+
+    private static final String WHAT_HAPPENS_NEXT_LABEL = "### What happens next\n\n";
+    private static final String HEARING_COULD_NOT_BE_LISTED_PNG =
+        """
+            ![Hearing could not be listed](https://raw.githubusercontent.com/hmcts/
+            ia-appeal-frontend/master/app/assets/images/hearingCouldNotBeListed.png)
+            """;
+    private LocationBasedFeatureToggler locationBasedFeatureToggler;
+
+    public ListCaseWithoutHearingRequirementsAutomaticallyConfirmation(LocationBasedFeatureToggler locationBasedFeatureToggler) {
+        this.locationBasedFeatureToggler = locationBasedFeatureToggler;
+    }
+
+
+    public boolean canHandle(
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callback, "callback must not be null");
+
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+        Event event = callback.getEvent();
+
+        boolean isAutoHearingRequestEnabled = Objects.equals(
+            locationBasedFeatureToggler.isAutoHearingRequestEnabled(asylumCase),
+            YesOrNo.YES
+        );
+
+        return LIST_CASE_WITHOUT_HEARING_REQUIREMENTS.equals(event)
+               && isAutoHearingRequestEnabled;
+    }
+
+    public PostSubmitCallbackResponse handle(
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        PostSubmitCallbackResponse response =
+            new PostSubmitCallbackResponse();
+
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        boolean hearingRequestFailed = asylumCase.read(MANUAL_CREATE_HEARING_REQUIRED, YesOrNo.class)
+            .map(yesOrNo -> yesOrNo.equals(YesOrNo.YES))
+            .orElse(false);
+
+        long caseId = callback.getCaseDetails().getId();
+
+        if (hearingRequestFailed) {
+
+            response.setConfirmationHeader("");
+            response.setConfirmationBody(HEARING_COULD_NOT_BE_LISTED_PNG
+                                         + WHAT_HAPPENS_NEXT_LABEL
+                                         + "The hearing could not be auto-requested. Please manually request the "
+                                         + "hearing via the [Hearings tab](/cases/case-details/" + caseId + "/hearings)");
+        } else {
+            response.setConfirmationHeader("# Hearing listed");
+            response.setConfirmationBody("#### What happens next\n\n"
+                                         + "The hearing request has been created and is visible on the [Hearings tab]"
+                                         + "(/cases/case-details/" + caseId + "/hearings)");
+        }
+
+        return response;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinitionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinitionTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ATTENDING_TCW;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CASE_LEVEL_FLAGS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_CANCEL_HEARINGS_REQUIRED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_CREATE_HEARING_REQUIRED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_UPDATE_HEARING_REQUIRED;
 
 import java.util.Set;
@@ -22,7 +23,8 @@ class AsylumCaseFieldDefinitionTest {
                 ATTENDING_TCW,
                 CASE_LEVEL_FLAGS,
                 MANUAL_CANCEL_HEARINGS_REQUIRED,
-                MANUAL_UPDATE_HEARING_REQUIRED
+                MANUAL_UPDATE_HEARING_REQUIRED,
+                MANUAL_CREATE_HEARING_REQUIRED
             ).contains(val))
             .forEach(v -> assertThat(UPPER_UNDERSCORE.to(LOWER_CAMEL, v.name()))
                 .isEqualTo(v.value()));

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/ListCaseWithoutHearingRequirementsAutomaticallyConfirmationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/ListCaseWithoutHearingRequirementsAutomaticallyConfirmationTest.java
@@ -1,0 +1,149 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_CREATE_HEARING_REQUIRED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.LocationBasedFeatureToggler;
+
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ListCaseWithoutHearingRequirementsAutomaticallyConfirmationTest {
+
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+    @Mock private LocationBasedFeatureToggler locationBasedFeatureToggler;
+
+    private ListCaseWithoutHearingRequirementsAutomaticallyConfirmation confirmation;
+
+    @BeforeEach
+    void setup() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        confirmation = new ListCaseWithoutHearingRequirementsAutomaticallyConfirmation(locationBasedFeatureToggler);
+    }
+
+    @Test
+    void should_return_successful_confirmation() {
+
+        when(caseDetails.getId()).thenReturn(1L);
+        when(callback.getEvent()).thenReturn(Event.LIST_CASE_WITHOUT_HEARING_REQUIREMENTS);
+        when(locationBasedFeatureToggler.isAutoHearingRequestEnabled(asylumCase)).thenReturn(YES);
+
+        PostSubmitCallbackResponse callbackResponse =
+            confirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        assertThat(
+            callbackResponse.getConfirmationHeader().get())
+            .contains("Hearing listed");
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get())
+            .contains("The hearing request has been created and is visible on the [Hearings tab]"
+                      + "(/cases/case-details/1/hearings)");
+
+    }
+
+    @Test
+    void should_return_failed_confirmation() {
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getId()).thenReturn(1L);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.LIST_CASE_WITHOUT_HEARING_REQUIREMENTS);
+        when(asylumCase.read(MANUAL_CREATE_HEARING_REQUIRED, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(locationBasedFeatureToggler.isAutoHearingRequestEnabled(asylumCase)).thenReturn(YES);
+
+        PostSubmitCallbackResponse callbackResponse =
+            confirmation.handle(callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getConfirmationHeader().isPresent());
+        assertTrue(callbackResponse.getConfirmationBody().isPresent());
+
+        assertEquals("", callbackResponse.getConfirmationHeader().get());
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get())
+            .contains("hearingCouldNotBeListed.png");
+
+        assertThat(
+            callbackResponse.getConfirmationBody().get())
+            .contains("The hearing could not be auto-requested. Please manually request the "
+                      + "hearing via the [Hearings tab](/cases/case-details/1/hearings)");
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> confirmation.handle(callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = YesOrNo.class, names = { "YES", "NO" })
+    void it_can_handle_callback(YesOrNo autoHearingEnabled) {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+            when(caseDetails.getCaseData()).thenReturn(asylumCase);
+            when(locationBasedFeatureToggler.isAutoHearingRequestEnabled(asylumCase)).thenReturn(autoHearingEnabled);
+
+            boolean canHandle = confirmation.canHandle(callback);
+
+            if (event == Event.LIST_CASE_WITHOUT_HEARING_REQUIREMENTS && autoHearingEnabled == YES) {
+
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> confirmation.canHandle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> confirmation.handle(null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-7986](https://tools.hmcts.net/jira/browse/RIA-7986)


### Change description ###
- Handled `ListCaseWithoutHearingRequirements` separately when `caseManagementLocation` is included in locations indicated as enabled by LaunchDarklyFlag
- Delegated request to IA-HEARINGS-API when auto request is on
- Allowed data flow to go through old lines of code when auto request LD flag resolves as `false`

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
