### PR TITLE
RIA-7456 EJP Edit appeal handling Part 2 - detained

### DIFF
--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-api
 home: https://github.com/hmcts/ia-case-api
-version: 0.0.42
+version: 0.0.43
 description: Immigration & Asylum Case API
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/src/functionalTest/resources/scenarios/RIA-7456-edit-appeal-detained-ejp-case.json
+++ b/src/functionalTest/resources/scenarios/RIA-7456-edit-appeal-detained-ejp-case.json
@@ -1,0 +1,57 @@
+{
+  "description": "RIA-7456 Edit appeal - Detained Legally represented EJP case'",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-ejp-appeal-started.json",
+        "replacements": {
+          "appealReferenceNumber": "PA/12345/2024",
+          "appellantHasFixedAddress": null,
+          "contactPreference": null,
+          "wantsSms": null,
+          "mobileNumber": null,
+          "homeOfficeDecisionDate": null,
+          "decisionLetterReceivedDate": "2024-01-29",
+          "appellantInDetention": "Yes",
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "isLegallyRepresentedEjp": "Yes",
+          "legalRepCompanyEjp": "Company Name",
+          "legalRepGivenNameEjp": "FirstName",
+          "legalRepFamilyNameEjp": "LastName",
+          "legalRepEmailEjp": "legalrep@example.com",
+          "legalRepReferenceEjp": "REF123"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-ejp-appeal-started.json",
+      "replacements": {
+        "appealReferenceNumber": "PA/12345/2024",
+        "appellantHasFixedAddress": null,
+        "contactPreference": null,
+        "wantsSms": null,
+        "mobileNumber": null,
+        "homeOfficeDecisionDate": null,
+        "decisionLetterReceivedDate": "2024-01-29",
+        "appellantInDetention": "Yes",
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "isLegallyRepresentedEjp": "Yes",
+        "legalRepCompanyEjp": "Company Name",
+        "legalRepGivenNameEjp": "FirstName",
+        "legalRepFamilyNameEjp": "LastName",
+        "legalRepEmailEjp": "legalrep@example.com",
+        "legalRepReferenceEjp": "REF123"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1911,6 +1911,28 @@ public enum AsylumCaseFieldDefinition {
 
     JUDGE_EVIDENCE_FOR_COSTS_ORDER(
     "judgeEvidenceForCostsOrder", new TypeReference<List<IdValue<Document>>>(){}),
+
+    LEGAL_REP_COMPANY_EJP(
+        "legalRepCompanyEjp", new TypeReference<String>(){}),
+
+    LEGAL_REP_GIVEN_NAME_EJP(
+        "legalRepGivenNameEjp", new TypeReference<String>(){}),
+
+    LEGAL_REP_FAMILY_NAME_EJP(
+        "legalRepFamilyNameEjp", new TypeReference<String>(){}),
+
+    LEGAL_REP_EMAIL_EJP(
+        "legalRepEmailEjp", new TypeReference<String>(){}),
+
+    LEGAL_REP_REFERENCE_EJP(
+        "legalRepReferenceEjp", new TypeReference<String>(){}),
+
+    FIRST_TIER_TRIBUNAL_TRANSFER_DATE(
+        "firstTierTribunalTransferDate", new TypeReference<String>(){}),
+
+    STATE_OF_THE_APPEAL(
+        "stateOfTheAppeal", new TypeReference<String>(){}),
+
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EjpEditAppealHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EjpEditAppealHandler.java
@@ -1,0 +1,99 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.*;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+/*
+This handler handles clearing of EJP related fields for 2 scenarios:
+EJP case switching from repped to unrepped and EJP switching to paper form using Edit Appeal event
+ */
+
+@Slf4j
+@Component
+public class EjpEditAppealHandler implements PreSubmitCallbackHandler<AsylumCase> {
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                && callback.getEvent() == Event.EDIT_APPEAL)
+                && isInternalCase(callback.getCaseDetails().getCaseData());
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        Boolean ejpCase = sourceOfAppealEjp(asylumCase);
+        Boolean isLegallyRepresentedEjp = isLegallyRepresentedEjpCase(asylumCase);
+
+        if (ejpCase) {
+            // EJP case repped to unrepped scenario
+            if (!isLegallyRepresentedEjp) {
+                asylumCase.clear(LEGAL_REP_COMPANY_EJP);
+                asylumCase.clear(LEGAL_REP_GIVEN_NAME_EJP);
+                asylumCase.clear(LEGAL_REP_FAMILY_NAME_EJP);
+                asylumCase.clear(LEGAL_REP_EMAIL_EJP);
+                asylumCase.clear(LEGAL_REP_REFERENCE_EJP);
+            }
+            // Paper form to EJP scenario - clears paper form fields not in EJP flow
+            asylumCase.clear(TRIBUNAL_RECEIVED_DATE);
+            asylumCase.clear(HOME_OFFICE_DECISION_DATE);
+            asylumCase.clear(APPELLANT_IN_UK);
+            asylumCase.clear(IS_ACCELERATED_DETAINED_APPEAL);
+            asylumCase.clear(DECISION_HEARING_FEE_OPTION);
+
+            asylumCase.clear(UPLOAD_THE_APPEAL_FORM_DOCS);
+
+        } else {
+            // EJP to Paper Form scenario - clears all EJP fields
+            asylumCase.clear(UPPER_TRIBUNAL_REFERENCE_NUMBER);
+            asylumCase.clear(FIRST_TIER_TRIBUNAL_TRANSFER_DATE);
+            asylumCase.clear(STATE_OF_THE_APPEAL);
+            asylumCase.clear(UT_TRANSFER_DOC);
+            asylumCase.clear(UPLOAD_EJP_APPEAL_FORM_DOCS);
+            asylumCase.clear(IS_LEGALLY_REPRESENTED_EJP);
+            asylumCase.clear(LEGAL_REP_COMPANY_EJP);
+            asylumCase.clear(LEGAL_REP_GIVEN_NAME_EJP);
+            asylumCase.clear(LEGAL_REP_FAMILY_NAME_EJP);
+            asylumCase.clear(LEGAL_REP_EMAIL_EJP);
+            asylumCase.clear(LEGAL_REP_REFERENCE_EJP);
+
+            Optional<String> optionalDateReceived = asylumCase.read(DECISION_LETTER_RECEIVED_DATE, String.class);
+            Optional<String> optionalDateSent = asylumCase.read(HOME_OFFICE_DECISION_DATE, String.class);
+
+            if (optionalDateReceived.isPresent() && optionalDateSent.isPresent()) {
+                if (!isAcceleratedDetainedAppeal(asylumCase)) {
+                    asylumCase.clear(DECISION_LETTER_RECEIVED_DATE);
+                } else {
+                    asylumCase.clear(HOME_OFFICE_DECISION_DATE);
+                }
+            }
+        }
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandler.java
@@ -69,9 +69,10 @@ public class HearingTypeHandler implements PreSubmitCallbackHandler<AsylumCase> 
                 asylumCase.write(IS_ACCELERATED_DETAINED_APPEAL, NO);
             }
 
-            boolean isRpDcAda = appealTypeForDisplay != null
-                    && (appealTypeForDisplay == AppealTypeForDisplay.DC || appealTypeForDisplay == AppealTypeForDisplay.RP
-                    || asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class).orElse(NO) == YES);
+            isRpDcAdaEjp = appealTypeForDisplay != null
+                                   && (appealTypeForDisplay == AppealTypeForDisplay.DC || appealTypeForDisplay == AppealTypeForDisplay.RP
+                                       || asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class).orElse(NO) == YES
+                                       || sourceOfAppealEjp(asylumCase));
 
             Optional<YesOrNo> isAcceleratedDetainedAppeal =
                     asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class);
