### PR TITLE
RIA-8219 update tribunal decision rule32 overview tab post event

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-8158-8219-updateTribunalDecision-rule-32.json
+++ b/src/functionalTest/resources/scenarios/RIA-8158-8219-updateTribunalDecision-rule-32.json
@@ -1,5 +1,5 @@
 {
-  "description": "RIA-8158 Update Tribunal Decision Rule 32",
+  "description": "RIA-8158-8219 Update Tribunal Decision Rule 32",
   "launchDarklyKey": "dlrm-setaside-feature-flag:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -30,6 +30,8 @@
       "template": "minimal-appeal-submitted.json",
       "replacements": {
         "updateTribunalDecisionList": "underRule32",
+        "reasonRehearingRule32": "Set aside and to be reheard under rule 32",
+        "updateTribunalDecisionDateRule32": "{$TODAY}",
         "judgesNamesToExclude": "Judge John Doe",
         "rule32ListingAdditionalIns": "Rule 32 listing instruction example",
         "rule32NoticeDocument": {

--- a/src/functionalTest/resources/scenarios/RIA-8220-8219-update-tribunal-decision-rule32.json
+++ b/src/functionalTest/resources/scenarios/RIA-8220-8219-update-tribunal-decision-rule32.json
@@ -1,5 +1,5 @@
 {
-  "description": "RIA-8220 Update Tribunal Decision Rule 32",
+  "description": "RIA-8220-8219 Update Tribunal Decision Rule 32",
   "launchDarklyKey": "dlrm-setaside-feature-flag:true",
   "request": {
     "uri": "/asylum/ccdAboutToSubmit",
@@ -31,6 +31,8 @@
       "replacements": {
         "updateTribunalDecisionList": "underRule32",
         "sendDirectionActionAvailable": "No",
+        "reasonRehearingRule32": "Set aside and to be reheard under rule 32",
+        "updateTribunalDecisionDateRule32": "{$TODAY}",
         "allSetAsideDocs": [
           {
             "id": "1",

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1700,6 +1700,12 @@ public enum AsylumCaseFieldDefinition {
     UPDATE_TRIBUNAL_DECISION_DATE(
         "updateTribunalDecisionDate", new TypeReference<String>(){}),
 
+    UPDATE_TRIBUNAL_DECISION_DATE_RULE_32(
+            "updateTribunalDecisionDateRule32", new TypeReference<String>(){}),
+
+    REASON_REHEARING_RULE_32(
+            "reasonRehearingRule32", new TypeReference<String>(){})
+
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateTribunalDecisionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateTribunalDecisionHandler.java
@@ -140,6 +140,8 @@ public class UpdateTribunalDecisionHandler implements PreSubmitCallbackHandler<A
 
             asylumCase.write(ALL_SET_ASIDE_DOCS,allFtpaSetAsideDocuments);
 
+            asylumCase.write(UPDATE_TRIBUNAL_DECISION_DATE_RULE_32, dateProvider.now().toString());
+            asylumCase.write(REASON_REHEARING_RULE_32, "Set aside and to be reheard under rule 32");
         }
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateTribunalDecisionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/UpdateTribunalDecisionHandlerTest.java
@@ -218,6 +218,9 @@ class UpdateTribunalDecisionHandlerTest {
     @Test
     void should_write_set_aside_documents_if_is_r32() {
 
+        LocalDate currentDate = LocalDate.now();
+        when(dateProvider.now()).thenReturn(currentDate);
+
         when(asylumCase.read(UPDATE_TRIBUNAL_DECISION_LIST, UpdateTribunalRules.class))
                 .thenReturn(Optional.of(UNDER_RULE_32));
 
@@ -240,6 +243,8 @@ class UpdateTribunalDecisionHandlerTest {
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
         verify(asylumCase, times(1)).write(ALL_SET_ASIDE_DOCS, allFtpaSetAsideDocuments);
+        verify(asylumCase, times(1)).write(UPDATE_TRIBUNAL_DECISION_DATE_RULE_32, currentDate.toString());
+        verify(asylumCase, times(1)).write(REASON_REHEARING_RULE_32, "Set aside and to be reheard under rule 32");
 
     }
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-8219


### Change description ###
- show overview information when judge trigger rule 32
- set the value for updateTribunalDecisionDateRule32 and reasonRehearingRule32 when triggered updateTribunalDecision event with rule 32
- updated the unit test and functional test

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
