### PR TITLE
DIAC-592 Refactored main prep import data to script with additional parameters…

### DIFF
--- a/bin/utils/python_scripts/filepath_settings.py
+++ b/bin/utils/python_scripts/filepath_settings.py
@@ -128,7 +128,7 @@ class Settings:
         'interpreterFamilyName': 'redacted - interpreterFamilyName',
         'interpreterGivenNames': 'redacted - interpreterGivenNames',
         'interpreterPhoneNumber': '12345678999',
-        'flagComment': 'redacted - flagComment'
+        'flagComment': 'redacted - flagComment',
     }
 
     csv_rows_to_redact = {

--- a/bin/utils/python_scripts/helpers.py
+++ b/bin/utils/python_scripts/helpers.py
@@ -31,7 +31,7 @@ def remove_first_n_rows(csv_file, n):
 
 def update_case_data_with_latest_event(case_data_file, case_event_file):
     """
-    Used for updating a case_data csv file to a certain event state to import test cases at specific events.
+    Used for updating a case_data csv file to a certain event state to import test cases at specific stages of the journey.
     :param case_data_file:
     :param case_event_file:
     :return:
@@ -62,3 +62,9 @@ def update_case_data_with_latest_event(case_data_file, case_event_file):
         with open(output_file, 'w', newline='') as output_data_file:
             data_writer = csv.writer(output_data_file)
             data_writer.writerows(updated_data_rows)
+
+
+# remove_first_n_rows("/ia-case-api/bin/utils/python_scripts/output_csv_files/case_event_202407221346_redacted.csv", 2)
+
+
+update_case_data_with_latest_event("/ia-case-api/bin/utils/python_scripts/output_csv_files/case_data_202407221421_redacted.csv", "ia-case-api/bin/utils/python_scripts/output_csv_files/case_event_202407221346_redacted_reduced.csv")

--- a/bin/utils/python_scripts/prep_import_data.py
+++ b/bin/utils/python_scripts/prep_import_data.py
@@ -6,26 +6,31 @@ from create_jsons_from_event_csv import create_jsons_from_csv
 from redact_info_from_json import redact_values_from_csv
 
 
-def prep_import_data(directory: str = settings.exported_csv_dir, events_to_get_individual_json: list[int] = None):
+def prep_import_data(directory: str = settings.exported_csv_dir, events_to_get_individual_json: list[int] = None, update_id: bool = True, redact_events: bool = True):
     """
     Function to prep exported CSV data for importing. Redacts and transforms most recent exported files within
-    python_scripts directory.
+    python_scripts directory. To only redact case data CSV run with redact_events=False
 
     Exported files should be in format: case_event_202402080516.csv and case_data_202402080518.csv
     (default export pattern)
     """
-    latest_case_event_data = get_latest_file(directory, 'case_event')
+    if not redact_events:
+        update_id = False
     latest_case_data = get_latest_file(directory, 'case_data')
-    if events_to_get_individual_json:
-        create_jsons_from_csv(latest_case_event_data, events=events_to_get_individual_json)
     redacted_case_data = redact_values_from_csv(latest_case_data)
     os.chmod(redacted_case_data, 0o777)
-    case_data_id = input(
-        'Import the redacted case data CSV and retrieve the correct case id.\nEnter the new case data id:')\
-        .encode('utf-8').decode('utf-8')
-    redacted_case_event_data = redact_values_from_csv(latest_case_event_data)
-    redacted_replaced_event_data = replace_case_data_id(case_data_id, redacted_case_event_data)
-    os.chmod(redacted_replaced_event_data, 0o777)
+    if redact_events:
+        latest_case_event_data = get_latest_file(directory, 'case_event')
+        redacted_case_event_data = redact_values_from_csv(latest_case_event_data)
+        os.chmod(redacted_case_event_data, 0o777)
+        if events_to_get_individual_json:
+            create_jsons_from_csv(latest_case_event_data, events=events_to_get_individual_json)
+    if update_id:
+        case_data_id = input(
+            'Import the redacted case data CSV and retrieve the correct case id.\nEnter the new case data id:') \
+            .encode('utf-8').decode('utf-8')
+        redacted_replaced_event_data = replace_case_data_id(case_data_id, redacted_case_event_data)
+        os.chmod(redacted_replaced_event_data, 0o777)
 
 
 def get_latest_file(dir_path: str, file_prefix: str) -> str:
@@ -61,4 +66,7 @@ def replace_case_data_id(new_id: str, file_path: str):
         writer.writerows(data_list)
     return file_path
 
-prep_import_data(events_to_get_individual_json=range(1, 100))
+
+# prep_import_data(events_to_get_individual_json=range(1, 100))
+
+prep_import_data(redact_events=False)


### PR DESCRIPTION
… to specify what needs done

### Jira link

See [DIAC-592](https://tools.hmcts.net/jira/browse/DIAC-592)

### Change description

Adding additional parameters for python redacting scripts, to allow for only redaction of case data and to not replace ID if applicable.

### Testing done

<!-- Comment:

Code refactor, have tested multiple times myself manually. There are no written tests for these scripts as they are simply for Dev usage when needing to redact data before importing.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
