### PR TITLE
RIA-8661 Fix legalRepFamilyName if needed in ListAssistIntegrationHandler

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListAssistIntegrationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListAssistIntegrationHandler.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
 
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
@@ -10,11 +11,15 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.AsylumFieldLegalRepNameFixer;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.PartyIdService;
 
 @Slf4j
 @Component
+@AllArgsConstructor
 public class ListAssistIntegrationHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private AsylumFieldLegalRepNameFixer asylumFieldLegalRepNameFixer;
 
     public boolean canHandle(
         PreSubmitCallbackStage callbackStage,
@@ -36,6 +41,8 @@ public class ListAssistIntegrationHandler implements PreSubmitCallbackHandler<As
         }
 
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        asylumFieldLegalRepNameFixer.fix(asylumCase);
 
         PartyIdService.setAppellantPartyId(asylumCase);
         PartyIdService.setLegalRepPartyId(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/AsylumFieldLegalRepNameFixer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/service/AsylumFieldLegalRepNameFixer.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.service;
+
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LEGAL_REP_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LEGAL_REP_NAME;
+
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+
+@Component
+public class AsylumFieldLegalRepNameFixer implements DataFixer {
+
+    @Override
+    public void fix(AsylumCase asylumCase) {
+        if (hasNoFamilyName(asylumCase)) {
+
+            Optional<String> legalRepName = asylumCase.read(LEGAL_REP_NAME, String.class);
+
+            if (legalRepName.isPresent()) {
+                String[] fullName = legalRepName.get().split(" ", 2);
+                asylumCase.write(LEGAL_REP_NAME, fullName[0]);
+
+                asylumCase.write(LEGAL_REP_FAMILY_NAME, fullName.length > 1 ? fullName[1] : " ");
+            }
+
+        }
+    }
+
+    private boolean hasNoFamilyName(AsylumCase asylumCase) {
+        return asylumCase.read(LEGAL_REP_FAMILY_NAME, String.class).orElse("").trim().isEmpty();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/AsylumFieldLegalRepNameFixerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/service/AsylumFieldLegalRepNameFixerTest.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.service;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LEGAL_REP_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LEGAL_REP_NAME;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+
+@ExtendWith(MockitoExtension.class)
+public class AsylumFieldLegalRepNameFixerTest {
+
+    private static final String LEGAL_REP_LEGACY_NAME_1 = "firstName lastName lastName";
+    private static final String LEGAL_REP_FIRST_NAME = "firstName";
+    private static final String LEGAL_REP_LAST_NAME = "lastName lastName";
+    private static final String LEGAL_REP_LEGACY_NAME_2 = "firstNameLastName";
+
+    @Mock
+    private AsylumCase asylumCase;
+
+    private AsylumFieldLegalRepNameFixer legalRepNameFixer;
+
+    @BeforeEach
+    void setup() {
+        legalRepNameFixer = new AsylumFieldLegalRepNameFixer();
+    }
+
+    @Test
+    void should_not_split_name_if_last_name_present() {
+
+        legalRepNameFixer.fix(asylumCase);
+
+        verify(asylumCase, never()).write(eq(LEGAL_REP_NAME), anyString());
+        verify(asylumCase, never()).write(eq(LEGAL_REP_FAMILY_NAME), anyString());
+    }
+
+    @Test
+    void should_split_name_if_last_name_not_present() {
+        when(asylumCase.read(LEGAL_REP_NAME, String.class)).thenReturn(Optional.of(LEGAL_REP_LEGACY_NAME_1));
+        when(asylumCase.read(LEGAL_REP_FAMILY_NAME, String.class))
+            .thenReturn(Optional.empty());
+
+        legalRepNameFixer.fix(asylumCase);
+
+        verify(asylumCase, times(1)).read(LEGAL_REP_NAME, String.class);
+        verify(asylumCase, times(1)).write(LEGAL_REP_NAME, LEGAL_REP_FIRST_NAME);
+        verify(asylumCase, times(1)).write(LEGAL_REP_FAMILY_NAME, LEGAL_REP_LAST_NAME);
+    }
+
+    @Test
+    void should_not_throw_outOfBounds_exception_if_first_name_has_no_space() {
+        when(asylumCase.read(LEGAL_REP_NAME, String.class)).thenReturn(Optional.of(LEGAL_REP_LEGACY_NAME_2));
+        when(asylumCase.read(LEGAL_REP_FAMILY_NAME, String.class))
+            .thenReturn(Optional.empty());
+
+        legalRepNameFixer.fix(asylumCase);
+
+        verify(asylumCase, times(1)).read(LEGAL_REP_NAME, String.class);
+        verify(asylumCase, times(1)).write(LEGAL_REP_NAME, LEGAL_REP_LEGACY_NAME_2);
+        verify(asylumCase, times(1)).write(LEGAL_REP_FAMILY_NAME, " ");
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-8661](https://tools.hmcts.net/jira/browse/RIA-8661)


### Change description ###
- Made "legalRepName" and "legalRepFamilyName" be read and checked during `listAssistIntegration` to detect if "legalRepFamilyName" is empty and needs to be extrapolated from "legalRepName", so old cases that had no "legalRepFamilyName" conform to new cases where first and last name are written in two separate fields


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
