### PR TITLE
DIAC-489 Revert hasServiceRequestAlready changes in RecordRemissionDecisionStateHandler

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandler.java
@@ -18,7 +18,6 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallb
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.PaymentStatus;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
-import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackStateHandler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.FeatureToggler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.FeePayment;
@@ -109,7 +108,6 @@ public class RecordRemissionDecisionStateHandler implements PreSubmitCallbackSta
 
                 asylumCase.write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.YES);
                 asylumCase.write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.NO);
-                asylumCase.write(HAS_SERVICE_REQUEST_ALREADY, HandlerUtils.isInternalCase(asylumCase) ? YesOrNo.NO : YesOrNo.YES);
 
                 return new PreSubmitCallbackResponse<>(asylumCase, currentState);
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RecordRemissionDecisionStateHandlerTest.java
@@ -207,7 +207,6 @@ class RecordRemissionDecisionStateHandlerTest {
         verify(feePayment, times(1)).aboutToSubmit(callback);
         verify(asylumCase, times(1)).write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.YES);
         verify(asylumCase, times(1)).write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.NO);
-        verify(asylumCase, times(1)).write(HAS_SERVICE_REQUEST_ALREADY, isAdmin.equals("NO") ? YesOrNo.YES : YesOrNo.NO);
 
     }
 
@@ -241,7 +240,6 @@ class RecordRemissionDecisionStateHandlerTest {
         verify(feePayment, times(1)).aboutToSubmit(callback);
         verify(asylumCase, times(1)).write(IS_SERVICE_REQUEST_TAB_VISIBLE_CONSIDERING_REMISSIONS, YesOrNo.YES);
         verify(asylumCase, times(1)).write(DISPLAY_MARK_AS_PAID_EVENT_FOR_PARTIAL_REMISSION, YesOrNo.NO);
-        verify(asylumCase, times(1)).write(HAS_SERVICE_REQUEST_ALREADY, isAdmin.equals("NO") ? YesOrNo.YES : YesOrNo.NO);
 
     }
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DIAC-489

### Change description ###
"hasServiceRequestAlready" changes in RecordRemissionDecisionStateHandler were reverted and causing issues in Service Request tab. Remove code setting ""hasServiceRequestAlready" value.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
