### PR TITLE
RIA-8975 Added handler to set isAriaMigrated for StartAppeal event

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-8975-add-is-aria-migrated-no.json
+++ b/src/functionalTest/resources/scenarios/RIA-8975-add-is-aria-migrated-no.json
@@ -1,0 +1,24 @@
+{
+  "description": "RIA-8975 Add is ARIA migrated flag (NO) during start appeal",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "eventId": "startAppeal",
+      "state": "appealStarted",
+      "caseData": {
+        "template": "minimal-appeal-started.json"
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-started.json",
+      "replacements": {
+        "isAriaMigrated": "No"
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/entities/AsylumCaseFieldDefinition.java
@@ -2119,9 +2119,12 @@ public enum AsylumCaseFieldDefinition {
     LETTER_NOTIFICATION_DOCUMENTS(
         "letterNotificationDocuments", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
 
-    // Temporary value to set the case state as 'Migrated'
     IS_ARIA_MIGRATED(
         "isAriaMigrated", new TypeReference<YesOrNo>(){}),
+
+    // Temporary value to set the case state as 'Migrated'
+    IS_ARIA_MIGRATED_TEMPORARY(
+            "isAriaMigratedTemporary", new TypeReference<YesOrNo>(){}),
 
     // Temporary value to set the case desired state
     ARIA_DESIRED_STATE(

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/migratedcase/AriaCreateCaseHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/migratedcase/AriaCreateCaseHandler.java
@@ -8,6 +8,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ARIA_DESIRED_STATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ARIA_DESIRED_STATE_SELECTED_VALUE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ARIA_MIGRATED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ARIA_MIGRATED_TEMPORARY;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
@@ -53,9 +54,10 @@ public class AriaCreateCaseHandler implements PreSubmitCallbackHandler<AsylumCas
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
 
         return (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-            && Event.ARIA_CREATE_CASE == callback.getEvent())
-            || (Event.START_APPEAL == callback.getEvent()
-            && asylumCase.read(IS_ARIA_MIGRATED, YesOrNo.class).equals(Optional.of(YesOrNo.YES)));
+            && (Event.ARIA_CREATE_CASE == callback.getEvent()
+                // @TODO Temporary event START_APPEAL for migration work, to be removed
+                || (Event.START_APPEAL == callback.getEvent()
+                && asylumCase.read(IS_ARIA_MIGRATED_TEMPORARY, YesOrNo.class).equals(Optional.of(YesOrNo.YES)))));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/migratedcase/CreateMigratedCasePreparer.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/migratedcase/CreateMigratedCasePreparer.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.migratedcase;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ARIA_DESIRED_STATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ARIA_DESIRED_STATE_SELECTED_VALUE;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ARIA_MIGRATED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ARIA_MIGRATED_TEMPORARY;
 
 import java.util.Optional;
 import org.springframework.stereotype.Component;
@@ -45,9 +45,9 @@ public class CreateMigratedCasePreparer implements PreSubmitCallbackStateHandler
         AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
         final State currentState = callback.getCaseDetails().getState();
 
-        asylumCase.read(ARIA_DESIRED_STATE, State.class).ifPresent(value -> asylumCase.write(ARIA_DESIRED_STATE_SELECTED_VALUE, value.getDescription()));
-
-        if (asylumCase.read(IS_ARIA_MIGRATED, YesOrNo.class).equals(Optional.of(YesOrNo.YES))) {
+        if (asylumCase.read(IS_ARIA_MIGRATED_TEMPORARY, YesOrNo.class).equals(Optional.of(YesOrNo.YES))) {
+            asylumCase.read(ARIA_DESIRED_STATE, State.class)
+                    .ifPresent(value -> asylumCase.write(ARIA_DESIRED_STATE_SELECTED_VALUE, value.getDescription()));
             return new PreSubmitCallbackResponse<>(asylumCase, State.MIGRATED);
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/migratedcase/StartAppealCreateCaseHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/migratedcase/StartAppealCreateCaseHandler.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.migratedcase;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ARIA_MIGRATED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
+
+@Component
+public class StartAppealCreateCaseHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    public StartAppealCreateCaseHandler() {
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        return (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+            && Event.START_APPEAL == callback.getEvent());
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<AsylumCase> handle(PreSubmitCallbackStage callbackStage,
+                                                        Callback<AsylumCase> callback) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        asylumCase.write(IS_ARIA_MIGRATED, NO);
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/migratedcase/AriaCreateCaseHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/migratedcase/AriaCreateCaseHandlerTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.migratedcase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -17,6 +17,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ARIA_DESIRED_STATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.ARIA_DESIRED_STATE_SELECTED_VALUE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ARIA_MIGRATED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ARIA_MIGRATED_TEMPORARY;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority.LATEST;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
@@ -40,7 +41,6 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
-import uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.migratedcase.AriaCreateCaseHandler;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.AppealReferenceNumberGenerator;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -146,7 +146,7 @@ class AriaCreateCaseHandlerTest {
                 boolean canHandle = ariaCreateCaseHandler.canHandle(callbackStage, callback);
 
                 if ((callbackStage == ABOUT_TO_SUBMIT && event == Event.ARIA_CREATE_CASE)
-                    || (event == Event.START_APPEAL && asylumCase.read(IS_ARIA_MIGRATED, YesOrNo.class).equals(Optional.of(YesOrNo.YES)))) {
+                    || (event == Event.START_APPEAL && asylumCase.read(IS_ARIA_MIGRATED_TEMPORARY, YesOrNo.class).equals(Optional.of(YesOrNo.YES)))) {
                     assertTrue(canHandle);
                 } else {
                     assertFalse(canHandle);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/migratedcase/StartAppealCreateCaseHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/migratedcase/StartAppealCreateCaseHandlerTest.java
@@ -1,0 +1,114 @@
+package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit.migratedcase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.IS_ARIA_MIGRATED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+class StartAppealCreateCaseHandlerTest {
+
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+
+    private StartAppealCreateCaseHandler startAppealCreateCaseHandler;
+
+    @BeforeEach
+    public void setUp() {
+
+        startAppealCreateCaseHandler =
+            new StartAppealCreateCaseHandler();
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+    }
+
+    @Test
+    void should_set_is_aria_migrated_no() {
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            startAppealCreateCaseHandler.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(asylumCase, times(1)).write(IS_ARIA_MIGRATED, YesOrNo.NO);
+    }
+
+    @Test
+    void it_can_handle_callback() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+
+                boolean canHandle = startAppealCreateCaseHandler.canHandle(callbackStage, callback);
+
+                if ((callbackStage == ABOUT_TO_SUBMIT && event == Event.START_APPEAL)) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+
+            reset(callback);
+        }
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+
+        assertThatThrownBy(() -> startAppealCreateCaseHandler.handle(ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> startAppealCreateCaseHandler.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> startAppealCreateCaseHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> startAppealCreateCaseHandler.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> startAppealCreateCaseHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-8975


### Change description ###
Added handler to set isAriaMigrated for StartAppeal event

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ x ] Does this PR introduce a breaking change
