### PR TITLE
RIA-9452 bug_fix

### DIFF
--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-api
 home: https://github.com/hmcts/ia-case-api
-version: 0.0.51
+version: 0.0.52
 description: Immigration & Asylum Case API
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestNewHearingRequirementsDirectionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestNewHearingRequirementsDirectionHandler.java
@@ -123,7 +123,12 @@ public class RequestNewHearingRequirementsDirectionHandler implements PreSubmitC
         asylumCase.clear(SEND_DIRECTION_PARTIES);
         asylumCase.clear(SEND_DIRECTION_DATE_DUE);
 
-        writePreviousHearingsToAsylumCase(asylumCase);
+        final HearingCentre listCaseHearingCentre = asylumCase.read(LIST_CASE_HEARING_CENTRE, HearingCentre.class)
+            .orElse(HearingCentre.DECISION_WITHOUT_HEARING);
+
+        if (!listCaseHearingCentre.equals(HearingCentre.DECISION_WITHOUT_HEARING)) {
+            writePreviousHearingsToAsylumCase(asylumCase);
+        }
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestNewHearingRequirementsDirectionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/RequestNewHearingRequirementsDirectionHandlerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.iacaseapi.domain.handlers.presubmit;
 
+import static com.google.inject.matcher.Matchers.any;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,20 +24,24 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_CENTRE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_DATE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.LIST_CASE_HEARING_LENGTH;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PREVIOUS_HEARINGS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SEND_DIRECTION_DATE_DUE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SEND_DIRECTION_EXPLANATION;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.SEND_DIRECTION_PARTIES;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -119,8 +124,8 @@ class RequestNewHearingRequirementsDirectionHandlerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = YesOrNo.class, names = { "YES", "NO" })
-    void should_append_new_direction_to_existing_directions_for_the_case(YesOrNo isIntegrated) {
+    @MethodSource("newHearingRequirementsData")
+    void should_append_new_direction_to_existing_directions_for_the_case(YesOrNo isIntegrated, HearingCentre hearingCentre) {
 
         final List<IdValue<Direction>> existingDirections = new ArrayList<>();
         final List<IdValue<Direction>> allDirections = new ArrayList<>();
@@ -137,7 +142,6 @@ class RequestNewHearingRequirementsDirectionHandlerTest {
         final String attendingHomeOfficeLegalRepresentative = "Jim Smith";
         final HoursAndMinutes actualCaseHearingLength = new HoursAndMinutes("5", "30");
         final String ariaListingReference = "LP/12345/2020";
-        final HearingCentre listCaseHearingCentre = HearingCentre.NEWPORT;
         final String listCaseHearingDate = "13/10/2020";
         final String listCaseHearingLength = "6 hours";
         final String appealDecision = "Dismissed";
@@ -159,7 +163,7 @@ class RequestNewHearingRequirementsDirectionHandlerTest {
             .thenReturn(Optional.of(actualCaseHearingLength));
         when(asylumCase.read(ARIA_LISTING_REFERENCE, String.class)).thenReturn(Optional.of(ariaListingReference));
         when(asylumCase.read(LIST_CASE_HEARING_CENTRE, HearingCentre.class))
-            .thenReturn(Optional.of(listCaseHearingCentre));
+            .thenReturn(Optional.of(hearingCentre));
         when(asylumCase.read(LIST_CASE_HEARING_DATE, String.class)).thenReturn(Optional.of(listCaseHearingDate));
         when(asylumCase.read(IS_INTEGRATED, YesOrNo.class)).thenReturn(Optional.of(isIntegrated));
 
@@ -202,6 +206,10 @@ class RequestNewHearingRequirementsDirectionHandlerTest {
         verify(asylumCase).clear(SEND_DIRECTION_EXPLANATION);
         verify(asylumCase).clear(SEND_DIRECTION_PARTIES);
         verify(asylumCase).clear(SEND_DIRECTION_DATE_DUE);
+
+        if (hearingCentre.equals(HearingCentre.DECISION_WITHOUT_HEARING)) {
+            verify(asylumCase, times(0)).write(PREVIOUS_HEARINGS, any());
+        }
     }
 
     @Test
@@ -278,5 +286,12 @@ class RequestNewHearingRequirementsDirectionHandlerTest {
             () -> requestNewHearingRequirementsDirectionHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
             .hasMessage("callback must not be null")
             .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+    private static Stream<Arguments> newHearingRequirementsData() {
+        return Stream.of(
+            Arguments.of(YES, HearingCentre.NEWPORT),
+            Arguments.of(NO, HearingCentre.DECISION_WITHOUT_HEARING)
+        );
     }
 }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/RIA-9452

### Change description
When submitting hearing requirements without hearing state it saves previousHearingRequirements to the list. 
Added a check if Hearing centre is "DECISION_WITHOUT_HEARING" then skip this saving.


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
