### PR TITLE
DIAC-1178 AiP appeals with remission should not be ended automatically before remission decision

### DIFF
--- a/charts/ia-case-api/values.preview.template.yaml
+++ b/charts/ia-case-api/values.preview.template.yaml
@@ -830,6 +830,7 @@ ccd:
         DATA_STORE_DB_PASSWORD: ${GENERIC_VALUES_PREVIEW_YAML_PASS}
         DATA_STORE_IDAM_KEY: ${DATA_STORE_S2S_KEY}        
         DATA_STORE_CROSS_JURISDICTIONAL_ROLES: caseworker-caa,caseworker-approver
+        DATA_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_ps,probate_backend,divorce_ccd_submission,sscs,sscs_bulkscan,cmc,cmc_claim_store,cmc_claim_external_api,jui_webapp,pui_webapp,bulk_scan_orchestrator,fpl_case_service,iac,finrem_ccd_data_migrator,finrem_case_orchestration,employment_tribunals,ethos_repl_service,ccpay_bubble,ctsc_work_allocation,em_ccd_orchestrator,xui_webapp,bulk_scan_payment_processor,pcq_consolidation_service,em_npa_app,ecm_consumer,aac_manage_case_assignment,am_role_assignment_service,wa_task_configuration_api,divorce_frontend,wa_task_management_api,wa_workflow_api,em_hrs_api,nfdiv_case_api,civil_service,wa_task_monitor,ccd_case_document_am_api,adoption_cos_api,adoption_web,et_cos,et_msg_handler,prl_cos_api,wa_case_event_handler,et_sya_api,ds_ui,hmc_cft_hearing_service,prl_cos_api,fis_hmc_api,ccd_next_hearing_date_updater,civil_general_applications,fis_cos_api,sptribs_case_api,et_wa_post_deployment_ft_tests,em_annotation_app,et_hearings_api,sptribs_dss_update_case_web
         IDAM_API_BASE_URL: https://idam-api.aat.platform.hmcts.net
         IDAM_OIDC_URL: https://idam-web-public.aat.platform.hmcts.net
         IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET: ${IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET}

--- a/charts/ia-case-api/values.preview.template.yaml
+++ b/charts/ia-case-api/values.preview.template.yaml
@@ -36,6 +36,8 @@ java:
     FEES_REGISTER_API_URL: "http://fees-register-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     DUMMY: true
     PAYMENT_REMINDER_DUE_IN_MINUTES: 1
+    PAYMENT_AFTER_REMISSION_REJECTION_DUE_IN_MINUTES: 5
+    PAYMENT_EA_HU_NO_REMISSION_DUE_IN_MINUTES: 5
   keyVaults:
     ia:
       resourceGroup: ia

--- a/charts/ia-case-api/values.preview.template.yaml
+++ b/charts/ia-case-api/values.preview.template.yaml
@@ -36,8 +36,8 @@ java:
     FEES_REGISTER_API_URL: "http://fees-register-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     DUMMY: true
     PAYMENT_REMINDER_DUE_IN_MINUTES: 1
-    PAYMENT_AFTER_REMISSION_REJECTION_DUE_IN_MINUTES: 5
-    PAYMENT_EA_HU_NO_REMISSION_DUE_IN_MINUTES: 5
+    PAYMENT_AFTER_REMISSION_REJECTION_DUE_IN_MINUTES: 1440
+    PAYMENT_EA_HU_NO_REMISSION_DUE_IN_MINUTES: 1440
   keyVaults:
     ia:
       resourceGroup: ia

--- a/charts/ia-case-api/values.preview.template.yaml
+++ b/charts/ia-case-api/values.preview.template.yaml
@@ -829,7 +829,6 @@ ccd:
         DATA_STORE_DB_PASSWORD: ${GENERIC_VALUES_PREVIEW_YAML_PASS}
         DATA_STORE_IDAM_KEY: ${DATA_STORE_S2S_KEY}        
         DATA_STORE_CROSS_JURISDICTIONAL_ROLES: caseworker-caa,caseworker-approver
