### PR TITLE
DIAC-588 Reinstate Appeal event to set 'appealSubmitted' state

### DIFF
--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-api
 home: https://github.com/hmcts/ia-case-api
-version: 0.0.50
+version: 0.0.51
 description: Immigration & Asylum Case API
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-api
 home: https://github.com/hmcts/ia-case-api
-version: 0.0.51
+version: 0.0.52
 description: Immigration & Asylum Case API
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/charts/ia-case-api/values.preview.template.yaml
+++ b/charts/ia-case-api/values.preview.template.yaml
@@ -78,7 +78,7 @@ ia-case-payments-api:
   enabled: true #set to true if testing against a local branch
   java:
     imagePullPolicy: Always
-    image: hmctspublic.azurecr.io/ia/case-payments-api:latest
+    image: hmctspublic.azurecr.io/ia/case-payments-api:pr-376
     releaseNameOverride: ${SERVICE_NAME}-case-payments-api
     ingressHost: ${SERVICE_NAME}-payments-api.preview.platform.hmcts.net
     disableTraefikTls: true

--- a/charts/ia-case-api/values.preview.template.yaml
+++ b/charts/ia-case-api/values.preview.template.yaml
@@ -31,7 +31,7 @@ java:
     AAC_URL: https://aac-${SERVICE_FQDN}
     CCD_DEFINITION_STORE_API_BASE_URL: "https://ccd-definition-store-{{ .Release.Name }}.preview.platform.hmcts.net"
     LOCATION_REF_DATA_URL: "http://rd-location-ref-api-aat.service.core-compute-aat.internal"
-    DUMMY: true
+    DUMMY: false
   keyVaults:
     ia:
       resourceGroup: ia

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReinstateAppealStateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/ReinstateAppealStateHandler.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.PaymentStatus;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackStateHandler;
 
@@ -78,6 +79,15 @@ public class ReinstateAppealStateHandler implements PreSubmitCallbackStateHandle
         asylumCase.write(RECORD_APPLICATION_ACTION_DISABLED, YesOrNo.NO);
         asylumCase.write(IS_APPLY_FOR_COSTS_OOT, YesOrNo.NO);
 
+        final Optional<PaymentStatus> paymentStatusOptional = asylumCase.read(PAYMENT_STATUS, PaymentStatus.class);
+
+        if (stateBeforeEndAppeal.get() == State.PENDING_PAYMENT
+                && paymentStatusOptional.isPresent()
+                && paymentStatusOptional.get() == PaymentStatus.PAID) {
+
+            return new PreSubmitCallbackResponse<>(asylumCase, State.APPEAL_SUBMITTED);
+        }
+        
         return new PreSubmitCallbackResponse<>(asylumCase, stateBeforeEndAppeal.get());
     }
 }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DIAC-588

### Change description
Update ReinstateAppealHandler to set appeal state to `appealSubmitted` when appeal was struck out for nonpayment and current payment status is Paid.


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
