### PR TITLE
RIA-8740 Ensure 'NextHearingFormat' drop-down is populated during 'r…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordAdjournmentDetailsMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordAdjournmentDetailsMidEventHandler.java
@@ -86,8 +86,9 @@ public class RecordAdjournmentDetailsMidEventHandler implements PreSubmitCallbac
         DynamicList hearingChannel = asylumCase.read(HEARING_CHANNEL, DynamicList.class).orElse(null);
         if (hearingChannel == null) {
             hearingChannel = provider.provideHearingChannels();
-        } else if (hearingChannel.getListItems() == null || hearingChannel.getListItems().isEmpty()) {
-            hearingChannel = new DynamicList(hearingChannel.getValue(), provider.provideHearingChannels().getListItems());
+        } else {
+            hearingChannel = new DynamicList(
+                hearingChannel.getValue(), provider.provideHearingChannels().getListItems());
         }
 
         asylumCase.write(NEXT_HEARING_FORMAT, hearingChannel);


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-8740


### Change description ###
* Ensure that the list of channels are always populated by fetching them from reference data.
* Set the selected value to the 'hearingChannel' value if available.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
