### PR TITLE
RIA-8230 Manage Fee Update confirmation screen updates

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -78,7 +78,7 @@
         <cve>CVE-2023-45648</cve>
         <cve>CVE-2023-31582</cve>
     </suppress>
-    <suppress until="2024-04-15">
+    <suppress until="2024-04-30">
         <notes>Temporarily suppress vulnerability</notes>
         <cve>CVE-2023-35116</cve>
         <cve>CVE-2023-41080</cve>
@@ -95,7 +95,7 @@
         <cve>CVE-2023-1370</cve>
         <cve>CVE-2024-1597</cve>
     </suppress>
-    <suppress until="2024-04-15">
+    <suppress until="2024-04-30">
         <cve>CVE-2024-1597</cve>
         <cve>CVE-2023-1370</cve>
     </suppress>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -85,7 +85,7 @@
         <cve>CVE-2023-31582</cve>
         <cve>CVE-2023-5072</cve>
     </suppress>
-    <suppress until="2024-04-15">
+    <suppress until="2024-04-30">
         <cve>CVE-2023-33202</cve>
         <cve>CVE-2023-6378</cve>
         <cve>CVE-2023-34055</cve>

--- a/src/functionalTest/resources/scenarios/RIA-8230-dlrm-manage-fee-additional-payment-tribunal-action-confirmation-screen.json
+++ b/src/functionalTest/resources/scenarios/RIA-8230-dlrm-manage-fee-additional-payment-tribunal-action-confirmation-screen.json
@@ -1,0 +1,26 @@
+{
+  "description": "RIA-8230 DLRM Manage fee update - Additional payment tribunal action - confirmation screen",
+  "request": {
+    "uri": "/asylum/ccdSubmitted",
+    "credentials": "AdminOfficer",
+    "input": {
+      "eventId": "manageFeeUpdate",
+      "state": "appealSubmitted",
+      "id": 8230,
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isDlrmFeeRefundEnabled": "Yes",
+          "feeUpdateTribunalAction": "additionalPayment"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "confirmation": {
+      "header": "# You have recorded a fee update",
+      "body": "#### What happens next\n\nA payment request will be sent to the appellant."
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-8230-dlrm-manage-fee-no-action-tribunal-action-confirmation-screen.json
+++ b/src/functionalTest/resources/scenarios/RIA-8230-dlrm-manage-fee-no-action-tribunal-action-confirmation-screen.json
@@ -1,0 +1,26 @@
+{
+  "description": "RIA-8230 DLRM Manage fee update - Refund tribunal action - confirmation screen",
+  "request": {
+    "uri": "/asylum/ccdSubmitted",
+    "credentials": "AdminOfficer",
+    "input": {
+      "eventId": "manageFeeUpdate",
+      "state": "appealSubmitted",
+      "id": 8230,
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isDlrmFeeRefundEnabled": "Yes",
+          "feeUpdateTribunalAction": "noAction"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "confirmation": {
+      "header": "# You have recorded a fee update",
+      "body": "#### What happens next\n\nThe appeal fee has been updated. No further action is required."
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-8230-dlrm-manage-fee-refund-tribunal-action-confirmation-screen.json
+++ b/src/functionalTest/resources/scenarios/RIA-8230-dlrm-manage-fee-refund-tribunal-action-confirmation-screen.json
@@ -1,0 +1,26 @@
+{
+  "description": "RIA-8230 DLRM Manage fee update - Refund tribunal action - confirmation screen",
+  "request": {
+    "uri": "/asylum/ccdSubmitted",
+    "credentials": "AdminOfficer",
+    "input": {
+      "eventId": "manageFeeUpdate",
+      "state": "appealSubmitted",
+      "id": 8230,
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isDlrmFeeRefundEnabled": "Yes",
+          "feeUpdateTribunalAction": "refund"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "confirmation": {
+      "header": "# You have recorded a fee update",
+      "body": "#### What happens next\n\nThe appropriate team will be notified to review the fee update and process a refund."
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -1739,6 +1739,9 @@ public enum AsylumCaseFieldDefinition {
     REQUEST_FEE_REMISSION_DATE(
         "requestFeeRemissionDate", new TypeReference<String>(){}),
 
+    FEE_UPDATE_TRIBUNAL_ACTION(
+        "feeUpdateTribunalAction", new TypeReference<FeeTribunalAction>(){}),
+
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeTribunalAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeTribunalAction.java
@@ -4,19 +4,19 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum FeeTribunalAction {
 
-        REFUND("refund"),
-        ADDITIONAL_PAYMENT("additionalPayment"),
-        NO_ACTION("noAction");
-        @JsonValue
-        private final String value;
+    REFUND("refund"),
+    ADDITIONAL_PAYMENT("additionalPayment"),
+    NO_ACTION("noAction");
+    @JsonValue
+    private final String value;
 
     FeeTribunalAction(String value) {
-            this.value = value;
-        }
+        this.value = value;
+    }
 
-        @Override
-        public String toString() {
-            return value;
-        }
+    @Override
+    public String toString() {
+        return value;
+    }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeTribunalAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeTribunalAction.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum FeeTribunalAction {
+
+        REFUND("refund"),
+        ADDITIONAL_PAYMENT("additionalPayment"),
+        NO_ACTION("noAction");
+        @JsonValue
+        private final String value;
+
+    FeeTribunalAction(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeUpdateReason.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeUpdateReason.java
@@ -6,7 +6,8 @@ public enum FeeUpdateReason {
 
     DECISION_TYPE_CHANGED("decisionTypeChanged"),
     APPEAL_NOT_VALID("appealNotValid"),
-    FEE_REMISSION_CHANGED("feeRemissionChanged");
+    FEE_REMISSION_CHANGED("feeRemissionChanged"),
+    APPEAL_WITHDRAWN("appealWithdrawn");
 
     @JsonValue
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/ManageFeeUpdateConfirmation.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/postsubmit/ManageFeeUpdateConfirmation.java
@@ -2,20 +2,28 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.postsubmit;
 
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.FEE_UPDATE_COMPLETED_STAGES;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.FEE_UPDATE_TRIBUNAL_ACTION;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_DLRM_FEE_REFUND_ENABLED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.FeeTribunalAction;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PostSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PostSubmitCallbackHandler;
 
 @Component
 public class ManageFeeUpdateConfirmation implements PostSubmitCallbackHandler<AsylumCase> {
 
     private static final String WHAT_HAPPENS_NEXT = "#### What happens next\n\n";
+
+    public ManageFeeUpdateConfirmation() {
+    }
 
     public boolean canHandle(
         Callback<AsylumCase> callback
@@ -40,8 +48,23 @@ public class ManageFeeUpdateConfirmation implements PostSubmitCallbackHandler<As
                 .getCaseData();
 
         Optional<List<String>> completedStages = asylumCase.read(FEE_UPDATE_COMPLETED_STAGES);
+        Optional<YesOrNo> dlrmRefundFlag = asylumCase.read(IS_DLRM_FEE_REFUND_ENABLED, YesOrNo.class);
 
-        if (completedStages.isPresent() && completedStages.get().size() > 1) {
+        if (dlrmRefundFlag.isPresent() && dlrmRefundFlag.get() == YES) {
+            FeeTribunalAction tribunalAction = asylumCase.read(FEE_UPDATE_TRIBUNAL_ACTION, FeeTribunalAction.class)
+                .orElseThrow(() -> new IllegalStateException("Fee update tribunal action is not present"));
+
+            postSubmitResponse.setConfirmationHeader("# You have recorded a fee update");
+            postSubmitResponse.setConfirmationBody(
+                WHAT_HAPPENS_NEXT
+                + switch (tribunalAction) {
+                    case REFUND -> "The appropriate team will be notified to review the fee update and process a refund.";
+                    case ADDITIONAL_PAYMENT -> "A payment request will be sent to the appellant.";
+                    case NO_ACTION -> "The appeal fee has been updated. No further action is required.";
+                }
+            );
+            return postSubmitResponse;
+        } else if (completedStages.isPresent() && completedStages.get().size() > 1) {
             String lastCompletedStep = completedStages.get().get(completedStages.get().size() - 1);
 
             if (lastCompletedStep.equals("feeUpdateRefundInstructed")) {
@@ -49,27 +72,26 @@ public class ManageFeeUpdateConfirmation implements PostSubmitCallbackHandler<As
                 postSubmitResponse.setConfirmationHeader("# You have marked the refund as instructed");
                 postSubmitResponse.setConfirmationBody(
                     WHAT_HAPPENS_NEXT
-                        + "The legal representative will be notified that the refund has been instructed.\n\n");
+                    + "The legal representative will be notified that the refund has been instructed.\n\n");
             } else {
                 postSubmitResponse.setConfirmationHeader("# You have progressed a fee update");
                 postSubmitResponse.setConfirmationBody(
                     WHAT_HAPPENS_NEXT
-                        + "If you have recorded that a refund has been approved, you must now instruct the refund.\n\n"
-                        + "If you have recorded that an additional fee has been requested, "
-                        + "the legal representative will be instructed to pay the fee.\n\n"
-                        + "If you have recorded that no fee update is required, you need to contact "
-                        + "the legal representative and tell them why the fee update is no longer required.\n\n"
+                    + "If you have recorded that a refund has been approved, you must now instruct the refund.\n\n"
+                    + "If you have recorded that an additional fee has been requested, "
+                    + "the legal representative will be instructed to pay the fee.\n\n"
+                    + "If you have recorded that no fee update is required, you need to contact "
+                    + "the legal representative and tell them why the fee update is no longer required.\n\n"
                 );
             }
             return postSubmitResponse;
-        }
-
-        postSubmitResponse.setConfirmationHeader("# You have recorded a fee update");
-        postSubmitResponse.setConfirmationBody(
-            WHAT_HAPPENS_NEXT
+        } else {
+            postSubmitResponse.setConfirmationHeader("# You have recorded a fee update");
+            postSubmitResponse.setConfirmationBody(
+                WHAT_HAPPENS_NEXT
                 + "The appropriate team will be notified to review the fee update and take the next steps."
-        );
-
-        return postSubmitResponse;
+            );
+            return postSubmitResponse;
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ManageFeeUpdatePreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ManageFeeUpdatePreparer.java
@@ -61,11 +61,12 @@ public class ManageFeeUpdatePreparer implements PreSubmitCallbackHandler<AsylumC
         asylumCase.write(DISPLAY_FEE_UPDATE_STATUS, displayFeeUpdateStatus);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse = new PreSubmitCallbackResponse<>(asylumCase);
-        if (completedStages.isPresent()
-            && completedStages.get().get(completedStages.get().size() - 1).equals("feeUpdateNotRequired")) {
-            callbackResponse.addError("You can no longer manage a fee update for this appeal "
-                + "because a fee update has been recorded as not required.");
-            return callbackResponse;
+        if (completedStages.isPresent() && !completedStages.get().isEmpty()) {
+            if (completedStages.get().get(completedStages.get().size() - 1).equals("feeUpdateNotRequired")) {
+                callbackResponse.addError("You can no longer manage a fee update for this appeal "
+                                          + "because a fee update has been recorded as not required.");
+                return callbackResponse;
+            }
         }
 
         AppealType appealType = asylumCase.read(APPEAL_TYPE, AppealType.class)

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeTribunalActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeTribunalActionTest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class FeeTribunalActionTest {
+
+    @Test
+    void has_correct_values() {
+        assertEquals("refund", FeeTribunalAction.REFUND.toString());
+        assertEquals("additionalPayment", FeeTribunalAction.ADDITIONAL_PAYMENT.toString());
+        assertEquals("noAction", FeeTribunalAction.NO_ACTION.toString());
+    }
+
+    @Test
+    void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
+        assertEquals(3, FeeTribunalAction.values().length);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeUpdateReasonTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/FeeUpdateReasonTest.java
@@ -11,10 +11,11 @@ class FeeUpdateReasonTest {
         assertEquals("decisionTypeChanged", FeeUpdateReason.DECISION_TYPE_CHANGED.toString());
         assertEquals("appealNotValid", FeeUpdateReason.APPEAL_NOT_VALID.toString());
         assertEquals("feeRemissionChanged", FeeUpdateReason.FEE_REMISSION_CHANGED.toString());
+        assertEquals("appealWithdrawn", FeeUpdateReason.APPEAL_WITHDRAWN.toString());
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(3, FeeUpdateReason.values().length);
+        assertEquals(4, FeeUpdateReason.values().length);
     }
 }


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-8230

### Change description ###

- Added confirmation screen dynamic content based on new Tribunal Action selection (new screen added to ccd-definitions)
- Retained previous logic for legacy scenarios where DLRM-refund feature flag value is not present/no
- Unit and functional tests

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
