### PR TITLE
DIAC-1152 Redis chart repo connection failure 

### DIFF
--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-api
 home: https://github.com/hmcts/ia-case-api
-version: 0.0.62
+version: 0.0.63
 description: Immigration & Asylum Case API
 maintainers:
   - name: HMCTS Immigration & Asylum Team

--- a/charts/ia-case-api/Chart.yaml
+++ b/charts/ia-case-api/Chart.yaml
@@ -89,8 +89,8 @@ dependencies:
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: ccd-message-publisher.enabled
   - name: redis
-    version: ~16.13.0
-    repository: "https://charts.bitnami.com/bitnami"
+    version: 20.13.4
+    repository: "oci://registry-1.docker.io/bitnamicharts"
     condition: redis.enabled
   - name: am-org-role-mapping-service
     version: ~0.0.68


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DIAC-1152

### Change description
DIAC-1152 Redis chart repo connection failure - Redis repository changed to oci://registry-1.docker.io/bitnamicharts and version to 20.13.4

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
