### PR TITLE
 RIA-9594 bug_fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/FeesHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/FeesHandler.java
@@ -124,6 +124,9 @@ public class FeesHandler implements PreSubmitCallbackHandler<AsylumCase> {
                     clearRemissionDetails(asylumCase);
                 }
 
+                asylumCase.write(AsylumCaseFieldDefinition.IS_FEE_PAYMENT_ENABLED,
+                        isfeePaymentEnabled ? YES : YesOrNo.NO);
+
                 asylumCase.clear(RP_DC_APPEAL_HEARING_OPTION);
                 break;
 
@@ -221,9 +224,6 @@ public class FeesHandler implements PreSubmitCallbackHandler<AsylumCase> {
     }
 
     private void setFeePaymentDetails(AsylumCase asylumCase, AppealType appealType) {
-
-        asylumCase.write(AsylumCaseFieldDefinition.IS_FEE_PAYMENT_ENABLED,
-            isfeePaymentEnabled ? YES : YesOrNo.NO);
 
         if (!asylumCase.read(PAYMENT_STATUS, PaymentStatus.class).isPresent()) {
             asylumCase.write(PAYMENT_STATUS, PAYMENT_PENDING);


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/RIA-9594

### Change description
Moved IS_FEE_PAYMENT_ENABLED in FeesHandler to handle() method(). Previosly it was saved only for deprivation, revocation and no remission remission types, now it is available for all Remission types. This flag is to enable PaymentHistory tab.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
