### PR TITLE
Diac 1132 AiP appeals should not be ended automatically when submitted with remission

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -189,7 +189,7 @@ enableSecurityScan()
 
     afterSuccess('akschartsinstall') {
         onPR {
-            if (env.ENABLE_WA == true) {
+            if (env.ENABLE_WA) {
                 githubUpdateDeploymentStatus(githubCreateDeployment("-AIP"), "https://ia-case-api-pr-${CHANGE_ID}-aip-frontend.preview.platform.hmcts.net")
                 githubUpdateDeploymentStatus(githubCreateDeployment("-LR"), "https://xui-ia-case-api-pr-${CHANGE_ID}." + "preview.platform.hmcts.net")
                 env.IDAM_API_URL = "https://idam-api.aat.platform.hmcts.net"

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AutomaticEndAppealForNonPaymentEaHuTrigger.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AutomaticEndAppealForNonPaymentEaHuTrigger.java
@@ -6,6 +6,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REMISSION_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isAcceleratedDetainedAppeal;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isAipJourney;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionOption;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
@@ -55,12 +57,18 @@ public class AutomaticEndAppealForNonPaymentEaHuTrigger implements PreSubmitCall
                 .getCaseData();
 
         Optional<RemissionType> remissionType = asylumCase.read(REMISSION_TYPE, RemissionType.class);
+        Optional<RemissionOption> remissionOption = asylumCase.read(REMISSION_OPTION, RemissionOption.class);
         Optional<AppealType> appealType = asylumCase.read(APPEAL_TYPE, AppealType.class);
+
+        boolean lrAppealWithNoRemission = remissionType.map(
+                remission -> remission.equals(RemissionType.NO_REMISSION)).orElse(true);
+        boolean aipAppealWithNoRemission = remissionOption.isEmpty()
+                || remissionOption.map(remission -> remission.equals(RemissionOption.NO_REMISSION)).orElse(true);
 
         return  callback.getEvent() == Event.SUBMIT_APPEAL
                 && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                 && !isAcceleratedDetainedAppeal(asylumCase)
-                && (remissionType.map(remission -> remission.equals(RemissionType.NO_REMISSION)).orElse(true))
+                && (isAipJourney(asylumCase) ? aipAppealWithNoRemission : lrAppealWithNoRemission)
                 && (appealType.isPresent() && Set.of(EA, HU, EU, AG).contains(appealType.get()));
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AutomaticEndAppealForNonPaymentEaHuTriggerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AutomaticEndAppealForNonPaymentEaHuTriggerTest.java
@@ -29,11 +29,13 @@ import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionOption;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.Scheduler;
 import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.AsylumCaseServiceResponseException;
@@ -75,24 +77,30 @@ class AutomaticEndAppealForNonPaymentEaHuTriggerTest {
 
     private static Stream<Arguments> aipLrScheduleAppeal() {
         return Stream.of(
-            Arguments.of(Optional.empty(), EA), // AIP = remissions can't be chosen (empty)
-            Arguments.of(Optional.empty(), HU),
-            Arguments.of(Optional.empty(), EU),
-            Arguments.of(Optional.of(RemissionType.NO_REMISSION), EA), // LR = chose no remissions
-            Arguments.of(Optional.of(RemissionType.NO_REMISSION), HU),
-            Arguments.of(Optional.of(RemissionType.NO_REMISSION), EU)
+            Arguments.of(Optional.of(JourneyType.AIP), Optional.empty(), Optional.of(RemissionOption.NO_REMISSION), EA), // AIP = chose no remission
+            Arguments.of(Optional.of(JourneyType.AIP), Optional.empty(), Optional.empty(), HU),
+            Arguments.of(Optional.of(JourneyType.AIP), Optional.empty(), Optional.empty(), EU),
+            Arguments.of(Optional.empty(), Optional.of(RemissionType.NO_REMISSION), Optional.empty(), EA), // LR = chose no remissions
+            Arguments.of(Optional.empty(), Optional.of(RemissionType.NO_REMISSION), Optional.empty(), HU),
+            Arguments.of(Optional.of(JourneyType.REP), Optional.of(RemissionType.NO_REMISSION), Optional.empty(), EU)
         );
     }
 
     @ParameterizedTest
     @MethodSource("aipLrScheduleAppeal")
-    void should_schedule_automatic_end_appeal_14_days_from_now_ea_hu_eu_after_submission(Optional<RemissionType> remissionType, AppealType appealType) {
+    void should_schedule_automatic_end_appeal_14_days_from_now_ea_hu_eu_after_submission(
+            Optional<JourneyType> journeyType,
+            Optional<RemissionType> remissionType,
+            Optional<RemissionOption> aipRemissionOption,
+            AppealType appealType
+    ) {
         when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(caseDetails.getId()).thenReturn(caseId);
-        when(asylumCase.read(REMISSION_TYPE, RemissionType.class))
-            .thenReturn(remissionType);
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(journeyType);
+        when(asylumCase.read(REMISSION_TYPE, RemissionType.class)).thenReturn(remissionType);
+        when(asylumCase.read(REMISSION_OPTION, RemissionOption.class)).thenReturn(aipRemissionOption);
         when(dateProvider.nowWithTime()).thenReturn(now);
         TimedEvent timedEvent = new TimedEvent(
             id,
@@ -304,6 +312,21 @@ class AutomaticEndAppealForNonPaymentEaHuTriggerTest {
         when(callback.getEvent()).thenReturn(Event.RECORD_REMISSION_DECISION); // unqualified event
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        assertThatThrownBy(() -> automaticEndAppealForNonPaymentEaHuTrigger.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback for auto end appeal for remission rejection")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void handling_should_throw_if_aip_with_remission_appeal_can_not_handle() {
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL); // unqualified event
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.of(JourneyType.AIP));
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(EU));
+        when(asylumCase.read(REMISSION_OPTION, RemissionOption.class))
+                .thenReturn(Optional.of(RemissionOption.ASYLUM_SUPPORT_FROM_HOME_OFFICE));
 
         assertThatThrownBy(() -> automaticEndAppealForNonPaymentEaHuTrigger.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
             .hasMessage("Cannot handle callback for auto end appeal for remission rejection")


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DIAC-1132

### Change description
AiP appeals submitted with remission should not be ended automatically until remission decision is recorded.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
