### PR TITLE
DIAC-456 Test post code validation update

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -169,9 +169,9 @@ withPipeline(type, product, component) {
     """
     }
 
-//    afterAlways('functionalTest:aat') {
-//        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
-//    }
+    afterAlways('functionalTest:aat') {
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
+    }
 
     enableSlackNotifications('#ia-tech')
 

--- a/build.gradle
+++ b/build.gradle
@@ -374,7 +374,6 @@ dependencies {
 
     implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
-    implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
     implementation(group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0') {
         exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -374,6 +374,7 @@ dependencies {
 
     implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
     implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
+    implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
     implementation(group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0') {
         exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
     }

--- a/charts/ia-case-api/values.preview.template.yaml
+++ b/charts/ia-case-api/values.preview.template.yaml
@@ -473,7 +473,7 @@ ia-aip-frontend:
   enabled: true
   nodejs:
     imagePullPolicy: Always
-    image: hmctspublic.azurecr.io/ia/aip-frontend:latest
+    image: hmctspublic.azurecr.io/ia/aip-frontend:pr-1152
     # image: hmctspublic.azurecr.io/ia/aip-frontend:pr-1139
     ingressHost: ${SERVICE_NAME}-aip-frontend.preview.platform.hmcts.net # override in public facing environments
     applicationPort: 3000

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/CcdScenarioRunnerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacaseapi/CcdScenarioRunnerTest.java
@@ -27,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationSerenityRunner;
 import net.serenitybdd.rest.SerenityRest;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,7 +55,6 @@ import uk.gov.hmcts.reform.iacaseapi.verifiers.Verifier;
 @RunWith(SpringIntegrationSerenityRunner.class)
 @Slf4j
 @SpringBootTest
-@Disabled
 @ActiveProfiles("functional")
 public class CcdScenarioRunnerTest {
 


### PR DESCRIPTION
The current validation is not working as expected in certain scenarios i.e. with the post code "E11 6SPE" where the user is redirected to the "Sorry there is a problem currently." These changes update the postcode search validation to display a clearer message to the user in cases of invalid postcodes.

https://tools.hmcts.net/jira/browse/DIAC-456