-        DATA_STORE_S2S_AUTHORISED_SERVICES: ccd_data,ccd_gw,ccd_ps,probate_backend,divorce_ccd_submission,sscs,sscs_bulkscan,cmc,cmc_claim_store,cmc_claim_external_api,jui_webapp,pui_webapp,bulk_scan_orchestrator,fpl_case_service,iac,finrem_ccd_data_migrator,finrem_case_orchestration,employment_tribunals,ethos_repl_service,ccpay_bubble,ctsc_work_allocation,em_ccd_orchestrator,xui_webapp,bulk_scan_payment_processor,pcq_consolidation_service,em_npa_app,ecm_consumer,aac_manage_case_assignment,am_role_assignment_service,wa_task_configuration_api,divorce_frontend,wa_task_management_api,wa_workflow_api,em_hrs_api,nfdiv_case_api,civil_service,wa_task_monitor,ccd_case_document_am_api,adoption_cos_api,adoption_web,et_cos,et_msg_handler,prl_cos_api,wa_case_event_handler,et_sya_api,ds_ui,hmc_cft_hearing_service,prl_cos_api,fis_hmc_api,ccd_next_hearing_date_updater,civil_general_applications,fis_cos_api,sptribs_case_api,et_wa_post_deployment_ft_tests,em_annotation_app,et_hearings_api,sptribs_dss_update_case_web
         IDAM_API_BASE_URL: https://idam-api.aat.platform.hmcts.net
         IDAM_OIDC_URL: https://idam-web-public.aat.platform.hmcts.net
         IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET: ${IDAM_OAUTH2_DATA_STORE_CLIENT_SECRET}

--- a/charts/ia-case-api/values.preview.template.yaml
+++ b/charts/ia-case-api/values.preview.template.yaml
@@ -36,8 +36,8 @@ java:
     FEES_REGISTER_API_URL: "http://fees-register-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     DUMMY: true
     PAYMENT_REMINDER_DUE_IN_MINUTES: 1
-    PAYMENT_AFTER_REMISSION_REJECTION_DUE_IN_MINUTES: 1440
-    PAYMENT_EA_HU_NO_REMISSION_DUE_IN_MINUTES: 1440
+    PAYMENT_AFTER_REMISSION_REJECTION_DUE_IN_MINUTES: 5
+    PAYMENT_EA_HU_NO_REMISSION_DUE_IN_MINUTES: 5
   keyVaults:
     ia:
       resourceGroup: ia

--- a/charts/ia-case-api/values.preview.template.yaml
+++ b/charts/ia-case-api/values.preview.template.yaml
@@ -34,7 +34,7 @@ java:
     CCD_DEFINITION_STORE_API_BASE_URL: "https://ccd-definition-store-{{ .Release.Name }}.preview.platform.hmcts.net"
     LOCATION_REF_DATA_URL: "http://rd-location-ref-api-aat.service.core-compute-aat.internal"
     FEES_REGISTER_API_URL: "http://fees-register-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
-    DUMMY_VAR: true
+    DUMMY: true
     PAYMENT_REMINDER_DUE_IN_MINUTES: 1
   keyVaults:
     ia:

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AutomaticEndAppealForNonPaymentEaHuTrigger.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AutomaticEndAppealForNonPaymentEaHuTrigger.java
@@ -6,6 +6,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.APPEAL_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.REMISSION_TYPE;
 import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isAcceleratedDetainedAppeal;
+import static uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils.isAipJourney;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionOption;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
@@ -55,12 +57,18 @@ public class AutomaticEndAppealForNonPaymentEaHuTrigger implements PreSubmitCall
                 .getCaseData();
 
         Optional<RemissionType> remissionType = asylumCase.read(REMISSION_TYPE, RemissionType.class);
+        Optional<RemissionOption> remissionOption = asylumCase.read(REMISSION_OPTION, RemissionOption.class);
         Optional<AppealType> appealType = asylumCase.read(APPEAL_TYPE, AppealType.class);
+
+        boolean lrAppealWithNoRemission = remissionType.map(
+                remission -> remission.equals(RemissionType.NO_REMISSION)).orElse(true);
+        boolean aipAppealWithNoRemission = remissionOption.isEmpty()
+                || remissionOption.map(remission -> remission.equals(RemissionOption.NO_REMISSION)).orElse(true);
 
         return  callback.getEvent() == Event.SUBMIT_APPEAL
                 && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                 && !isAcceleratedDetainedAppeal(asylumCase)