@@ -83,7 +84,7 @@ public class HearingTypeHandler implements PreSubmitCallbackHandler<AsylumCase> 
 
             boolean isAgeAssessmentAppeal = asylumCase.read(AGE_ASSESSMENT, YesOrNo.class).orElse(NO).equals(YES);
 
-            if (isRpDcAda && !isAgeAssessmentAppeal) {
+            if (isRpDcAdaEjp && !isAgeAssessmentAppeal) {
                 //No fee
                 asylumCase.write(HEARING_TYPE_RESULT, YES);
             } else {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/IsEjpHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/IsEjpHandler.java
@@ -28,7 +28,7 @@ public class IsEjpHandler implements PreSubmitCallbackHandler<AsylumCase> {
         requireNonNull(callback, "callback must not be null");
 
         return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-               && callback.getEvent() == Event.START_APPEAL
+               && (callback.getEvent() == Event.START_APPEAL || callback.getEvent() == Event.EDIT_APPEAL)
                && isInternalCase(callback.getCaseDetails().getCaseData());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EjpEditAppealHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EjpEditAppealHandlerTest.java
@@ -1,0 +1,131 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.*;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.SourceOfAppeal;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class EjpEditAppealHandlerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+
+    private EjpEditAppealHandler ejpEditAppealHandler;
+
+    @BeforeEach
+    void setup() {
+        ejpEditAppealHandler = new EjpEditAppealHandler();
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.EDIT_APPEAL);
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YES));
+    }
+
+    @Test
+    void should_clear_ejp_legal_rep_fields_when_editing_to_not_repped() {
+        when(asylumCase.read(SOURCE_OF_APPEAL, SourceOfAppeal.class)).thenReturn(Optional.of(SourceOfAppeal.TRANSFERRED_FROM_UPPER_TRIBUNAL));
+        when(asylumCase.read(IS_LEGALLY_REPRESENTED_EJP, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+
+        PreSubmitCallbackResponse<AsylumCase> response = ejpEditAppealHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertThat(response).isNotNull();
+        verify(asylumCase, times(1)).clear(LEGAL_REP_COMPANY_EJP);
+        verify(asylumCase, times(1)).clear(LEGAL_REP_GIVEN_NAME_EJP);
+        verify(asylumCase, times(1)).clear(LEGAL_REP_FAMILY_NAME_EJP);
+        verify(asylumCase, times(1)).clear(LEGAL_REP_EMAIL_EJP);
+        verify(asylumCase, times(1)).clear(LEGAL_REP_REFERENCE_EJP);
+    }
+
+    @Test
+    void should_clear_paper_form_fields_when_editing_to_ejp_case() {
+        when(asylumCase.read(SOURCE_OF_APPEAL, SourceOfAppeal.class)).thenReturn(Optional.of(SourceOfAppeal.TRANSFERRED_FROM_UPPER_TRIBUNAL));
+
+        PreSubmitCallbackResponse<AsylumCase> response = ejpEditAppealHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertThat(response).isNotNull();
+        verify(asylumCase, times(1)).clear(TRIBUNAL_RECEIVED_DATE);
+        verify(asylumCase, times(1)).clear(HOME_OFFICE_DECISION_DATE);
+        verify(asylumCase, times(1)).clear(APPELLANT_IN_UK);
+        verify(asylumCase, times(1)).clear(IS_ACCELERATED_DETAINED_APPEAL);
+        verify(asylumCase, times(1)).clear(DECISION_HEARING_FEE_OPTION);
+        verify(asylumCase, times(1)).clear(UPLOAD_THE_APPEAL_FORM_DOCS);
+    }
+
+    @Test
+    void should_clear_ejp_fields_when_editing_to_paper_form_case() {
+        when(asylumCase.read(SOURCE_OF_APPEAL, SourceOfAppeal.class)).thenReturn(Optional.of(SourceOfAppeal.PAPER_FORM));
+
+        PreSubmitCallbackResponse<AsylumCase> response = ejpEditAppealHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertThat(response).isNotNull();
+        verify(asylumCase, times(1)).clear(UPPER_TRIBUNAL_REFERENCE_NUMBER);
+        verify(asylumCase, times(1)).clear(FIRST_TIER_TRIBUNAL_TRANSFER_DATE);
+        verify(asylumCase, times(1)).clear(STATE_OF_THE_APPEAL);
+        verify(asylumCase, times(1)).clear(UT_TRANSFER_DOC);
+        verify(asylumCase, times(1)).clear(UPLOAD_EJP_APPEAL_FORM_DOCS);
+        verify(asylumCase, times(1)).clear(IS_LEGALLY_REPRESENTED_EJP);
+        verify(asylumCase, times(1)).clear(LEGAL_REP_COMPANY_EJP);
+        verify(asylumCase, times(1)).clear(LEGAL_REP_GIVEN_NAME_EJP);
+        verify(asylumCase, times(1)).clear(LEGAL_REP_FAMILY_NAME_EJP);
+        verify(asylumCase, times(1)).clear(LEGAL_REP_EMAIL_EJP);
+        verify(asylumCase, times(1)).clear(LEGAL_REP_REFERENCE_EJP);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = YesOrNo.class, names = { "NO", "YES" })
+    void should_clear_ho_letter_sent_field_editing_to_paper_form_non_ada(YesOrNo isAda) {
+        when(asylumCase.read(SOURCE_OF_APPEAL, SourceOfAppeal.class)).thenReturn(Optional.of(SourceOfAppeal.PAPER_FORM));
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(isAda));
+        when(asylumCase.read(DECISION_LETTER_RECEIVED_DATE, String.class)).thenReturn(Optional.of("2024-02-01"));
+        when(asylumCase.read(HOME_OFFICE_DECISION_DATE, String.class)).thenReturn(Optional.of("2024-02-01"));
+
+        PreSubmitCallbackResponse<AsylumCase> response = ejpEditAppealHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertThat(response).isNotNull();
+        if (isAda.equals(NO)) {
+            verify(asylumCase, times(1)).clear(DECISION_LETTER_RECEIVED_DATE);
+        } else {
+            verify(asylumCase, times(1)).clear(HOME_OFFICE_DECISION_DATE);
+        }
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> ejpEditAppealHandler.handle(MID_EVENT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> ejpEditAppealHandler.handle(ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingTypeHandlerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -216,11 +217,14 @@ class HearingTypeHandlerTest {
         assertThat(hearingTypeResult.getValue()).isEqualTo(YesOrNo.NO);
     }
 
-    @Test
-    void should_set_hearing_type_no_fee_for_ejp_cases_start_appeal() {
+    @ParameterizedTest
+    @EnumSource(value = Event.class, names = {
+        "START_APPEAL", "EDIT_APPEAL"
+    })
+    void should_set_hearing_type_no_fee_for_ejp_cases(Event event) {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        when(callback.getEvent()).thenReturn(event);
         when(asylumCase.read(SOURCE_OF_APPEAL, SourceOfAppeal.class))
             .thenReturn(Optional.of(SourceOfAppeal.TRANSFERRED_FROM_UPPER_TRIBUNAL));
         when(asylumCase.read(APPEAL_TYPE_FOR_DISPLAY, AppealTypeForDisplay.class))

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/IsEjpHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/IsEjpHandlerTest.java
@@ -6,14 +6,14 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.*;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.START_APPEAL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.*;
 
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -28,7 +28,6 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings("unchecked")
 class IsEjpHandlerTest {
 
     @Mock
@@ -45,15 +44,17 @@ class IsEjpHandlerTest {
         isEjpHandler = new IsEjpHandler();
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 
     }
 
-    @Test
-    void should_write_is_ejp_yes_for_transferred_from_ut() {
-
+    @ParameterizedTest
+    @EnumSource(value = Event.class, names = {
+        "START_APPEAL", "EDIT_APPEAL"
+    })
+    void should_write_is_ejp_yes_for_transferred_from_ut(Event event) {
+        when(callback.getEvent()).thenReturn(event);
         when(asylumCase.read(SOURCE_OF_APPEAL, SourceOfAppeal.class)).thenReturn(Optional.of(SourceOfAppeal.TRANSFERRED_FROM_UPPER_TRIBUNAL));
 
         PreSubmitCallbackResponse<AsylumCase> response = isEjpHandler.handle(ABOUT_TO_SUBMIT, callback);
@@ -62,9 +63,12 @@ class IsEjpHandlerTest {
         verify(asylumCase, times(1)).write(IS_EJP, YesOrNo.YES);
     }
 
-    @Test
-    void should_write_is_ejp_no_for_paper_form() {
-
+    @ParameterizedTest
+    @EnumSource(value = Event.class, names = {
+        "START_APPEAL", "EDIT_APPEAL"
+    })
+    void should_write_is_ejp_no_for_paper_form(Event event) {
+        when(callback.getEvent()).thenReturn(event);
         when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(asylumCase.read(SOURCE_OF_APPEAL, SourceOfAppeal.class)).thenReturn(Optional.of(SourceOfAppeal.PAPER_FORM));
 
@@ -74,27 +78,28 @@ class IsEjpHandlerTest {
         verify(asylumCase, times(1)).write(IS_EJP, YesOrNo.NO);
     }
 
-    @Test
-    void it_can_handle_callback() {
+    @ParameterizedTest
+    @EnumSource(value = Event.class)
+    void it_can_handle_callback(Event event) {
 
-        for (Event event : Event.values()) {
+        for (PreSubmitCallbackStage stage : PreSubmitCallbackStage.values()) {
             when(callback.getEvent()).thenReturn(event);
-            when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
-            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
-                boolean canHandle = isEjpHandler.canHandle(callbackStage, callback);
-                if (callbackStage == ABOUT_TO_SUBMIT && callback.getEvent().equals(START_APPEAL)
-                ) {
-                    assertTrue(canHandle);
-                } else {
-                    assertFalse(canHandle);
-                }
+            boolean canHandle = isEjpHandler.canHandle(stage, callback);
+
+            if (stage == ABOUT_TO_SUBMIT && (event == Event.START_APPEAL || event == Event.EDIT_APPEAL)) {
+                assertTrue(canHandle);
+            } else {
+                assertFalse(canHandle);
             }
-            reset(callback);
         }
     }
 
-    @Test
-    void handling_should_throw_if_cannot_actually_handle() {
+    @ParameterizedTest
+    @EnumSource(value = Event.class, names = {
+        "START_APPEAL", "EDIT_APPEAL"
+    })
+    void handling_should_throw_if_cannot_actually_handle(Event event) {
+        when(callback.getEvent()).thenReturn(event);
 
         Assertions.assertThatThrownBy(() -> isEjpHandler.handle(MID_EVENT, callback))
             .hasMessage("Cannot handle callback")
@@ -105,8 +110,12 @@ class IsEjpHandlerTest {
             .isExactlyInstanceOf(IllegalStateException.class);
     }
 
-    @Test
-    void should_not_allow_null_arguments() {
+    @ParameterizedTest
+    @EnumSource(value = Event.class, names = {
+        "START_APPEAL", "EDIT_APPEAL"
+    })
+    void should_not_allow_null_arguments(Event event) {
+        when(callback.getEvent()).thenReturn(event);
 
         assertThatThrownBy(() -> isEjpHandler.canHandle(null, callback))
             .hasMessage("callbackStage must not be null")


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-7456

### Change description ###

- EjpEditAppealHandler: this new handler handles scenarios when editing between EJP repped and unrepped, EJP to Paper form and Paper form to EJP.
- HearingTypeHandler: updated logic to include ejp check for Edit Appeal to set the correct value to show dateLetterReceived for all EJP flows
- IsEjpHandler: updated to set this flag to Yes/No for Edit Appeal event
- Updated and new unit tests
- New functional test for detained scenario

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
