### PR TITLE
RIA-8397 Take state for deletion condition from case instead of application

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -17,7 +17,7 @@
         ]]</notes>
         <cve>CVE-2022-45688</cve>
     </suppress>
-    <suppress until="2023-12-31">    
+    <suppress until="2024-06-01">
         <notes>Temporarily suppress vulnerability</notes>
         <cve>CVE-2023-20863</cve>
         <cve>CVE-2023-20873</cve>

--- a/src/functionalTest/resources/scenarios/RIA-7780-decide-an-application-change-hearing-type-error.json
+++ b/src/functionalTest/resources/scenarios/RIA-7780-decide-an-application-change-hearing-type-error.json
@@ -12,6 +12,7 @@
         "template": "minimal-appeal-submitted.json",
         "replacements": {
           "manualCanHearingRequired": "Yes",
+          "isIntegrated": "Yes",
           "appealType": "revocationOfProtection",
           "appealGroundsRevocation": {
             "values": [


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-8397](https://tools.hmcts.net/jira/browse/RIA-8397)


### Change description ###
- Made condition to delete hearing request be based on current state of the case instead of state that was written into the application at the time the application was submitted

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
