### PR TITLE
RIA-8659 Add error to midEvent if date range selected but both start/end empty

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -2077,7 +2077,15 @@ public enum AsylumCaseFieldDefinition {
 
     AUTO_LIST_HEARING("autoListHearing", new TypeReference<YesOrNo>(){}),
 
-    IS_PANEL_REQUIRED("isPanelRequired", new TypeReference<YesOrNo>(){});
+    IS_PANEL_REQUIRED("isPanelRequired", new TypeReference<YesOrNo>(){}),
+
+    CHANGE_HEARING_DATE_YES_NO("changeHearingDateYesNo", new TypeReference<String>(){}),
+
+    CHANGE_HEARING_DATE_TYPE("changeHearingDateType", new TypeReference<String>(){}),
+
+    CHANGE_HEARING_DATE_RANGE_EARLIEST("changeHearingDateRangeEarliest", new TypeReference<String>(){}),
+
+    CHANGE_HEARING_DATE_RANGE_LATEST("changeHearingDateRangeLatest", new TypeReference<String>(){});
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingsUpdateHearingRequestTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HearingsUpdateHearingRequestTest.java
@@ -3,10 +3,15 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARINGS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_RANGE_EARLIEST;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_RANGE_LATEST;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_TYPE;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_DATE_YES_NO;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.CHANGE_HEARING_VENUE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.MANUAL_UPDATE_HEARING_REQUIRED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.UPDATE_HEARING_REQUEST;
@@ -37,6 +42,9 @@ public class HearingsUpdateHearingRequestTest {
 
     public static final String NO_HEARINGS_ERROR_MESSAGE =
         "You've made an invalid request. You must request a substantive hearing before you can update a hearing.";
+    private static final String COMPLIANT_DATE_RANGE_NEEDED = "Earliest hearing date or Latest hearing date required";
+    private static final String UPDATE_HEARING_DATE_PAGE_ID = "updateHearingDate";
+    private static final String UPDATE_HEARING_LIST_PAGE_ID = "updateHearingList";
 
     @Mock
     private Callback<AsylumCase> callback;
@@ -60,6 +68,7 @@ public class HearingsUpdateHearingRequestTest {
     @Test
     public void should_delegate_to_hearings_api_start_event_when_update_hearings_is_null() {
         when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUEST);
+        when(callback.getPageId()).thenReturn(UPDATE_HEARING_LIST_PAGE_ID);
         when(iaHearingsApiService.aboutToStart(callback)).thenReturn(asylumCase);
 
         DynamicList adjournmentDetailsHearing =
@@ -81,6 +90,8 @@ public class HearingsUpdateHearingRequestTest {
     @Test
     public void should_delegate_to_hearings_api_mid_event_when_update_hearings_is_not_null() {
         when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUEST);
+        when(callback.getPageId()).thenReturn(UPDATE_HEARING_LIST_PAGE_ID);
+
         when(asylumCase.read(CHANGE_HEARINGS))
             .thenReturn(Optional.of(new DynamicList("hearing 1")));
 
@@ -99,8 +110,87 @@ public class HearingsUpdateHearingRequestTest {
     }
 
     @Test
+    public void should_add_error_when_date_range_needed_and_not_compliant() {
+        when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUEST);
+        when(callback.getPageId()).thenReturn(UPDATE_HEARING_DATE_PAGE_ID);
+
+        when(asylumCase.read(CHANGE_HEARING_DATE_YES_NO, String.class)).thenReturn(Optional.of("yes"));
+        when(asylumCase.read(CHANGE_HEARING_DATE_TYPE, String.class)).thenReturn(Optional.of("ChooseADateRange"));
+        when(asylumCase.read(CHANGE_HEARING_DATE_RANGE_EARLIEST, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(CHANGE_HEARING_DATE_RANGE_LATEST, String.class)).thenReturn(Optional.empty());
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            hearingsUpdateHearingRequest.handle(MID_EVENT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(1, callbackResponse.getErrors().size());
+        assertTrue(callbackResponse.getErrors().contains(COMPLIANT_DATE_RANGE_NEEDED));
+    }
+
+    @Test
+    public void should_not_add_error_when_date_range_needed_and_compliant() {
+        when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUEST);
+        when(callback.getPageId()).thenReturn(UPDATE_HEARING_DATE_PAGE_ID);
+
+        when(asylumCase.read(CHANGE_HEARING_DATE_YES_NO, String.class)).thenReturn(Optional.of("yes"));
+        when(asylumCase.read(CHANGE_HEARING_DATE_TYPE, String.class)).thenReturn(Optional.of("ChooseADateRange"));
+        when(asylumCase.read(CHANGE_HEARING_DATE_RANGE_EARLIEST, String.class)).thenReturn(Optional.of("2024-02-23"));
+        when(asylumCase.read(CHANGE_HEARING_DATE_RANGE_LATEST, String.class)).thenReturn(Optional.empty());
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            hearingsUpdateHearingRequest.handle(MID_EVENT, callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getErrors().isEmpty());
+    }
+
+    @Test
+    public void should_not_add_error_when_date_range_not_needed() {
+        when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUEST);
+        when(callback.getPageId()).thenReturn(UPDATE_HEARING_DATE_PAGE_ID);
+
+        when(asylumCase.read(CHANGE_HEARING_DATE_YES_NO, String.class)).thenReturn(Optional.of("no"));
+        when(asylumCase.read(CHANGE_HEARING_DATE_TYPE, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(CHANGE_HEARING_DATE_RANGE_EARLIEST, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(CHANGE_HEARING_DATE_RANGE_LATEST, String.class)).thenReturn(Optional.empty());
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            hearingsUpdateHearingRequest.handle(MID_EVENT, callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getErrors().isEmpty());
+    }
+
+    @Test
+    public void should_not_add_error_when_not_on_date_page() {
+        when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUEST);
+        when(callback.getPageId()).thenReturn(UPDATE_HEARING_LIST_PAGE_ID);
+        when(iaHearingsApiService.aboutToStart(callback)).thenReturn(asylumCase);
+
+        DynamicList adjournmentDetailsHearing =
+            new DynamicList(
+                new Value("code", "adjournmentDetailsHearing"),
+                Arrays.asList(new Value("code", "hearing1")));
+        when(asylumCase.read(CHANGE_HEARINGS, DynamicList.class))
+            .thenReturn(Optional.of(adjournmentDetailsHearing));
+
+        when(asylumCase.read(CHANGE_HEARING_DATE_YES_NO, String.class)).thenReturn(Optional.of("yes"));
+        when(asylumCase.read(CHANGE_HEARING_DATE_TYPE, String.class)).thenReturn(Optional.of("ChooseADateRange"));
+        when(asylumCase.read(CHANGE_HEARING_DATE_RANGE_EARLIEST, String.class)).thenReturn(Optional.empty());
+        when(asylumCase.read(CHANGE_HEARING_DATE_RANGE_LATEST, String.class)).thenReturn(Optional.empty());
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            hearingsUpdateHearingRequest.handle(MID_EVENT, callback);
+
+        assertNotNull(callbackResponse);
+        assertTrue(callbackResponse.getErrors().isEmpty());
+    }
+
+    @Test
     void should_throw_error_if_no_hearings() {
         when(callback.getEvent()).thenReturn(UPDATE_HEARING_REQUEST);
+        when(callback.getPageId()).thenReturn(UPDATE_HEARING_LIST_PAGE_ID);
+
         when(iaHearingsApiService.aboutToStart(callback)).thenReturn(asylumCase);
 
         DynamicList adjournmentDetailsHearing =


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-8659](https://tools.hmcts.net/jira/browse/RIA-8659)


### Change description ###
- Added midEvent trigger for `updateHearingRequest` on the date page to prevent users from selecting that the date needs to change with a date range where neither start or end dates are populated (since both fields now have to be optional to allow for the absence of one of them but not both of them)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
