### PR TITLE
DIAC-2168 - Remove appellant surname from INFO log

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/service/CcdSupplementaryDetailsSearchService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacaseapi/infrastructure/service/CcdSupplementaryDetailsSearchService.java
@@ -135,8 +135,8 @@ public class CcdSupplementaryDetailsSearchService implements SupplementaryDetail
             String.valueOf(caseDetails.getCaseData().get(APPEAL_REFERENCE_NUMBER))
         );
 
-        log.info("Supplementary details for caseId {} - surname: {}, caseReferenceNumber: {}",
-                 caseDetails.getId(), supplementaryDetails.getSurname(), supplementaryDetails.getCaseReferenceNumber());
+        log.info("Supplementary details for caseId {} - caseReferenceNumber: {}",
+                 caseDetails.getId(), supplementaryDetails.getCaseReferenceNumber());
         return new SupplementaryInfo(
             String.valueOf(caseDetails.getId()),
             supplementaryDetails


### PR DESCRIPTION
Surnames were being logged at INFO level which gets shipped to centralised logging. This is a data protection concern as PII should not be present in application logs. The caseId and caseReferenceNumber remain in the log for debugging purposes.
