### PR TITLE
DIAC-557 CVE Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -358,7 +358,7 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.10.0'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.8'
-    implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.3'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.4'
     implementation group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.3.3'
 
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.83'
@@ -384,7 +384,7 @@ dependencies {
         exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
     }
     implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.74'
-    implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.19.2-RELEASE'
+    implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '5.0.1-RELEASE'
 
     compileOnly 'org.projectlombok:lombok'
 
@@ -395,11 +395,14 @@ dependencies {
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
 
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap' , version: '4.0.0'
+    implementation(group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap' , version: '4.0.0'){
+        exclude group: "org.bouncycastle", module: "bcprov-jdk15on"
+    }
 
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.3'
 
     implementation group: 'net.minidev', name: 'json-smart', version: '2.5.0'
+    implementation 'joda-time:joda-time:2.12.7'
 
     testImplementation group: 'org.pitest', name: 'pitest', version: versions.pitest
     testImplementation "info.solidsoft.gradle.pitest:gradle-pitest-plugin:${versions.pitest}"
@@ -408,7 +411,7 @@ dependencies {
     testImplementation group: 'com.h2database', name: 'h2', version: '1.4.197'
 
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
-    
+
     testImplementation group: 'org.mockito', name: 'mockito-core', version :'4.3.0'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version :'5.2.0'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,28 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2024-06-01">
-        <!-- 2022-09: Not applicable to us. We don't use HTTP Invoker nor do we communicate through native java bean serialization.
-        We use JSON instead. Suppressed for a year to allow re-assessing in the unlikely event we decide to introduce it. -->
-        <notes><![CDATA[ springframework spring-* packages:
-            https://github.com/spring-projects/spring-framework/issues/24434#issuecomment-1132113566]]></notes>
-        <cve>CVE-2016-1000027</cve>
-    </suppress>
-    <suppress until="2024-12-01">
-        <notes>![CDATA[
-            False positive - https://github.com/jeremylong/DependencyCheck/issues/5502
-
-            We don't use the libraries affected by this vulnerability. This is a false positive in dependencycheck that is still current in version 8.2.1.
-            Try to remove it when a dependencycheck upgrade becomes available.
-            If it still happens, check that we don't use hutool-json and json-java. If we don't, extend the suppression date by another year.
-            ]]</notes>
-        <cve>CVE-2022-45688</cve>
-        <cve>CVE-2023-5072</cve>
-    </suppress>
-    <suppress until="2024-08-26">
-        <cve>CVE-2024-1597</cve>
-    </suppress>
-    <suppress until="2024-12-01">
-        <cve>CVE-2023-1370</cve>
-        <cve>CVE-2023-33202</cve>
-    </suppress>
 </suppressions>


### PR DESCRIPTION
### Jira link (if applicable)
[DIAC-557](https://tools.hmcts.net/jira/browse/DIAC-557)

### Change description ###
Update postgresql to v42.4.4  (patch) fixing critical CVE-2024-1597

Update  uk.gov.service.notify notifications-java-client to v5.0.1-RELEASE (major) fixing [CVE-2023-5072](https://nvd.nist.gov/vuln/detail/CVE-2023-5072)

Exclude bouncy castle bcprov-jdk15on from Spring-Cloud-Starter-Bootstrap fixing [CVE-2023-33202](https://nvd.nist.gov/vuln/detail/CVE-2023-33202)

Remove unneeded suppressions

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
