### PR TITLE
RIA-8074 Standard direction party appellant for EJP scenario

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-8074-internal-ejp-case-request-case-edit-direction.json
+++ b/src/functionalTest/resources/scenarios/RIA-8074-internal-ejp-case-request-case-edit-direction.json
@@ -1,0 +1,36 @@
+{
+  "description": "RIA-8074 Request case edit - EJP Unrep Non-detained - Appellant party",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "requestCaseEdit",
+      "state": "caseUnderReview",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isAdmin": "Yes",
+          "isEjp": "Yes",
+          "appellantInDetention": "No",
+          "isLegallyRepresentedEjp": "No",
+          "sendDirectionExplanation": null,
+          "sendDirectionParties": null,
+          "sendDirectionDateDue": null
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "sendDirectionExplanation": null,
+        "sendDirectionParties": "appellant",
+        "sendDirectionDateDue": null
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-8074-internal-ejp-force-request-case-building-direction.json
+++ b/src/functionalTest/resources/scenarios/RIA-8074-internal-ejp-force-request-case-building-direction.json
@@ -1,0 +1,35 @@
+{
+  "description": "RIA-8074 Force request case building - EJP Unrep Non-detained - Appellant party",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 8074,
+      "eventId": "forceRequestCaseBuilding",
+      "state": "*",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "sendDirectionExplanation": "Test",
+          "sendDirectionDateDue": "{$TODAY+28}",
+          "uploadHomeOfficeBundleAvailable": "Yes",
+          "isAdmin": "Yes",
+          "isEjp": "Yes",
+          "appellantInDetention": "No",
+          "isLegallyRepresentedEjp": "No"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "uploadHomeOfficeBundleAvailable": "Yes",
+        "sendDirectionParties": "appellant"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-8074-internal-ejp-request-case-building-direction.json
+++ b/src/functionalTest/resources/scenarios/RIA-8074-internal-ejp-request-case-building-direction.json
@@ -1,0 +1,35 @@
+{
+  "description": "RIA-8074 Request case building - EJP Unrep Non-detained - Appellant party",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 8074,
+      "eventId": "requestCaseBuilding",
+      "state": "*",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "sendDirectionExplanation": "Test",
+          "sendDirectionDateDue": "{$TODAY+28}",
+          "uploadHomeOfficeBundleAvailable": "Yes",
+          "isAdmin": "Yes",
+          "isEjp": "Yes",
+          "appellantInDetention": "No",
+          "isLegallyRepresentedEjp": "No"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "uploadHomeOfficeBundleAvailable": "Yes",
+        "sendDirectionParties": "appellant"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-8074-internal-ejp-request-new-hearing-requirements-direction.json
+++ b/src/functionalTest/resources/scenarios/RIA-8074-internal-ejp-request-new-hearing-requirements-direction.json
@@ -1,0 +1,35 @@
+{
+  "description": "RIA-8074 Request new hearing requirements - EJP Unrep Non-detained - Appellant party",
+  "launchDarklyKey": "reheard-feature:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 8074,
+      "eventId": "requestNewHearingRequirements",
+      "state": "ftpaDecided",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "caseFlagSetAsideReheardExists": "Yes",
+          "sendDirectionExplanation": "Test",
+          "sendDirectionDateDue": "{$TODAY+5}",
+          "isAdmin": "Yes",
+          "isEjp": "Yes",
+          "appellantInDetention": "No",
+          "isLegallyRepresentedEjp": "No"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "sendDirectionParties": "appellant"
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-8074-internal-ejp-request-response-review-direction.json
+++ b/src/functionalTest/resources/scenarios/RIA-8074-internal-ejp-request-response-review-direction.json
@@ -1,0 +1,35 @@
+{
+  "description": "RIA-8074 Request response review - EJP Unrep Non-detained - Appellant party",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 8074,
+      "eventId": "requestResponseReview",
+      "state": "*",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "sendDirectionExplanation": "Test",
+          "sendDirectionDateDue": "{$TODAY+28}",
+          "uploadHomeOfficeBundleAvailable": "Yes",
+          "isAdmin": "Yes",
+          "isEjp": "Yes",
+          "appellantInDetention": "No",
+          "isLegallyRepresentedEjp": "No"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "uploadHomeOfficeBundleAvailable": "Yes",
+        "sendDirectionParties": "appellant"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtils.java
@@ -89,4 +89,9 @@ public class HandlerUtils {
     public static boolean isEjpCase(AsylumCase asylumCase) {
         return asylumCase.read(IS_EJP, YesOrNo.class).orElse(YesOrNo.NO) == YesOrNo.YES;
     }
+
+    // This method uses the isLegallyRepresentedEjp field to check for Legally Represented EJP cases
+    public static boolean isLegallyRepresentedEjpCase(AsylumCase asylumCase) {
+        return asylumCase.read(IS_LEGALLY_REPRESENTED_EJP, YesOrNo.class).orElse(YesOrNo.NO) == YesOrNo.YES;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestCaseEditPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestCaseEditPreparer.java
@@ -2,8 +2,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SEND_DIRECTION_PARTIES;
-import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isAppellantInDetention;
-import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isInternalCase;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.*;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
@@ -41,8 +40,14 @@ public class RequestCaseEditPreparer implements PreSubmitCallbackHandler<AsylumC
                 .getCaseDetails()
                 .getCaseData();
 
-        asylumCase.write(SEND_DIRECTION_PARTIES, (isInternalCase(asylumCase) && isAppellantInDetention(asylumCase)
-                ? Parties.APPELLANT : Parties.LEGAL_REPRESENTATIVE));
+        boolean isInternalDetained = (isInternalCase(asylumCase) && isAppellantInDetention(asylumCase));
+        boolean isEjpUnrepNonDetained = (isEjpCase(asylumCase) && !isAppellantInDetention(asylumCase) && !isLegallyRepresentedEjpCase(asylumCase));
+
+        if (isInternalDetained || isEjpUnrepNonDetained) {
+            asylumCase.write(SEND_DIRECTION_PARTIES, Parties.APPELLANT);
+        } else {
+            asylumCase.write(SEND_DIRECTION_PARTIES, Parties.LEGAL_REPRESENTATIVE);
+        }
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestHearingRequirementsDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestHearingRequirementsDirectionHandler.java
@@ -93,8 +93,11 @@ public class RequestHearingRequirementsDirectionHandler implements PreSubmitCall
     }
 
     private Parties resolvePartiesForHearingRequirements(AsylumCase asylumCase) {
-        if (HandlerUtils.isAipJourney(asylumCase) ||
-                (isInternalCase(asylumCase) && isAppellantInDetention(asylumCase) && !isAcceleratedDetainedAppeal(asylumCase))) {
+
+        boolean isInternalDetainedNonAda = (isInternalCase(asylumCase) && isAppellantInDetention(asylumCase) && !isAcceleratedDetainedAppeal(asylumCase));
+        boolean isEjpUnrepNonDetained = (isEjpCase(asylumCase) && !isAppellantInDetention(asylumCase) && !isLegallyRepresentedEjpCase(asylumCase));
+
+        if (HandlerUtils.isAipJourney(asylumCase) || isInternalDetainedNonAda || isEjpUnrepNonDetained) {
             return Parties.APPELLANT;
         }
         return Parties.LEGAL_REPRESENTATIVE;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestNewHearingRequirementsDirectionPreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestNewHearingRequirementsDirectionPreparer.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.*;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -66,7 +67,13 @@ public class RequestNewHearingRequirementsDirectionPreparer implements PreSubmit
 
             asylumCase.write(SEND_DIRECTION_EXPLANATION, explanation);
 
-            asylumCase.write(SEND_DIRECTION_PARTIES, Parties.LEGAL_REPRESENTATIVE);
+            boolean isEjpUnrepNonDetained = (isEjpCase(asylumCase) && !isAppellantInDetention(asylumCase) && !isLegallyRepresentedEjpCase(asylumCase));
+
+            if (isEjpUnrepNonDetained) {
+                asylumCase.write(SEND_DIRECTION_PARTIES, Parties.APPELLANT);
+            } else {
+                asylumCase.write(SEND_DIRECTION_PARTIES, Parties.LEGAL_REPRESENTATIVE);
+            }
 
             asylumCase.write(SEND_DIRECTION_DATE_DUE,
                 dateProvider

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestResponseReviewHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestResponseReviewHandler.java
@@ -54,11 +54,10 @@ public class RequestResponseReviewHandler implements PreSubmitCallbackHandler<As
                        + "If you do not respond by the date indicated below, the case will automatically go to hearing."
         );
 
-        if (
-                isInternalCase(asylumCase)
-                && isAppellantInDetention(asylumCase)
-                && !isAcceleratedDetainedAppeal(asylumCase)
-        ) {
+        boolean isInternalDetainedNonAda = (isInternalCase(asylumCase) && isAppellantInDetention(asylumCase) && !isAcceleratedDetainedAppeal(asylumCase));
+        boolean isEjpUnrepNonDetained = (isEjpCase(asylumCase) && !isAppellantInDetention(asylumCase) && !isLegallyRepresentedEjpCase(asylumCase));
+
+        if (isInternalDetainedNonAda || isEjpUnrepNonDetained) {
             asylumCase.write(SEND_DIRECTION_PARTIES, Parties.APPELLANT);
         } else {
             asylumCase.write(SEND_DIRECTION_PARTIES, Parties.LEGAL_REPRESENTATIVE);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/DirectionPartiesResolver.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/DirectionPartiesResolver.java
@@ -1,9 +1,8 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.service;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SEND_DIRECTION_PARTIES;
-import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isAppellantInDetention;
-import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isInternalCase;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.*;
 
 import java.util.Optional;
 import org.springframework.stereotype.Service;
@@ -21,6 +20,9 @@ public class DirectionPartiesResolver {
 
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
+        boolean isInternalDetained = (isInternalCase(asylumCase) && isAppellantInDetention(asylumCase));
+        boolean isEjpUnrepNonDetained = (isEjpCase(asylumCase) && !isAppellantInDetention(asylumCase) && !isLegallyRepresentedEjpCase(asylumCase));
+
         switch (callback.getEvent()) {
 
             case LIST_CASE:
@@ -29,7 +31,7 @@ public class DirectionPartiesResolver {
             case FORCE_REQUEST_CASE_BUILDING:
             case REQUEST_RESPONSE_REVIEW:
             case REQUEST_NEW_HEARING_REQUIREMENTS:
-                return isInternalCase(asylumCase) && isAppellantInDetention(asylumCase)
+                return (isInternalDetained || isEjpUnrepNonDetained)
                         ? Parties.APPELLANT
                         : Parties.LEGAL_REPRESENTATIVE;
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/HandlerUtilsTest.java
@@ -127,4 +127,16 @@ class HandlerUtilsTest {
         when(asylumCase.read(IS_NOTIFICATION_TURNED_OFF, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
         assertFalse(HandlerUtils.isNotificationTurnedOff(asylumCase));
     }
+
+    @Test
+    void isLegallyRepresentedEjpCase_should_return_true() {
+        when(asylumCase.read(IS_LEGALLY_REPRESENTED_EJP, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        assertTrue(HandlerUtils.isLegallyRepresentedEjpCase(asylumCase));
+    }
+
+    @Test
+    void isLegallyRepresentedEjpCase_should_return_false() {
+        when(asylumCase.read(IS_LEGALLY_REPRESENTED_EJP, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        assertFalse(HandlerUtils.isLegallyRepresentedEjpCase(asylumCase));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestCaseEditPreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestCaseEditPreparerTest.java
@@ -86,6 +86,26 @@ class RequestCaseEditPreparerTest {
     }
 
     @Test
+    void should_prepare_send_direction_parties_field_appellant_ejp_unrep_non_detained() {
+        when(asylumCase.read(IS_EJP, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(IS_LEGALLY_REPRESENTED_EJP, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        final Parties expectedParties = Parties.APPELLANT;
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.REQUEST_CASE_EDIT);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            requestCaseEditPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).write(SEND_DIRECTION_PARTIES, expectedParties);
+    }
+
+    @Test
     void handling_should_throw_if_cannot_actually_handle() {
 
         assertThatThrownBy(() -> requestCaseEditPreparer.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-8074

### Change description ###

- Standard direction party being set to 'Appellant' for EJP scenario: 

**isEjp = Yes, appellantInDetention = No, isLegallyRepresentedEjp = No**

- Updates to DirectionPartiesResolver and handlers/preparers for these events:

**REQUEST_CASE_EDIT,
REQUEST_CASE_BUILDING,
FORCE_REQUEST_CASE_BUILDING,
REQUEST_RESPONSE_REVIEW,
REQUEST_NEW_HEARING_REQUIREMENTS.**

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
