### PR TITLE
RIA-9203 OOC option 2 leave UK fix to use decision letter date for out of time appeals

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeDecisionDateChecker.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/HomeOfficeDecisionDateChecker.java
@@ -4,7 +4,6 @@ import static java.time.LocalDate.parse;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CLIENT_LEAVE_UK;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_CLIENT_LEAVE_UK_ADMIN_J;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_ENTRY_CLEARANCE_DECISION;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DATE_ON_DECISION_LETTER;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.DECISION_LETTER_RECEIVED_DATE;
@@ -183,10 +182,6 @@ public class HomeOfficeDecisionDateChecker implements PreSubmitCallbackHandler<A
                     .orElseThrow(() -> new RequiredFieldMissingException("dateEntryClearanceDecision is not present")));
 
             case LEAVE_UK:
-                Optional<String> dateClientLeaveUk = asylumCase.read(DATE_CLIENT_LEAVE_UK_ADMIN_J);
-                return parse(dateClientLeaveUk
-                    .orElseThrow(() -> new RequiredFieldMissingException("dateClientLeaveUk is not present")));
-
             case NONE:
                 Optional<String> homeOfficeDecisionLetterDate = asylumCase.read(DECISION_LETTER_RECEIVED_DATE);
                 return parse(homeOfficeDecisionLetterDate


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-9203

### Change description ###

- Switched the date used to calculate out of time appeals for Internal OOC appeals for option 2, Leave UK
- Previously used DATE_CLIENT_LEAVE_UK_ADMIN_J now uses DECISION_LETTER_RECEIVED_DATE

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
