### PR TITLE
RIA-0000 Setting json-smart version to fix mismatch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,12 +342,6 @@ dependencies {
     implementation group: 'org.yaml', name: 'snakeyaml'
     implementation group: 'org.apache.commons', name: 'commons-lang3'
 
-    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.22'
-    implementation (group: 'net.minidev', name: 'json-smart', version: '2.4.10'){
-        version {
-            strictly('2.4.10')
-        }
-    }
     implementation group: 'commons-io', name: 'commons-io', version: '2.10.0'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.8'
@@ -396,7 +390,6 @@ dependencies {
 
     implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.37.3'
 
-    implementation group: 'net.minidev', name: 'json-smart', version: '2.5.0'
     implementation 'joda-time:joda-time:2.12.7'
 
     implementation group: 'com.googlecode.libphonenumber', name: 'libphonenumber', version: '8.13.43'


### PR DESCRIPTION
Fixing error:

> Could not find any version that matches net.minidev:json-smart:[1.3.3,2.4.8].
     Versions that do not match: 2.5.2
     Required by:
         project : > org.springframework.security:spring-security-oauth2-client:5.7.11 > com.nimbusds:oauth2-oidc-sdk:9.35


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
