### PR TITLE
RIA-8432 RIA-8433 Tweak legalRepPartyId(s)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/LegalRepresentativeUpdateDetailsHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/LegalRepresentativeUpdateDetailsHandler.java
@@ -1,8 +1,11 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_ORGANISATION_REQUEST_FIELD;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LEGAL_REP_COMPANY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LEGAL_REP_REFERENCE_NUMBER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PREVIOUS_REPRESENTATIONS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.service.PartyIdService.resetLegalRepPartyId;
 
 import java.util.Collections;
 import java.util.List;
@@ -56,6 +59,7 @@ public class LegalRepresentativeUpdateDetailsHandler implements PreSubmitCallbac
 
         if (changeOrganisationRequest.isPresent()) {
             writeToPreviousRepresentations(callback);
+            resetLegalRepPartyId(asylumCase);
         }
 
         String company = asylumCase.read(

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PinInPostActivated.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PinInPostActivated.java
@@ -92,6 +92,8 @@ public class PinInPostActivated implements PreSubmitCallbackStateHandler<AsylumC
         asylumCase.clear(AsylumCaseFieldDefinition.LEGAL_REP_COMPANY_NAME);
         asylumCase.clear(AsylumCaseFieldDefinition.LEGAL_REP_COMPANY_ADDRESS);
         asylumCase.clear(AsylumCaseFieldDefinition.LEGAL_REP_REFERENCE_NUMBER);
+        asylumCase.clear(AsylumCaseFieldDefinition.LEGAL_REP_INDIVIDUAL_PARTY_ID);
+        asylumCase.clear(AsylumCaseFieldDefinition.LEGAL_REP_ORGANISATION_PARTY_ID);
     }
 
     private void updateSubscription(AsylumCase asylumCase) {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/PartyIdService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/PartyIdService.java
@@ -69,6 +69,13 @@ public class PartyIdService {
         }
     }
 
+    public static void resetLegalRepPartyId(AsylumCase asylumCase) {
+        if (!HandlerUtils.isAipJourney(asylumCase)) {
+            asylumCase.write(LEGAL_REP_INDIVIDUAL_PARTY_ID, HearingPartyIdGenerator.generate());
+            asylumCase.write(LEGAL_REP_ORGANISATION_PARTY_ID, HearingPartyIdGenerator.generate());
+        }
+    }
+
     public static void setSponsorPartyId(AsylumCase asylumCase) {
 
         boolean isAppealOutOfCountry = asylumCase.read(APPELLANT_IN_UK, YesOrNo.class)

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PartyIdServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PartyIdServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPELLANT_IN_UK;
@@ -255,6 +256,18 @@ class PartyIdServiceTest {
         PartyIdService.setSponsorPartyId(asylumCase);
 
         verify(asylumCase, never()).write(eq(SPONSOR_PARTY_ID), anyString());
+
+    }
+
+    @Test
+    void should_reset_legal_rep_partyId_when_aip_journey() {
+
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.empty());
+
+        PartyIdService.resetLegalRepPartyId(asylumCase);
+
+        verify(asylumCase, times(1)).write(eq(LEGAL_REP_INDIVIDUAL_PARTY_ID), anyString());
+        verify(asylumCase, times(1)).write(eq(LEGAL_REP_ORGANISATION_PARTY_ID), anyString());
 
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PinInPostActivatedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/PinInPostActivatedTest.java
@@ -223,6 +223,8 @@ public class PinInPostActivatedTest {
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LEGAL_REP_COMPANY_NAME);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LEGAL_REP_COMPANY_ADDRESS);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LEGAL_REP_REFERENCE_NUMBER);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LEGAL_REP_INDIVIDUAL_PARTY_ID);
+        verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.LEGAL_REP_ORGANISATION_PARTY_ID);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.EMAIL);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.MOBILE_NUMBER);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.CONTACT_PREFERENCE);


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-8432](https://tools.hmcts.net/jira/browse/RIA-8432)
[RIA-8433](https://tools.hmcts.net/jira/browse/RIA-8433)


### Change description ###
- `legalRepIndividualPartyId` and `legalRepOrganisationPartyId` to be cleared when all other LR fields are cleared (`PIP_ACTIVATION` event)
- Calling `resetLegalRepPartyId(asylumCase)` in `LegalRepresentativeUpdateDetailsHandler.java` to regenerate `legalRepIndividualPartyId` and `legalRepOrganisationPartyId` when `UPDATE_LEGAL_REPRESENTATIVES_DETAILS` runs because of a change in LR (cannot call it from another class otherwise CHANGE_ORGANISATION_REQUEST_FIELD will have been cleared by then)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