-                && (remissionType.map(remission -> remission.equals(RemissionType.NO_REMISSION)).orElse(true))
+                && (isAipJourney(asylumCase) ? aipAppealWithNoRemission : lrAppealWithNoRemission)
                 && (appealType.isPresent() && Set.of(EA, HU, EU, AG).contains(appealType.get()));
 
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/SendNotificationHandler.java
@@ -192,8 +192,6 @@ public class SendNotificationHandler implements PreSubmitCallbackHandler<AsylumC
             eventsToHandle.add(Event.EDIT_CASE_LISTING);
         }
 
-        log.info("-----------getEventsToHandle {}", eventsToHandle);
-
         return eventsToHandle;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/AiPFeesHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/AiPFeesHandler.java
@@ -107,6 +107,7 @@ public class AiPFeesHandler implements PreSubmitCallbackHandler<AsylumCase> {
                             .orElse("decisionWithHearing");
                     asylumCase.write(DECISION_HEARING_FEE_OPTION, hearingOption);
                     asylumCase.clear(PAYMENT_STATUS);
+                    asylumCase.clear(REMISSION_OPTION);
                     clearFeeOptionDetails(asylumCase);
                     clearRemissionDetails(asylumCase);
                     break;
@@ -136,6 +137,7 @@ public class AiPFeesHandler implements PreSubmitCallbackHandler<AsylumCase> {
                         .orElse("decisionWithHearing");
                 asylumCase.write(DECISION_HEARING_FEE_OPTION, hearingOption);
                 asylumCase.clear(PAYMENT_STATUS);
+                asylumCase.clear(REMISSION_OPTION);
 
                 clearFeeOptionDetails(asylumCase);
                 clearRemissionDetails(asylumCase);
@@ -188,7 +190,6 @@ public class AiPFeesHandler implements PreSubmitCallbackHandler<AsylumCase> {
                             clearRemissionDetails(asylumCase);
                         }
                     } else {
-                        asylumCase.write(REMISSION_OPTION, RemissionOption.I_WANT_TO_GET_HELP_WITH_FEES);
                         asylumCase.write(FEE_REMISSION_TYPE, "Help with Fees");
                         asylumCase.clear(ASYLUM_SUPPORT_REF_NUMBER);
                         asylumCase.clear(LOCAL_AUTHORITY_LETTERS);
@@ -224,7 +225,6 @@ public class AiPFeesHandler implements PreSubmitCallbackHandler<AsylumCase> {
     }
 
     private void clearRemissionDetails(AsylumCase asylumCase) {
-        asylumCase.clear(REMISSION_OPTION);
         asylumCase.clear(FEE_REMISSION_TYPE);
         asylumCase.clear(ASYLUM_SUPPORT_REF_NUMBER);
         asylumCase.clear(LOCAL_AUTHORITY_LETTERS);

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentHandler.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PAYMENT_STATUS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.PaymentStatus.PAID;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
@@ -14,13 +13,11 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
-import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.PaymentStatus;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
-@Slf4j
 public class PaymentHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
     private final boolean isfeePaymentEnabled;
@@ -65,9 +62,6 @@ public class PaymentHandler implements PreSubmitCallbackHandler<AsylumCase> {
         asylumCase.write(AsylumCaseFieldDefinition.IS_FEE_PAYMENT_ENABLED,
             isfeePaymentEnabled ? YesOrNo.YES : YesOrNo.NO);
 
-        log.info("PaymentHandler.handle(): paymentStatus: {}, caseReference: {}, state: {}",
-                asylumCase.read(PAYMENT_STATUS, PaymentStatus.class).orElse(null),
-                callback.getCaseDetails().getId(), callback.getCaseDetails().getState());
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentHandler.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefinition.PAYMENT_STATUS;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.PaymentStatus.PAID;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
@@ -13,11 +14,13 @@ import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.PaymentStatus;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.HandlerUtils;
 import uk.gov.hmcts.reform.iacaseapi.domain.handlers.PreSubmitCallbackHandler;
 
 @Component
+@Slf4j
 public class PaymentHandler implements PreSubmitCallbackHandler<AsylumCase> {
 
     private final boolean isfeePaymentEnabled;
@@ -62,6 +65,9 @@ public class PaymentHandler implements PreSubmitCallbackHandler<AsylumCase> {
         asylumCase.write(AsylumCaseFieldDefinition.IS_FEE_PAYMENT_ENABLED,
             isfeePaymentEnabled ? YesOrNo.YES : YesOrNo.NO);
 
+        log.info("PaymentHandler.handle(): paymentStatus: {}, caseReference: {}, state: {}",
+                asylumCase.read(PAYMENT_STATUS, PaymentStatus.class).orElse(null),
+                callback.getCaseDetails().getId(), callback.getCaseDetails().getState());
         return new PreSubmitCallbackResponse<>(asylumCase);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentStateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentStateHandler.java
@@ -116,12 +116,13 @@ public class PaymentStateHandler implements PreSubmitCallbackStateHandler<Asylum
 
         Optional<PaymentStatus> paymentStatus = asylumCase.read(PAYMENT_STATUS, PaymentStatus.class);
         boolean isPaymentStatusPaid = paymentStatus.isPresent() && (paymentStatus.get() == PAID);
-        boolean isPaymentStatusPendingOrFailed = paymentStatus.isPresent()
-                && (paymentStatus.get() == PAYMENT_PENDING || paymentStatus.get() == FAILED)
-                || (remissionOption.isPresent());
+        boolean isPaymentStatusPendingOrFailed = (paymentStatus.isPresent()
+                && (paymentStatus.get() == PAYMENT_PENDING || paymentStatus.get() == FAILED))
+                || (remissionOption.isPresent() && remissionOption.get() != RemissionOption.NO_REMISSION);
 
-        log.info("RemissionOption: {}, isPaymentStatusPendingOrFailed: {}, current state:{}, isPayLaterAppeal: {}, caseID: {}",
-                remissionOption.orElse(null), isPaymentStatusPendingOrFailed, currentState, isPayLaterAppeal, callback.getCaseDetails().getId());
+        log.info("RemissionOption: {}, isPaymentStatusPendingOrFailed: {}, remissionOption: {}, current state:{}, isPayLaterAppeal: {}, caseID: {}",
+                remissionOption.orElse(null), isPaymentStatusPendingOrFailed, remissionOption.orElse(RemissionOption.NO_REMISSION),
+                currentState, isPayLaterAppeal, callback.getCaseDetails().getId());
         if (isDlrmFeeRemissionEnabled && aipRemissionExists) {
             return handleDlrmFeeRemission(callback, appealType, currentState, isPayLaterAppeal, isPaymentStatusPaid);
         } else if (isValidPayLaterPaymentEvent(callback, currentState, isPayLaterAppeal)) {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentStateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentStateHandler.java
@@ -120,6 +120,8 @@ public class PaymentStateHandler implements PreSubmitCallbackStateHandler<Asylum
                 && (paymentStatus.get() == PAYMENT_PENDING || paymentStatus.get() == FAILED)
                 || (remissionOption.isPresent());
 
+        log.info("RemissionOption: {}, isPaymentStatusPendingOrFailed: {}, current state:{}, isPayLaterAppeal: {}, caseID: {}",
+                remissionOption.orElse(null), isPaymentStatusPendingOrFailed, currentState, isPayLaterAppeal, callback.getCaseDetails().getId());
         if (isDlrmFeeRemissionEnabled && aipRemissionExists) {
             return handleDlrmFeeRemission(callback, appealType, currentState, isPayLaterAppeal, isPaymentStatusPaid);
         } else if (isValidPayLaterPaymentEvent(callback, currentState, isPayLaterAppeal)) {

--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentStateHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentStateHandler.java
@@ -93,7 +93,7 @@ public class PaymentStateHandler implements PreSubmitCallbackStateHandler<Asylum
             boolean isPaymentStatusPendingOrFailed = paymentStatus.isPresent()
                     && (paymentStatus.get() == PAYMENT_PENDING || paymentStatus.get() == FAILED)
                     || (remissionType.isPresent());
-            return decideAppealState(appealType, isPaymentStatusPendingOrFailed, asylumCase, currentState);
+            return decideAppealState(appealType, isPaymentStatusPendingOrFailed, asylumCase);
         }
     }
 
@@ -121,22 +121,20 @@ public class PaymentStateHandler implements PreSubmitCallbackStateHandler<Asylum
         } else if (isValidPayLaterPaymentEvent(callback, currentState, isPayLaterAppeal)) {
             return new PreSubmitCallbackResponse<>(asylumCase, currentState);
         } else {
-            return decideAppealState(appealType, isPaymentStatusPendingOrFailed, asylumCase, currentState);
+            return decideAppealState(appealType, isPaymentStatusPendingOrFailed, asylumCase);
         }
     }
 
     private static PreSubmitCallbackResponse<AsylumCase> decideAppealState(AppealType appealType,
                                                                            boolean isPaymentStatusPendingOrFailed,
-                                                                           AsylumCase asylumCase,
-                                                                           State currentState) {
+                                                                           AsylumCase asylumCase) {
         switch (appealType) {
             case EA:
             case HU:
             case EU:
             case AG:
                 if (isPaymentStatusPendingOrFailed) {
-                    return new PreSubmitCallbackResponse<>(
-                            asylumCase, currentState == APPEAL_STARTED ? PENDING_PAYMENT : currentState);
+                    return new PreSubmitCallbackResponse<>(asylumCase, PENDING_PAYMENT);
                 }
                 return new PreSubmitCallbackResponse<>(asylumCase, APPEAL_SUBMITTED);
             default:

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AutomaticEndAppealForNonPaymentEaHuTriggerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/AutomaticEndAppealForNonPaymentEaHuTriggerTest.java
@@ -29,11 +29,13 @@ import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacaseapi.domain.DateProvider;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AppealType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionOption;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType;
 import uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacaseapi.domain.service.Scheduler;
 import uk.gov.hmcts.reform.iacaseapi.infrastructure.clients.AsylumCaseServiceResponseException;
@@ -75,24 +77,30 @@ class AutomaticEndAppealForNonPaymentEaHuTriggerTest {
 
     private static Stream<Arguments> aipLrScheduleAppeal() {
         return Stream.of(
-            Arguments.of(Optional.empty(), EA), // AIP = remissions can't be chosen (empty)
-            Arguments.of(Optional.empty(), HU),
-            Arguments.of(Optional.empty(), EU),
-            Arguments.of(Optional.of(RemissionType.NO_REMISSION), EA), // LR = chose no remissions
-            Arguments.of(Optional.of(RemissionType.NO_REMISSION), HU),
-            Arguments.of(Optional.of(RemissionType.NO_REMISSION), EU)
+            Arguments.of(Optional.of(JourneyType.AIP), Optional.empty(), Optional.of(RemissionOption.NO_REMISSION), EA), // AIP = chose no remission
+            Arguments.of(Optional.of(JourneyType.AIP), Optional.empty(), Optional.empty(), HU),
+            Arguments.of(Optional.of(JourneyType.AIP), Optional.empty(), Optional.empty(), EU),
+            Arguments.of(Optional.empty(), Optional.of(RemissionType.NO_REMISSION), Optional.empty(), EA), // LR = chose no remissions
+            Arguments.of(Optional.empty(), Optional.of(RemissionType.NO_REMISSION), Optional.empty(), HU),
+            Arguments.of(Optional.of(JourneyType.REP), Optional.of(RemissionType.NO_REMISSION), Optional.empty(), EU)
         );
     }
 
     @ParameterizedTest
     @MethodSource("aipLrScheduleAppeal")
-    void should_schedule_automatic_end_appeal_14_days_from_now_ea_hu_eu_after_submission(Optional<RemissionType> remissionType, AppealType appealType) {
+    void should_schedule_automatic_end_appeal_14_days_from_now_ea_hu_eu_after_submission(
+            Optional<JourneyType> journeyType,
+            Optional<RemissionType> remissionType,
+            Optional<RemissionOption> aipRemissionOption,
+            AppealType appealType
+    ) {
         when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
         when(caseDetails.getId()).thenReturn(caseId);
-        when(asylumCase.read(REMISSION_TYPE, RemissionType.class))
-            .thenReturn(remissionType);
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(journeyType);
+        when(asylumCase.read(REMISSION_TYPE, RemissionType.class)).thenReturn(remissionType);
+        when(asylumCase.read(REMISSION_OPTION, RemissionOption.class)).thenReturn(aipRemissionOption);
         when(dateProvider.nowWithTime()).thenReturn(now);
         TimedEvent timedEvent = new TimedEvent(
             id,
@@ -304,6 +312,21 @@ class AutomaticEndAppealForNonPaymentEaHuTriggerTest {
         when(callback.getEvent()).thenReturn(Event.RECORD_REMISSION_DECISION); // unqualified event
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        assertThatThrownBy(() -> automaticEndAppealForNonPaymentEaHuTrigger.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback for auto end appeal for remission rejection")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void handling_should_throw_if_aip_with_remission_appeal_can_not_handle() {
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL); // unqualified event
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.of(JourneyType.AIP));
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(EU));
+        when(asylumCase.read(REMISSION_OPTION, RemissionOption.class))
+                .thenReturn(Optional.of(RemissionOption.ASYLUM_SUPPORT_FROM_HOME_OFFICE));
 
         assertThatThrownBy(() -> automaticEndAppealForNonPaymentEaHuTrigger.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
             .hasMessage("Cannot handle callback for auto end appeal for remission rejection")

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/AiPFeesHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/AiPFeesHandlerTest.java
@@ -174,6 +174,7 @@ class AiPFeesHandlerTest {
                 .write(DECISION_HEARING_FEE_OPTION, "decisionWithoutHearing");
         verifyFeeOptionDetailsCleared();
         verifyRemissionsDetailsCleared();
+        verify(asylumCase, times(1)).clear(REMISSION_OPTION);
     }
 
     @ParameterizedTest
@@ -200,6 +201,7 @@ class AiPFeesHandlerTest {
         verify(asylumCase, times(1)).clear(PAYMENT_STATUS);
         verifyFeeOptionDetailsCleared();
         verifyRemissionsDetailsCleared();
+        verify(asylumCase, times(1)).clear(REMISSION_OPTION);
     }
 
     @Test
@@ -338,7 +340,6 @@ class AiPFeesHandlerTest {
         assertEquals(asylumCase, callbackResponse.getData());
 
         verify(feePayment, times(1)).aboutToSubmit(callback);
-        verify(asylumCase, times(1)).write(REMISSION_OPTION, RemissionOption.I_WANT_TO_GET_HELP_WITH_FEES);
         verify(asylumCase, times(1)).write(FEE_REMISSION_TYPE, "Help with Fees");
         verify(asylumCase, times(1)).clear(ASYLUM_SUPPORT_REF_NUMBER);
         verify(asylumCase, times(1)).clear(LOCAL_AUTHORITY_LETTERS);
@@ -356,7 +357,6 @@ class AiPFeesHandlerTest {
                 Arguments.of(RemissionOption.I_WANT_TO_GET_HELP_WITH_FEES, HelpWithFeesOption.ALREADY_APPLIED)
         );
     }
-
 
     @Test
     void should_not_write_remission_data_when_no_remission_and_no_hwf() {
@@ -394,7 +394,6 @@ class AiPFeesHandlerTest {
     }
 
     private void verifyRemissionsDetailsCleared() {
-        verify(asylumCase, times(1)).clear(REMISSION_OPTION);
         verify(asylumCase, times(1)).clear(FEE_REMISSION_TYPE);
         verify(asylumCase, times(1)).clear(ASYLUM_SUPPORT_REF_NUMBER);
         verify(asylumCase, times(1)).clear(LOCAL_AUTHORITY_LETTERS);

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentStateHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentStateHandlerTest.java
@@ -56,7 +56,6 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.HelpWithFeesOption.WILL_PAY_FOR_APPEAL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionOption.NO_REMISSION;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.APPEAL_SUBMITTED;
-import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.ENDED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.PENDING_PAYMENT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType.AIP;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType.REP;
@@ -149,28 +148,6 @@ class PaymentStateHandlerTest {
 
         assertNotNull(returnedCallbackResponse);
         Assertions.assertThat(returnedCallbackResponse.getState()).isEqualTo(APPEAL_SUBMITTED);
-        assertEquals(asylumCase, returnedCallbackResponse.getData());
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = AppealType.class, names = {"EU", "HU", "EA"}, mode = INCLUDE)
-    void should_return_current_state_for_EU_HU_EA_appeals_with_no_remission(AppealType appealType) {
-
-        when(caseDetails.getCaseData()).thenReturn(asylumCase);
-        when(caseDetails.getState()).thenReturn(ENDED);
-        when(callback.getEvent()).thenReturn(Event.PAYMENT_APPEAL);
-
-        when(featureToggler.getValue("dlrm-fee-remission-feature-flag", false)).thenReturn(true);
-        when(asylumCase.read(AsylumCaseFieldDefinition.JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.of(AIP));
-        when(asylumCase.read(REMISSION_OPTION, RemissionOption.class)).thenReturn(Optional.of(NO_REMISSION));
-        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(appealType));
-        when(asylumCase.read(PAYMENT_STATUS, PaymentStatus.class)).thenReturn(Optional.of(PaymentStatus.FAILED));
-
-        PreSubmitCallbackResponse<AsylumCase> returnedCallbackResponse =
-            paymentStateHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback, callbackResponse);
-
-        assertNotNull(returnedCallbackResponse);
-        Assertions.assertThat(returnedCallbackResponse.getState()).isEqualTo(ENDED);
         assertEquals(asylumCase, returnedCallbackResponse.getData());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentStateHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacaseapi/domain/handlers/presubmit/payment/PaymentStateHandlerTest.java
@@ -56,6 +56,7 @@ import static uk.gov.hmcts.reform.iacaseapi.domain.entities.AsylumCaseFieldDefin
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.HelpWithFeesOption.WILL_PAY_FOR_APPEAL;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.RemissionOption.NO_REMISSION;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.APPEAL_SUBMITTED;
+import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.ENDED;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.State.PENDING_PAYMENT;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType.AIP;
 import static uk.gov.hmcts.reform.iacaseapi.domain.entities.ccd.field.JourneyType.REP;
@@ -148,6 +149,28 @@ class PaymentStateHandlerTest {
 
         assertNotNull(returnedCallbackResponse);
         Assertions.assertThat(returnedCallbackResponse.getState()).isEqualTo(APPEAL_SUBMITTED);
+        assertEquals(asylumCase, returnedCallbackResponse.getData());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AppealType.class, names = {"EU", "HU", "EA"}, mode = INCLUDE)
+    void should_return_current_state_for_EU_HU_EA_appeals_with_no_remission(AppealType appealType) {
+
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(caseDetails.getState()).thenReturn(ENDED);
+        when(callback.getEvent()).thenReturn(Event.PAYMENT_APPEAL);
+
+        when(featureToggler.getValue("dlrm-fee-remission-feature-flag", false)).thenReturn(true);
+        when(asylumCase.read(AsylumCaseFieldDefinition.JOURNEY_TYPE, JourneyType.class)).thenReturn(Optional.of(AIP));
+        when(asylumCase.read(REMISSION_OPTION, RemissionOption.class)).thenReturn(Optional.of(NO_REMISSION));
+        when(asylumCase.read(APPEAL_TYPE, AppealType.class)).thenReturn(Optional.of(appealType));
+        when(asylumCase.read(PAYMENT_STATUS, PaymentStatus.class)).thenReturn(Optional.of(PaymentStatus.FAILED));
+
+        PreSubmitCallbackResponse<AsylumCase> returnedCallbackResponse =
+            paymentStateHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback, callbackResponse);
+
+        assertNotNull(returnedCallbackResponse);
+        Assertions.assertThat(returnedCallbackResponse.getState()).isEqualTo(ENDED);
         assertEquals(asylumCase, returnedCallbackResponse.getData());
     }
 


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DIAC-1178


### Change description
AiP appeals with remission should not be ended automatically before remission decision.
AiP appeals (HU/EU/EA) should be progressed to Appeal submitted state after payment.


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
