### PR TITLE
RIA-TASK OOC Feature toggle field

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1937,6 +1937,9 @@ public enum AsylumCaseFieldDefinition {
 
     LEGAL_PRACTICE_ADDRESS_EJP(
         "legalPracticeAddressEjp", new TypeReference<AddressUk>(){}),
+
+    IS_OUT_OF_COUNTRY_ENABLED(
+        "isOutOfCountryEnabled", new TypeReference<YesOrNo>() {}),
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealTypePreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/EditAppealTypePreparer.java
@@ -4,9 +4,11 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.AGE_ASSESSMENT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE_FOR_DISPLAY;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_NABA_ENABLED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isAipJourney;
 
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealTypeForDisplay;
@@ -45,6 +47,11 @@ public class EditAppealTypePreparer implements PreSubmitCallbackHandler<AsylumCa
             callback
                 .getCaseDetails()
                 .getCaseData();
+        // Pre NABA Definition release, there is no population of AppealTypeForDisplay. So no change needed.
+        Optional<YesOrNo> isNabaEnabled = asylumCase.read(IS_NABA_ENABLED, YesOrNo.class);
+        if (isNabaEnabled.equals(Optional.of(NO))) {
+            return new PreSubmitCallbackResponse<>(asylumCase);
+        }
 
         // After release of NABA, the pre-NABA cases will not have APPEAL_TYPE_FOR_DISPLAY populated, so when they get
         // to select appeal type screen (via EditAppeal event), it will not be pre-populated. This preparer will

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/NabaFeatureTogglePreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/NabaFeatureTogglePreparer.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_NABA_ADA_ENABLED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_NABA_ENABLED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_NABA_ENABLED_OOC;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_OUT_OF_COUNTRY_ENABLED;
+
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.EDIT_APPEAL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.START_APPEAL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
@@ -68,6 +70,12 @@ public class NabaFeatureTogglePreparer implements PreSubmitCallbackHandler<Asylu
         // This field is used by LR in-country flows and Internal EJP and Paper form in-country flow
         // Writing this value to show the Accelerated Detained related screens on the UI
         asylumCase.write(IS_NABA_ADA_ENABLED, isAdaEnabled);
+
+        // We need this in the backend, as the ccd -defs master branch still has this field in use. Once we do the
+        // NABA ccd release, we can omit this.
+        YesOrNo isOutOfCountryEnabled
+            = featureToggler.getValue("out-of-country-feature", false) ? YES : NO;
+        asylumCase.write(IS_OUT_OF_COUNTRY_ENABLED, isOutOfCountryEnabled);
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/NabaFeatureTogglePreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/NabaFeatureTogglePreparerTest.java
@@ -9,6 +9,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_NABA_ADA_ENABLED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_NABA_ENABLED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_NABA_ENABLED_OOC;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_OUT_OF_COUNTRY_ENABLED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.EDIT_APPEAL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.START_APPEAL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
@@ -52,14 +53,14 @@ class NabaFeatureTogglePreparerTest {
 
     @ParameterizedTest
     @EnumSource(value = Event.class, names = { "START_APPEAL", "EDIT_APPEAL" })
-    void handler_checks_naba_ada_feature_flag_set_value(Event event) {
+    void handler_checks_naba_ada_ooc_feature_flag_set_value(Event event) {
 
         when(callback.getEvent()).thenReturn(event);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(featureToggler.getValue("naba-feature-flag", false)).thenReturn(true);
         when(featureToggler.getValue("naba-ada-feature-flag", false)).thenReturn(true);
-
+        when(featureToggler.getValue("out-of-country-feature", false)).thenReturn(true);
         PreSubmitCallbackResponse<AsylumCase> response =
                 nabaFeatureTogglePreparer.handle(ABOUT_TO_START, callback);
 
@@ -73,6 +74,8 @@ class NabaFeatureTogglePreparerTest {
             IS_NABA_ENABLED_OOC, YesOrNo.YES);
         Mockito.verify(asylumCase, times(1)).write(
             IS_NABA_ADA_ENABLED, YesOrNo.YES);
+        Mockito.verify(asylumCase, times(1)).write(
+            IS_OUT_OF_COUNTRY_ENABLED, YesOrNo.YES);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
- updated the logic for 'AppealTypeForDisplay' and Edit Appeal Preparer, to skip the read of 'AppealTypeForDisplay' if the the feature toggle is turned off for NABA.

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
