### PR TITLE
RIA-7457 EJP Edit appeal part 3 - non detained handlers

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7457-edit-appeal-non-detained-ejp-case.json
+++ b/src/functionalTest/resources/scenarios/RIA-7457-edit-appeal-non-detained-ejp-case.json
@@ -1,0 +1,53 @@
+{
+  "description": "RIA-7457 Edit appeal - Non-detained Legally represented EJP case",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "eventId": "editAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-ejp-appeal-started.json",
+        "replacements": {
+          "appealReferenceNumber": "PA/12345/2024",
+          "appellantHasFixedAddress": "Yes",
+          "contactPreference": "wantsEmail",
+          "email": "example@exampke.com",
+          "mobileNumber": null,
+          "homeOfficeDecisionDate": null,
+          "decisionLetterReceivedDate": "2024-01-29",
+          "appellantInDetention": "No",
+          "isLegallyRepresentedEjp": "Yes",
+          "legalRepCompanyEjp": "Company Name",
+          "legalRepGivenNameEjp": "FirstName",
+          "legalRepFamilyNameEjp": "LastName",
+          "legalRepEmailEjp": "legalrep@example.com",
+          "legalRepReferenceEjp": "REF123"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-ejp-appeal-started.json",
+      "replacements": {
+        "appealReferenceNumber": "PA/12345/2024",
+        "appellantHasFixedAddress": "Yes",
+        "contactPreference": "wantsEmail",
+        "email": "example@exampke.com",
+        "mobileNumber": null,
+        "homeOfficeDecisionDate": null,
+        "decisionLetterReceivedDate": "2024-01-29",
+        "appellantInDetention": "No",
+        "isLegallyRepresentedEjp": "Yes",
+        "legalRepCompanyEjp": "Company Name",
+        "legalRepGivenNameEjp": "FirstName",
+        "legalRepFamilyNameEjp": "LastName",
+        "legalRepEmailEjp": "legalrep@example.com",
+        "legalRepReferenceEjp": "REF123"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EjpAppellantLegalPracticeAddressMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EjpAppellantLegalPracticeAddressMidEventHandler.java
@@ -28,7 +28,7 @@ public class EjpAppellantLegalPracticeAddressMidEventHandler implements PreSubmi
         requireNonNull(callback, "callback must not be null");
 
         return (callbackStage == PreSubmitCallbackStage.MID_EVENT
-               && callback.getEvent() == Event.START_APPEAL
+               && (callback.getEvent() == Event.START_APPEAL || callback.getEvent() == Event.EDIT_APPEAL)
                && callback.getPageId().equals(NATIONALITIES_PAGE_ID)
                && sourceOfAppealEjp(callback.getCaseDetails().getCaseData()));
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EjpContactPreferenceFieldMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EjpContactPreferenceFieldMidEventHandler.java
@@ -29,7 +29,7 @@ public class EjpContactPreferenceFieldMidEventHandler implements PreSubmitCallba
         requireNonNull(callback, "callback must not be null");
 
         return (callbackStage == PreSubmitCallbackStage.MID_EVENT
-                && callback.getEvent() == Event.START_APPEAL
+                && (callback.getEvent() == Event.START_APPEAL || callback.getEvent() == Event.EDIT_APPEAL)
                 && callback.getPageId().equals(ADDRESS_PAGE_ID)
                 && sourceOfAppealEjp(callback.getCaseDetails().getCaseData()));
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EjpEditAppealHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EjpEditAppealHandlerTest.java
@@ -118,6 +118,43 @@ class EjpEditAppealHandlerTest {
     }
 
     @Test
+    void should_clear_legal_rep_address_ejp_field_when_editing_to_unrepped_case() {
+        when(asylumCase.read(SOURCE_OF_APPEAL, SourceOfAppeal.class)).thenReturn(Optional.of(SourceOfAppeal.TRANSFERRED_FROM_UPPER_TRIBUNAL));
+        when(asylumCase.read(IS_LEGALLY_REPRESENTED_EJP, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+
+        PreSubmitCallbackResponse<AsylumCase> response = ejpEditAppealHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertThat(response).isNotNull();
+        verify(asylumCase, times(1)).clear(LEGAL_PRACTICE_ADDRESS_EJP);
+    }
+
+    @Test
+    void should_clear_appellant_address_for_non_detained_repped_with_fixed_address() {
+        when(asylumCase.read(SOURCE_OF_APPEAL, SourceOfAppeal.class)).thenReturn(Optional.of(SourceOfAppeal.TRANSFERRED_FROM_UPPER_TRIBUNAL));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(IS_LEGALLY_REPRESENTED_EJP, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(APPELLANT_HAS_FIXED_ADDRESS, YesOrNo.class)).thenReturn(Optional.of(YES));
+
+        PreSubmitCallbackResponse<AsylumCase> response = ejpEditAppealHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertThat(response).isNotNull();
+        verify(asylumCase, times(1)).clear(LEGAL_PRACTICE_ADDRESS_EJP);
+    }
+
+    @Test
+    void should_clear_legal_rep_ejp_address_for_non_detained_repped_with_no_fixed_address() {
+        when(asylumCase.read(SOURCE_OF_APPEAL, SourceOfAppeal.class)).thenReturn(Optional.of(SourceOfAppeal.TRANSFERRED_FROM_UPPER_TRIBUNAL));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+        when(asylumCase.read(IS_LEGALLY_REPRESENTED_EJP, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(APPELLANT_HAS_FIXED_ADDRESS, YesOrNo.class)).thenReturn(Optional.of(NO));
+
+        PreSubmitCallbackResponse<AsylumCase> response = ejpEditAppealHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertThat(response).isNotNull();
+        verify(asylumCase, times(1)).clear(APPELLANT_ADDRESS);
+    }
+
+    @Test
     void handling_should_throw_if_cannot_actually_handle() {
 
         assertThatThrownBy(() -> ejpEditAppealHandler.handle(MID_EVENT, callback))


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-7457

### Change description ###

- Updates to EJP handlers and mid events to allow handling for Edit Appeal event
- Additional logic to handle clearing of fields when editing between different screens in non-detained flow
- Updated unit tests
- New functional test for EJP non-detained


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
