### PR TITLE
RIA-8742 Prepopulate location from hmc value if local epims id empty

### DIFF
--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-api
 home: https://github.com/hmcts/ia-case-api
-version: 0.0.43
+version: 0.0.44
 description: Immigration & Asylum Case API
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordAdjournmentDetailsMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordAdjournmentDetailsMidEventHandler.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_REASON_TO_CANCEL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_CHANNEL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_REASON_TO_CANCEL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_REASON_TO_UPDATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_CENTRE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_LENGTH;
@@ -14,7 +14,6 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.NEXT_HEARING_VENUE;
 
 import java.util.Objects;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
@@ -103,11 +102,13 @@ public class RecordAdjournmentDetailsMidEventHandler implements PreSubmitCallbac
     private AsylumCase prePopulateHearingVenue(Callback<AsylumCase> callback) {
         DynamicList refDataHearingLocationList = locationRefDataService.getHearingLocationsDynamicList();
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
-        Optional<HearingCentre> hearingCentre = asylumCase.read(LIST_CASE_HEARING_CENTRE, HearingCentre.class);
+        String hearingCentreEpimsId = asylumCase.read(LIST_CASE_HEARING_CENTRE, HearingCentre.class)
+            .map(HearingCentre::getEpimsId)
+            .orElse("");
 
-        if (hearingCentre.isPresent()) {
+        if (!hearingCentreEpimsId.isBlank()) {
             Value hearingLocationValue = refDataHearingLocationList.getListItems().stream()
-                .filter(location -> Objects.equals(location.getCode(), hearingCentre.get().getEpimsId()))
+                .filter(location -> Objects.equals(location.getCode(), hearingCentreEpimsId))
                 .findAny().orElseGet(() -> new Value("", ""));
             refDataHearingLocationList.setValue(hearingLocationValue);
             asylumCase.write(NEXT_HEARING_VENUE, refDataHearingLocationList);


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-8742](https://tools.hmcts.net/jira/browse/RIA-8742)


### Change description ###
- Made dropdown list with hearing location in `recordAdjournmentDetails` resort to querying the location in hearing details from HMC when `listCaseHearingCentre` is null (before listing) or is present with an empty epims id (`remoteHearing` | `decisionWithoutHearing`)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
