### PR TITLE
RIA-7458 EJP Edit appeal after submit

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7458-edit-appeal-after-submit-detained-ejp-case.json
+++ b/src/functionalTest/resources/scenarios/RIA-7458-edit-appeal-after-submit-detained-ejp-case.json
@@ -1,0 +1,51 @@
+{
+  "description": "RIA-7458 Edit appeal after submit - Detained EJP case'",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "eventId": "editAppealAfterSubmit",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-ejp-appeal-submitted.json",
+        "replacements": {
+          "sourceOfAppeal": "transferredFromUpperTribunal",
+          "upperTribunalReferenceNumber": "UI-2020-123451",
+          "firstTierTribunalTransferDate": "2024-02-13",
+          "appellantInDetention": "Yes",
+          "detentionFacility": "immigrationRemovalCentre",
+          "ircName": "Brookhouse",
+          "hearingCentre": "taylorHouse",
+          "isLegallyRepresentedEjp": "Yes",
+          "legalRepCompanyEjp": "Company Name",
+          "legalRepGivenNameEjp": "FirstName",
+          "legalRepFamilyNameEjp": "LastName",
+          "legalRepEmailEjp": "legalrep@example.com",
+          "legalRepReferenceEjp": "REF123"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-ejp-appeal-submitted.json",
+      "replacements": {
+        "sourceOfAppeal": "transferredFromUpperTribunal",
+        "upperTribunalReferenceNumber": "UI-2020-123451",
+        "firstTierTribunalTransferDate": "2024-02-13",
+        "appellantInDetention": "Yes",
+        "detentionFacility": "immigrationRemovalCentre",
+        "ircName": "Brookhouse",
+        "hearingCentre": "taylorHouse",
+        "isLegallyRepresentedEjp": "Yes",
+        "legalRepCompanyEjp": "Company Name",
+        "legalRepGivenNameEjp": "FirstName",
+        "legalRepFamilyNameEjp": "LastName",
+        "legalRepEmailEjp": "legalrep@example.com",
+        "legalRepReferenceEjp": "REF123"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEvent.java
@@ -120,7 +120,7 @@ public class StartAppealMidEvent implements PreSubmitCallbackHandler<AsylumCase>
 
         }
 
-        if (callback.getPageId().equals(UPPER_TRIBUNAL_REFERENCE_NUMBER_PAGE_ID) && (callback.getEvent() == Event.START_APPEAL || callback.getEvent() == Event.EDIT_APPEAL)) {
+        if (callback.getPageId().equals(UPPER_TRIBUNAL_REFERENCE_NUMBER_PAGE_ID) && (callback.getEvent() == Event.START_APPEAL || callback.getEvent() == Event.EDIT_APPEAL || callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT)) {
             String upperTribunalReferenceNumber = asylumCase
                 .read(UPPER_TRIBUNAL_REFERENCE_NUMBER, String.class)
                 .orElseThrow(() -> new IllegalStateException("upperTribunalReferenceNumber is missing"));

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealAfterSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealAfterSubmitHandlerTest.java
@@ -3,10 +3,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.times;
@@ -644,5 +641,17 @@ class EditAppealAfterSubmitHandlerTest {
 
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.SUITABILITY_INTERPRETER_SERVICES_YES_OR_NO);
         verify(asylumCase, times(1)).clear(AsylumCaseFieldDefinition.SUITABILITY_INTERPRETER_SERVICES_LANGUAGE);
+    }
+
+    @Test
+    void should_not_throw_exception_for_ejp_cases_with_no_decision_letter_date() {
+        when(asylumCase.read(IS_EJP, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(DATE_ON_DECISION_LETTER, String.class)).thenReturn(Optional.empty());
+        PreSubmitCallbackResponse<AsylumCase> response = editAppealAfterSubmitHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(response);
+        assertEquals(asylumCase, response.getData());
+
+        assertDoesNotThrow(() -> editAppealAfterSubmitHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/StartAppealMidEventTest.java
@@ -347,7 +347,7 @@ class StartAppealMidEventTest {
 
     @ParameterizedTest
     @EnumSource(value = Event.class, names = {
-        "START_APPEAL", "EDIT_APPEAL"
+        "START_APPEAL", "EDIT_APPEAL", "EDIT_APPEAL_AFTER_SUBMIT"
     })
     void should_error_when_upper_tribunal_reference_number_format_is_wrong(Event event) {
         when(callback.getEvent()).thenReturn(event);
@@ -366,7 +366,7 @@ class StartAppealMidEventTest {
 
     @ParameterizedTest
     @EnumSource(value = Event.class, names = {
-        "START_APPEAL", "EDIT_APPEAL"
+        "START_APPEAL", "EDIT_APPEAL", "EDIT_APPEAL_AFTER_SUBMIT"
     })
     void should_validate_as_correct_format_for_upper_tribunal_reference_number(Event event) {
         when(callback.getEvent()).thenReturn(event);


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-7458

### Change description ###

- Adding 'editAppealAfterSubmit' event to StartAppealMidEvent handler so that the utReferenceNumber validation works
- Adding a check so that out of time fields are not handled for EJP cases (where no decision date is present) in EditAppealAfterSubmitHandler to prevent exception being thrown
- Unit tests updated and functional test added

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
