### PR TITLE
RIA-8851 Set isLocationUsingRefData when starting case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -444,6 +444,12 @@ public enum AsylumCaseFieldDefinition {
     LIST_CASE_HEARING_CENTRE_ADDRESS(
         "listCaseHearingCentreAddress", new TypeReference<HearingCentre>(){}),
 
+    LISTING_LOCATION(
+        "listingLocation", new TypeReference<DynamicList>(){}),
+
+    IS_CASE_USING_LOCATION_REF_DATA(
+        "isCaseUsingLocationRefData", new TypeReference<YesOrNo>(){}),
+
     LIST_CASE_HEARING_DATE(
         "listCaseHearingDate", new TypeReference<String>(){}),
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/LocationRefDataEnabler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/LocationRefDataEnabler.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_CASE_USING_LOCATION_REF_DATA;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event.START_APPEAL;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.FeatureToggler;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LocationRefDataEnabler  implements PreSubmitCallbackHandler<AsylumCase> {
+
+    /*
+    Setting a flag to denote the case as an appeal that uses Location Ref Data or not.
+    Once the feature is universally adopted across an environment, this can be defaulted to
+    "true" or can be refactored so that the feature isn't hidden behind this filter.
+     */
+
+    private static final String APPEALS_LOCATION_REFERENCE_DATA = "appeals-location-reference-data";
+
+    private final FeatureToggler featureToggler;
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+               && callback.getEvent() == START_APPEAL;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final AsylumCase asylumCase =
+            callback
+                .getCaseDetails()
+                .getCaseData();
+
+        boolean isEnabledForCurrentUser = featureToggler
+            .getValue(APPEALS_LOCATION_REFERENCE_DATA, false);
+
+        if (isEnabledForCurrentUser) {
+            asylumCase.write(IS_CASE_USING_LOCATION_REF_DATA, YES);
+        }
+
+        log.info("Current user is creating a case that {} Location Ref Data",
+            isEnabledForCurrentUser ? "USES" : "DOES NOT USE");
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/LocationRefDataEnablerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/LocationRefDataEnablerTest.java
@@ -1,0 +1,129 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_CASE_USING_LOCATION_REF_DATA;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.mockito.verification.VerificationMode;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.service.FeatureToggler;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+public class LocationRefDataEnablerTest {
+
+    private static final String APPEALS_LOCATION_REFERENCE_DATA = "appeals-location-reference-data";
+
+    @Mock
+    private FeatureToggler featureToggler;
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+
+    private LocationRefDataEnabler locationRefDataEnabler;
+
+    @BeforeEach
+    public void setUp() {
+
+        locationRefDataEnabler =
+            new LocationRefDataEnabler(featureToggler);
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "true", "false" })
+    void should_write_field_based_on_toggle_value(boolean isEnabled) {
+        when(featureToggler.getValue(APPEALS_LOCATION_REFERENCE_DATA, false))
+            .thenReturn(isEnabled);
+
+        locationRefDataEnabler.handle(ABOUT_TO_SUBMIT, callback);
+
+        VerificationMode verificationMode = isEnabled ? times(1) : never();
+        verify(asylumCase, verificationMode).write(IS_CASE_USING_LOCATION_REF_DATA, YES);
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> locationRefDataEnabler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.SEND_DIRECTION);
+        assertThatThrownBy(() -> locationRefDataEnabler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = locationRefDataEnabler.canHandle(callbackStage, callback);
+
+                if (event == Event.START_APPEAL
+                    && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT) {
+
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> locationRefDataEnabler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> locationRefDataEnabler.canHandle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> locationRefDataEnabler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> locationRefDataEnabler.handle(PreSubmitCallbackStage.ABOUT_TO_START, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-8851](https://tools.hmcts.net/jira/browse/RIA-8851)


### Change description ###
- Made `isCaseUsingLocationRefData` be written at the end of the START_APPEAL event, so that it's set to YES when the Launch Darkly flag return true for the user(s) that are enabled to use Location Ref Data

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
