### PR TITLE
DIAC-959 Role cft-ttl-manager missing from setup scripts

### DIFF
--- a/bin/add-roles.sh
+++ b/bin/add-roles.sh
@@ -77,3 +77,4 @@
 ./bin/utils/ccd-add-role.sh "caseworker-ia-bails" "$USER_TOKEN" "$SERVICE_TOKEN"
 ./bin/utils/ccd-add-role.sh "caseworker-ia-homeofficebail" "$USER_TOKEN" "$SERVICE_TOKEN"
 ./bin/utils/ccd-add-role.sh "ia_bail_caseflags_profile" "$USER_TOKEN" "$SERVICE_TOKEN"
+./bin/utils/ccd-add-role.sh "cft-ttl-manager" "$USER_TOKEN" "$SERVICE_TOKEN"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DIAC-959

### Change description
Role cft-ttl-manager missing from setup scripts - role added to setup script

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
