### PR TITLE
RIA-8782 listing location alignment with list case hearing centre

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ListEditCaseHandler.java
@@ -15,14 +15,17 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_CENTRE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_CONDUCTION_OPTIONS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.HEARING_RECORDING_DOCUMENTS;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LISTING_LOCATION;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_CENTRE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_CENTRE_ADDRESS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REHEARD_CASE_LISTED_WITHOUT_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REVIEWED_UPDATED_HEARING_REQUIREMENTS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.STAFF_LOCATION;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isCaseUsingLocationRefData;
 
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.DynamicList;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.HearingCentre;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
@@ -73,6 +76,15 @@ public class ListEditCaseHandler implements PreSubmitCallbackHandler<AsylumCase>
             callback
                 .getCaseDetails()
                 .getCaseData();
+
+        // to keep LISTING_LOCATION aligned with LIST_CASE_HEARING_CENTRE until all code uses LISTING_LOCATION
+        if (isCaseUsingLocationRefData(asylumCase)) {
+            asylumCase.read(LISTING_LOCATION, DynamicList.class)
+                .ifPresent(dynamicList -> {
+                    String epimsId = dynamicList.getValue().getCode();
+                    HearingCentre.from(epimsId).ifPresent(hc -> asylumCase.write(LIST_CASE_HEARING_CENTRE, hc));
+                });
+        }
 
         HearingCentre listCaseHearingCentre =
             asylumCase.read(LIST_CASE_HEARING_CENTRE, HearingCentre.class).orElse(HearingCentre.NEWPORT);


### PR DESCRIPTION
### Jira link (if applicable)
[RIA-8782](https://tools.hmcts.net/jira/browse/RIA-8782)


### Change description ###
- `listCaseHearingCentre` is still needed in a number of places across the code of ia-case-api, ia-case-documents-api and ia-case-notifications-api. This trick will write `listCaseHearingCentre` in parallel with `listingLocation` until the ticket that properly cleans up the move from the old field (`listCaseHearingCentre`) to the new one (`listingLocation`)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
